### PR TITLE
[FIX] Support digits in team keys and fix GraphQL or filter

### DIFF
--- a/src/utils/graphql-issues-service.ts
+++ b/src/utils/graphql-issues-service.ts
@@ -476,7 +476,7 @@ export class GraphQLIssuesService {
       // (GraphQL `or` filter with undefined variables matches anything)
       if (
         !resolvedTeam ||
-        (resolvedTeam.key !== args.teamId &&
+        (resolvedTeam.key.toUpperCase() !== args.teamId.toUpperCase() &&
           resolvedTeam.name.toLowerCase() !== args.teamId.toLowerCase())
       ) {
         throw new Error(`Team "${args.teamId}" not found`);
@@ -690,7 +690,7 @@ export class GraphQLIssuesService {
       // (GraphQL `or` filter with undefined variables matches anything)
       if (
         !resolvedTeam ||
-        (resolvedTeam.key !== args.teamId &&
+        (resolvedTeam.key.toUpperCase() !== args.teamId.toUpperCase() &&
           resolvedTeam.name.toLowerCase() !== args.teamId.toLowerCase())
       ) {
         throw new Error(`Team "${args.teamId}" not found`);

--- a/tests/unit/graphql-issues-service-team.test.ts
+++ b/tests/unit/graphql-issues-service-team.test.ts
@@ -155,6 +155,32 @@ describe("GraphQLIssuesService - Team Resolution Validation", () => {
       expect(result).toEqual([]);
     });
 
+    it("should accept team key case-insensitively", async () => {
+      // Setup: batch resolve returns team with uppercase key
+      mockGraphQLService.rawRequest
+        .mockResolvedValueOnce({
+          teams: {
+            nodes: [
+              { id: "correct-team-id", key: "ENG", name: "Engineering" },
+            ],
+          },
+          projects: { nodes: [] },
+          users: { nodes: [] },
+        })
+        .mockResolvedValueOnce({
+          issues: { nodes: [] },
+        });
+
+      // Should not throw - team key matches case-insensitively (user typed lowercase)
+      const result = await service.searchIssues({
+        query: "test",
+        teamId: "eng",
+        limit: 10,
+      });
+
+      expect(result).toEqual([]);
+    });
+
     it("should accept team key containing digits at end", async () => {
       // Bug: regex /^[A-Z]+$/ excludes digits, so "ABC1" is treated as team name
       // This causes lookup by name "ABC1" instead of key "ABC1"


### PR DESCRIPTION
## Summary

- Fix team key detection regex to accept alphanumeric keys (MAN8, 601F, etc.)
- Fix Linear GraphQL `or` filter issue where undefined variables match incorrectly

## Problem

1. **Regex issue**: `/^[A-Z]+$/` excluded digits, so team keys like "MAN8" or "601F" were treated as team names instead of keys

2. **GraphQL filter issue**: Linear's `or` filter behaves incorrectly when one condition has an undefined variable - it matches arbitrary teams instead of treating undefined as "no match"

## Solution

1. Changed regex to `/^[A-Z0-9]+$/i` to accept alphanumeric team keys
2. Explicitly set both `teamKey` and `teamName` variables (one to value, one to `null`) when resolving team identifiers

## Test plan

- [x] Unit tests pass (28/28)
- [x] Live test: `--team MAN8` creates issue in correct team
- [x] Live test: `--team 601F` creates issue in correct team

🤖 Generated with [Claude Code](https://claude.com/claude-code)