### PR TITLE
Update CLI version to 2025.11.3

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -30,7 +30,7 @@ import { outputUsageInfo } from "./utils/usage.js";
 program
   .name("linearis")
   .description("CLI for Linear.app with JSON output")
-  .version("2025.11.2")
+  .version("2025.11.3")
   .option("--api-token <token>", "Linear API token");
 
 // Default action - show help when no subcommand


### PR DESCRIPTION
linearis cli reports its version as 2025.11.2 instead of the actual version 2025.11.3 as defined by the package.json