### PR TITLE
feat(embeds): add upload command for file uploads to Linear storage

### DIFF
--- a/src/commands/embeds.ts
+++ b/src/commands/embeds.ts
@@ -94,7 +94,7 @@ export function setupEmbedsCommands(program: Command): void {
     .description("Upload a file to Linear storage.")
     .action(
       handleAsyncCommand(
-        async (filePath: string, options: any, command: Command) => {
+        async (filePath: string, _options: any, command: Command) => {
           // Get API token from parent command options for authentication
           const apiToken = await getApiToken(command.parent!.parent!.opts());
 

--- a/src/utils/file-service.ts
+++ b/src/utils/file-service.ts
@@ -14,7 +14,11 @@ import { access, mkdir, readFile, stat, writeFile } from "fs/promises";
 import { basename, dirname, extname } from "path";
 import { extractFilenameFromUrl, isLinearUploadUrl } from "./embed-parser.js";
 
-/** Maximum file size for uploads (20MB) */
+/**
+ * Maximum file size for uploads (20MB)
+ * This limit is imposed by Linear's fileUpload API.
+ * See: https://linear.app/developers/graphql/fileupload
+ */
 const MAX_FILE_SIZE = 20 * 1024 * 1024;
 
 /**
@@ -302,7 +306,7 @@ export class FileService {
         method: "POST",
         headers: {
           "Content-Type": "application/json",
-          Authorization: this.apiToken,
+          Authorization: `Bearer ${this.apiToken}`,
         },
         body: JSON.stringify({
           query,

--- a/tests/unit/file-service-upload.test.ts
+++ b/tests/unit/file-service-upload.test.ts
@@ -77,7 +77,7 @@ describe("FileService - uploadFile", () => {
       expect(mockFetch).toHaveBeenCalledTimes(2);
       const graphqlCall = mockFetch.mock.calls[0];
       expect(graphqlCall[0]).toBe("https://api.linear.app/graphql");
-      expect(graphqlCall[1].headers["Authorization"]).toBe(testApiToken);
+      expect(graphqlCall[1].headers["Authorization"]).toBe(`Bearer ${testApiToken}`);
 
       // Verify PUT call
       const putCall = mockFetch.mock.calls[1];


### PR DESCRIPTION
## Summary

Add `linearis embeds upload <file>` command that uploads local files to Linear's cloud storage and returns the asset URL for use in markdown.

This mirrors the existing `embeds download` command to provide complete upload/download capability.

## Changes

- Add `uploadFile()` method to `FileService` using GraphQL `fileUpload` mutation
- Add `upload` subcommand to `embeds` command group  
- Add MIME type detection for common file types (images, documents, text, archives, video/audio)
- Add 20MB file size limit validation
- Add comprehensive unit tests (12 tests)

## How it works

1. Validates file exists and is under 20MB
2. Calls Linear's `fileUpload` GraphQL mutation to get pre-signed URL
3. PUTs file content to the pre-signed URL with appropriate headers
4. Returns asset URL for embedding in comments/descriptions

## Example usage

```bash
# Upload a file
linearis embeds upload ./screenshot.png
# Returns: { "success": true, "assetUrl": "https://uploads.linear.app/...", "filename": "screenshot.png" }

# Use with comments
URL=$(linearis embeds upload ./bug.png | jq -r .assetUrl)
linearis comments create ABC-123 --body "See attached: ![$URL]($URL)"
```

## Testing

- 12 new unit tests covering:
  - Successful uploads
  - MIME type detection
  - File not found errors
  - File size validation
  - GraphQL error handling
  - PUT request failures

All tests pass locally.

## Context

This feature was requested to support file attachments in Linear ticket comments from CLI tools like Huginn. Currently Huginn has to bypass Linearis and call Linear's GraphQL API directly for file uploads - this PR allows it to use Linearis consistently for all Linear operations.