### PR TITLE
[FIX] Standardize --state flag in issues create command

### DIFF
--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -129,7 +129,8 @@ export function setupIssuesCommands(program: Command): void {
       "--cycle <cycle>",
       "cycle name or ID (requires --team)"
     )
-    .option("--status <status>", "status name or ID")
+    .option("--state <state>", "state name or ID")
+    .option("--status <status>", "state name or ID (deprecated, use --state)")
     .option("--parent-ticket <parentId>", "parent issue ID or identifier")
     .action(
       handleAsyncCommand(
@@ -149,6 +150,12 @@ export function setupIssuesCommands(program: Command): void {
             labelIds = options.labels.split(",").map((l: string) => l.trim());
           }
 
+          // Support both --state and --status (deprecated)
+          if (options.status) {
+            console.error("Warning: --status is deprecated, use --state instead");
+          }
+          const stateValue = options.state || options.status;
+
           const createArgs = {
             title,
             teamId: options.team, // GraphQL service handles team resolution
@@ -156,7 +163,7 @@ export function setupIssuesCommands(program: Command): void {
             assigneeId: options.assignee,
             priority: options.priority ? parseInt(options.priority) : undefined,
             projectId: options.project, // GraphQL service handles project resolution
-            stateId: options.status,
+            stateId: stateValue,
             labelIds, // GraphQL service handles label resolution
             parentId: options.parentTicket, // GraphQL service handles parent resolution
             milestoneId: options.projectMilestone,


### PR DESCRIPTION
## Summary

- Add `--state` flag to `issues create` command (consistent with `issues update`)
- Deprecate `--status` flag with warning message to stderr
- Both flags work for backwards compatibility, but `--status` now emits a deprecation warning

## Problem

The CLI had inconsistent naming for workflow state flags:

| Command | Flag | 
|---------|------|
| `issues search` | `--states` (plural, accepts multiple) |
| `issues update` | `--state` |
| `issues create` | `--status` ← inconsistent |

All three commands reference Linear's **WorkflowState** entity, so they should use consistent naming.

## Solution

- Added `--state` flag to `issues create` as the new preferred option
- Kept `--status` working with a deprecation warning for backwards compatibility
- `--states` (plural) in search remains unchanged since it semantically accepts multiple values

## After this change

| Command | Flag | Notes |
|---------|------|-------|
| `issues search` | `--states` | Plural (accepts multiple) |
| `issues create` | `--state` | ✅ New preferred flag |
| `issues create` | `--status` | Deprecated, shows warning |
| `issues update` | `--state` | No change needed |

## Test plan

- [x] Build passes (`pnpm run build`)
- [ ] `linearis issues create --help` shows both flags
- [ ] Using `--state` works without warning
- [ ] Using `--status` works but shows deprecation warning to stderr

🤖 Generated with [Claude Code](https://claude.com/claude-code)