### PR TITLE
feat: Add issue relations support (blocks, related, duplicate, similar)

### DIFF
--- a/src/queries/common.ts
+++ b/src/queries/common.ts
@@ -142,6 +142,49 @@ export const ISSUE_CHILDREN_FRAGMENT = `
 `;
 
 /**
+ * Issue relations fragment
+ * Provides both outgoing relations (this issue -> related) and
+ * incoming/inverse relations (other issue -> this issue)
+ * Types: blocks, duplicate, related, similar
+ */
+export const ISSUE_RELATIONS_FRAGMENT = `
+  relations {
+    nodes {
+      id
+      type
+      createdAt
+      issue {
+        id
+        identifier
+        title
+      }
+      relatedIssue {
+        id
+        identifier
+        title
+      }
+    }
+  }
+  inverseRelations {
+    nodes {
+      id
+      type
+      createdAt
+      issue {
+        id
+        identifier
+        title
+      }
+      relatedIssue {
+        id
+        identifier
+        title
+      }
+    }
+  }
+`;
+
+/**
  * Complete issue fragment with all relationships
  *
  * Combines all issue fragments into a comprehensive field selection.
@@ -162,9 +205,10 @@ export const COMPLETE_ISSUE_FRAGMENT = `
 `;
 
 /**
- * Complete issue fragment including comments
+ * Complete issue fragment including comments and relations
  */
 export const COMPLETE_ISSUE_WITH_COMMENTS_FRAGMENT = `
   ${COMPLETE_ISSUE_FRAGMENT}
   ${ISSUE_COMMENTS_FRAGMENT}
+  ${ISSUE_RELATIONS_FRAGMENT}
 `;

--- a/src/queries/issues.ts
+++ b/src/queries/issues.ts
@@ -10,6 +10,7 @@
 import {
   COMPLETE_ISSUE_FRAGMENT,
   COMPLETE_ISSUE_WITH_COMMENTS_FRAGMENT,
+  ISSUE_RELATIONS_FRAGMENT,
 } from "./common.js";
 
 /**
@@ -371,6 +372,92 @@ export const BATCH_RESOLVE_FOR_CREATE_QUERY = `
     }
 
     # Resolve cycles by name (team-scoped lookup is preferred but we also provide global fallback)
-    
+
+  }
+`;
+
+// ============================================================================
+// Issue Relations Queries and Mutations
+// ============================================================================
+
+/**
+ * Get issue relations by UUID
+ *
+ * Fetches all relations (both directions) for an issue by its UUID.
+ * Returns both outgoing relations and inverse/incoming relations.
+ */
+export const GET_ISSUE_RELATIONS_BY_ID_QUERY = `
+  query GetIssueRelationsById($id: String!) {
+    issue(id: $id) {
+      id
+      identifier
+      ${ISSUE_RELATIONS_FRAGMENT}
+    }
+  }
+`;
+
+/**
+ * Get issue relations by identifier (TEAM-123 format)
+ *
+ * Fetches all relations (both directions) for an issue using team key + number.
+ * Returns both outgoing relations and inverse/incoming relations.
+ */
+export const GET_ISSUE_RELATIONS_BY_IDENTIFIER_QUERY = `
+  query GetIssueRelationsByIdentifier($teamKey: String!, $number: Float!) {
+    issues(
+      filter: {
+        team: { key: { eq: $teamKey } }
+        number: { eq: $number }
+      }
+      first: 1
+    ) {
+      nodes {
+        id
+        identifier
+        ${ISSUE_RELATIONS_FRAGMENT}
+      }
+    }
+  }
+`;
+
+/**
+ * Create issue relation mutation
+ *
+ * Creates a new relation between two issues.
+ * Types: blocks, duplicate, related, similar
+ */
+export const CREATE_ISSUE_RELATION_MUTATION = `
+  mutation CreateIssueRelation($input: IssueRelationCreateInput!) {
+    issueRelationCreate(input: $input) {
+      success
+      issueRelation {
+        id
+        type
+        createdAt
+        issue {
+          id
+          identifier
+          title
+        }
+        relatedIssue {
+          id
+          identifier
+          title
+        }
+      }
+    }
+  }
+`;
+
+/**
+ * Delete issue relation mutation
+ *
+ * Removes an existing relation by its UUID.
+ */
+export const DELETE_ISSUE_RELATION_MUTATION = `
+  mutation DeleteIssueRelation($id: String!) {
+    issueRelationDelete(id: $id) {
+      success
+    }
   }
 `;

--- a/src/utils/linear-types.d.ts
+++ b/src/utils/linear-types.d.ts
@@ -67,8 +67,29 @@ export interface LinearIssue {
     createdAt: string;
     updatedAt: string;
   }>;
+  relations?: LinearIssueRelation[];
   createdAt: string;
   updatedAt: string;
+}
+
+/**
+ * Issue relation representing a link between two issues
+ * Types: blocks, duplicate, related, similar (similar is typically AI-generated)
+ */
+export interface LinearIssueRelation {
+  id: string;
+  type: "blocks" | "duplicate" | "related" | "similar";
+  issue: {
+    id: string;
+    identifier: string;
+    title: string;
+  };
+  relatedIssue: {
+    id: string;
+    identifier: string;
+    title: string;
+  };
+  createdAt: string;
 }
 
 export interface LinearProject {

--- a/tests/integration/issues-relations-cli.test.ts
+++ b/tests/integration/issues-relations-cli.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Integration tests for issues relations CLI commands
+ *
+ * These tests require LINEAR_API_TOKEN to be set in environment.
+ * If not set, tests will be skipped.
+ *
+ * NOTE: These tests document expected behavior but are skipped by default
+ * to avoid creating test data in production Linear workspaces.
+ */
+
+import { describe, expect, it } from "vitest";
+import { exec } from "child_process";
+import { promisify } from "util";
+
+const execAsync = promisify(exec);
+const CLI_PATH = "dist/main.js";
+const hasApiToken = !!process.env.LINEAR_API_TOKEN;
+
+if (!hasApiToken) {
+  console.warn(
+    "\n  LINEAR_API_TOKEN not set - skipping issues relations integration tests\n" +
+      "   To run these tests, set LINEAR_API_TOKEN in your environment\n",
+  );
+}
+
+describe("Issues Relations CLI", () => {
+  describe("issues relations list", () => {
+    it.skip("should list relations for an issue by identifier", async () => {
+      // This test documents the expected behavior for listing relations
+      // Command: linearis issues relations list ABC-123
+      // Expected: JSON object with issueId, identifier, and relations array
+
+      if (!hasApiToken) return;
+
+      const { stdout } = await execAsync(
+        `node ${CLI_PATH} issues relations list ABC-123`,
+      );
+      const result = JSON.parse(stdout);
+
+      expect(result).toHaveProperty("issueId");
+      expect(result).toHaveProperty("identifier");
+      expect(result).toHaveProperty("relations");
+      expect(Array.isArray(result.relations)).toBe(true);
+    });
+
+    it.skip("should return empty relations array for issue with no relations", async () => {
+      // This test documents that issues without relations return empty array
+
+      if (!hasApiToken) return;
+
+      // Would need an issue known to have no relations
+    });
+  });
+
+  describe("issues relations add", () => {
+    it.skip("should add a blocking relation", async () => {
+      // Command: linearis issues relations add ABC-123 --blocks DEF-456
+      // Expected: Array with created relation object
+
+      if (!hasApiToken) return;
+
+      // Skipped to avoid creating test data in production
+    });
+
+    it.skip("should add multiple related issues at once", async () => {
+      // Command: linearis issues relations add ABC-123 --related DEF-456,GHI-789
+      // Expected: Array with 2 created relation objects
+
+      if (!hasApiToken) return;
+
+      // Skipped to avoid creating test data in production
+    });
+
+    it.skip("should support all relation types", async () => {
+      // Tests that all 4 relation types work:
+      // --blocks, --related, --duplicate, --similar
+
+      if (!hasApiToken) return;
+
+      // Skipped to avoid creating test data in production
+    });
+  });
+
+  describe("issues relations add - validation", () => {
+    it("should error when no relation type flag is provided", async () => {
+      const { stdout } = await execAsync(
+        `node ${CLI_PATH} issues relations add ABC-123 2>&1`,
+      ).catch((e) => ({ stdout: e.stdout }));
+
+      const result = JSON.parse(stdout);
+      expect(result.error).toContain(
+        "Must specify one of --blocks, --related, --duplicate, or --similar",
+      );
+    });
+
+    it("should error when multiple relation type flags are provided", async () => {
+      const { stdout } = await execAsync(
+        `node ${CLI_PATH} issues relations add ABC-123 --blocks DEF-456 --related GHI-789 2>&1`,
+      ).catch((e) => ({ stdout: e.stdout }));
+
+      const result = JSON.parse(stdout);
+      expect(result.error).toContain(
+        "Cannot specify multiple relation types",
+      );
+    });
+  });
+
+  describe("issues relations remove", () => {
+    it.skip("should remove a relation by UUID", async () => {
+      // Command: linearis issues relations remove <relation-uuid>
+      // Expected: { success: true }
+
+      if (!hasApiToken) return;
+
+      // Skipped to avoid deleting data in production
+    });
+  });
+
+  describe("issues read - relations in output", () => {
+    it.skip("should include relations in issue read output", async () => {
+      // This test documents that 'issues read' now includes relations
+      // Command: linearis issues read ABC-123
+      // Expected: Issue object includes 'relations' array
+
+      if (!hasApiToken) return;
+
+      const { stdout } = await execAsync(
+        `node ${CLI_PATH} issues read ABC-123`,
+      );
+      const result = JSON.parse(stdout);
+
+      // Relations should be present (may be empty array or undefined if no relations)
+      // When relations exist, they should have the expected structure
+      if (result.relations && result.relations.length > 0) {
+        expect(result.relations[0]).toHaveProperty("id");
+        expect(result.relations[0]).toHaveProperty("type");
+        expect(result.relations[0]).toHaveProperty("issue");
+        expect(result.relations[0]).toHaveProperty("relatedIssue");
+        expect(result.relations[0]).toHaveProperty("createdAt");
+      }
+    });
+  });
+});

--- a/tests/unit/graphql-issues-service-relations.test.ts
+++ b/tests/unit/graphql-issues-service-relations.test.ts
@@ -1,0 +1,537 @@
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { GraphQLIssuesService } from "../../src/utils/graphql-issues-service.js";
+import { GraphQLService } from "../../src/utils/graphql-service.js";
+import { LinearService } from "../../src/utils/linear-service.js";
+
+/**
+ * Unit tests for GraphQLIssuesService relation methods
+ *
+ * These tests verify the relation transformation and validation logic
+ * using mocked GraphQL responses.
+ */
+
+// Mock the services
+const mockGraphQLService = {
+  rawRequest: vi.fn(),
+} as unknown as GraphQLService;
+
+const mockLinearService = {
+  resolveStatusId: vi.fn(),
+} as unknown as LinearService;
+
+describe("GraphQLIssuesService - Relations", () => {
+  let service: GraphQLIssuesService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new GraphQLIssuesService(mockGraphQLService, mockLinearService);
+  });
+
+  // Valid UUID format for testing
+  const UUID_1 = "550e8400-e29b-12d3-a456-426614174000";
+  const UUID_2 = "660e8400-e29b-12d3-a456-426614174001";
+  const UUID_3 = "770e8400-e29b-12d3-a456-426614174002";
+  const REL_UUID_1 = "880e8400-e29b-12d3-a456-426614174003";
+  const REL_UUID_2 = "990e8400-e29b-12d3-a456-426614174004";
+
+  describe("getIssueRelations", () => {
+    it("should return empty relations array when issue has no relations", async () => {
+      mockGraphQLService.rawRequest = vi.fn().mockResolvedValue({
+        issue: {
+          id: UUID_1,
+          identifier: "ABC-123",
+          relations: { nodes: [] },
+          inverseRelations: { nodes: [] },
+        },
+      });
+
+      const result = await service.getIssueRelations(UUID_1);
+
+      expect(result).toEqual({
+        issueId: UUID_1,
+        identifier: "ABC-123",
+        relations: [],
+      });
+    });
+
+    it("should transform outgoing relations correctly", async () => {
+      mockGraphQLService.rawRequest = vi.fn().mockResolvedValue({
+        issue: {
+          id: UUID_1,
+          identifier: "ABC-123",
+          relations: {
+            nodes: [
+              {
+                id: REL_UUID_1,
+                type: "blocks",
+                createdAt: "2025-01-15T10:30:00.000Z",
+                issue: {
+                  id: UUID_1,
+                  identifier: "ABC-123",
+                  title: "Source Issue",
+                },
+                relatedIssue: {
+                  id: UUID_2,
+                  identifier: "DEF-456",
+                  title: "Blocked Issue",
+                },
+              },
+            ],
+          },
+          inverseRelations: { nodes: [] },
+        },
+      });
+
+      const result = await service.getIssueRelations(UUID_1);
+
+      expect(result.relations).toHaveLength(1);
+      expect(result.relations[0]).toEqual({
+        id: REL_UUID_1,
+        type: "blocks",
+        createdAt: "2025-01-15T10:30:00.000Z",
+        issue: {
+          id: UUID_1,
+          identifier: "ABC-123",
+          title: "Source Issue",
+        },
+        relatedIssue: {
+          id: UUID_2,
+          identifier: "DEF-456",
+          title: "Blocked Issue",
+        },
+      });
+    });
+
+    it("should transform inverse relations correctly", async () => {
+      mockGraphQLService.rawRequest = vi.fn().mockResolvedValue({
+        issue: {
+          id: UUID_2,
+          identifier: "DEF-456",
+          relations: { nodes: [] },
+          inverseRelations: {
+            nodes: [
+              {
+                id: REL_UUID_1,
+                type: "blocks",
+                createdAt: "2025-01-15T10:30:00.000Z",
+                issue: {
+                  id: UUID_1,
+                  identifier: "ABC-123",
+                  title: "Blocking Issue",
+                },
+                relatedIssue: {
+                  id: UUID_2,
+                  identifier: "DEF-456",
+                  title: "This Issue",
+                },
+              },
+            ],
+          },
+        },
+      });
+
+      const result = await service.getIssueRelations(UUID_2);
+
+      expect(result.relations).toHaveLength(1);
+      expect(result.relations[0].type).toBe("blocks");
+    });
+
+    it("should combine outgoing and inverse relations", async () => {
+      mockGraphQLService.rawRequest = vi.fn().mockResolvedValue({
+        issue: {
+          id: UUID_1,
+          identifier: "ABC-123",
+          relations: {
+            nodes: [
+              {
+                id: REL_UUID_1,
+                type: "blocks",
+                createdAt: "2025-01-15T10:30:00.000Z",
+                issue: { id: UUID_1, identifier: "ABC-123", title: "Issue 1" },
+                relatedIssue: { id: UUID_2, identifier: "DEF-456", title: "Issue 2" },
+              },
+            ],
+          },
+          inverseRelations: {
+            nodes: [
+              {
+                id: REL_UUID_2,
+                type: "related",
+                createdAt: "2025-01-16T10:30:00.000Z",
+                issue: { id: UUID_3, identifier: "GHI-789", title: "Issue 3" },
+                relatedIssue: { id: UUID_1, identifier: "ABC-123", title: "Issue 1" },
+              },
+            ],
+          },
+        },
+      });
+
+      const result = await service.getIssueRelations(UUID_1);
+
+      expect(result.relations).toHaveLength(2);
+      expect(result.relations[0].id).toBe(REL_UUID_1);
+      expect(result.relations[1].id).toBe(REL_UUID_2);
+    });
+
+    it("should resolve TEAM-123 identifier to UUID", async () => {
+      mockGraphQLService.rawRequest = vi.fn().mockResolvedValue({
+        issues: {
+          nodes: [
+            {
+              id: UUID_1,
+              identifier: "ABC-123",
+              relations: { nodes: [] },
+              inverseRelations: { nodes: [] },
+            },
+          ],
+        },
+      });
+
+      const result = await service.getIssueRelations("ABC-123");
+
+      expect(result.issueId).toBe(UUID_1);
+      expect(result.identifier).toBe("ABC-123");
+    });
+
+    it("should throw error when issue not found by UUID", async () => {
+      mockGraphQLService.rawRequest = vi.fn().mockResolvedValue({
+        issue: null,
+      });
+
+      await expect(
+        service.getIssueRelations(UUID_1),
+      ).rejects.toThrow(`Issue with ID "${UUID_1}" not found`);
+    });
+
+    it("should throw error when issue not found by identifier", async () => {
+      mockGraphQLService.rawRequest = vi.fn().mockResolvedValue({
+        issues: { nodes: [] },
+      });
+
+      await expect(service.getIssueRelations("XYZ-999")).rejects.toThrow(
+        'Issue with identifier "XYZ-999" not found',
+      );
+    });
+  });
+
+  describe("addIssueRelations", () => {
+    it("should create single relation successfully", async () => {
+      // First call resolves source issue ID
+      mockGraphQLService.rawRequest = vi
+        .fn()
+        .mockResolvedValueOnce({
+          issues: {
+            nodes: [{ id: UUID_1 }],
+          },
+        })
+        // Second call resolves target issue ID
+        .mockResolvedValueOnce({
+          issues: {
+            nodes: [{ id: UUID_2 }],
+          },
+        })
+        // Third call creates the relation
+        .mockResolvedValueOnce({
+          issueRelationCreate: {
+            success: true,
+            issueRelation: {
+              id: REL_UUID_1,
+              type: "blocks",
+              createdAt: "2025-01-15T10:30:00.000Z",
+              issue: { id: UUID_1, identifier: "ABC-123", title: "Source" },
+              relatedIssue: { id: UUID_2, identifier: "DEF-456", title: "Target" },
+            },
+          },
+        });
+
+      const result = await service.addIssueRelations(
+        "ABC-123",
+        ["DEF-456"],
+        "blocks",
+      );
+
+      expect(result).toHaveLength(1);
+      expect(result[0].id).toBe(REL_UUID_1);
+      expect(result[0].type).toBe("blocks");
+    });
+
+    it("should create multiple relations sequentially", async () => {
+      // Resolve source UUID
+      mockGraphQLService.rawRequest = vi
+        .fn()
+        .mockResolvedValueOnce({ issues: { nodes: [{ id: UUID_1 }] } })
+        // Resolve first target UUID
+        .mockResolvedValueOnce({ issues: { nodes: [{ id: UUID_2 }] } })
+        // Resolve second target UUID
+        .mockResolvedValueOnce({ issues: { nodes: [{ id: UUID_3 }] } })
+        // Create first relation
+        .mockResolvedValueOnce({
+          issueRelationCreate: {
+            success: true,
+            issueRelation: {
+              id: REL_UUID_1,
+              type: "related",
+              createdAt: "2025-01-15T10:30:00.000Z",
+              issue: { id: UUID_1, identifier: "ABC-123", title: "Source" },
+              relatedIssue: { id: UUID_2, identifier: "DEF-456", title: "Target 1" },
+            },
+          },
+        })
+        // Create second relation
+        .mockResolvedValueOnce({
+          issueRelationCreate: {
+            success: true,
+            issueRelation: {
+              id: REL_UUID_2,
+              type: "related",
+              createdAt: "2025-01-15T10:31:00.000Z",
+              issue: { id: UUID_1, identifier: "ABC-123", title: "Source" },
+              relatedIssue: { id: UUID_3, identifier: "GHI-789", title: "Target 2" },
+            },
+          },
+        });
+
+      const result = await service.addIssueRelations(
+        "ABC-123",
+        ["DEF-456", "GHI-789"],
+        "related",
+      );
+
+      expect(result).toHaveLength(2);
+      expect(result[0].id).toBe(REL_UUID_1);
+      expect(result[1].id).toBe(REL_UUID_2);
+    });
+
+    it("should pass through UUIDs without resolution", async () => {
+      mockGraphQLService.rawRequest = vi.fn().mockResolvedValueOnce({
+        issueRelationCreate: {
+          success: true,
+          issueRelation: {
+            id: REL_UUID_1,
+            type: "duplicate",
+            createdAt: "2025-01-15T10:30:00.000Z",
+            issue: { id: UUID_1, identifier: "ABC-123", title: "Source" },
+            relatedIssue: { id: UUID_2, identifier: "DEF-456", title: "Target" },
+          },
+        },
+      });
+
+      const result = await service.addIssueRelations(
+        UUID_1,
+        [UUID_2],
+        "duplicate",
+      );
+
+      expect(result).toHaveLength(1);
+      // Verify that rawRequest was called only once (no resolution calls)
+      expect(mockGraphQLService.rawRequest).toHaveBeenCalledTimes(1);
+    });
+
+    it("should throw error when relation creation fails", async () => {
+      mockGraphQLService.rawRequest = vi.fn().mockResolvedValueOnce({
+        issueRelationCreate: {
+          success: false,
+        },
+      });
+
+      await expect(
+        service.addIssueRelations(UUID_1, [UUID_2], "blocks"),
+      ).rejects.toThrow(`Failed to create relation to issue ${UUID_2}`);
+    });
+
+    it("should report partial success when some relations fail", async () => {
+      const UUID_4 = "aa0e8400-e29b-12d3-a456-426614174005";
+
+      mockGraphQLService.rawRequest = vi
+        .fn()
+        // First relation succeeds
+        .mockResolvedValueOnce({
+          issueRelationCreate: {
+            success: true,
+            issueRelation: {
+              id: REL_UUID_1,
+              type: "related",
+              createdAt: "2025-01-15T10:30:00.000Z",
+              issue: { id: UUID_1, identifier: "ABC-123", title: "Source" },
+              relatedIssue: { id: UUID_2, identifier: "DEF-456", title: "Target 1" },
+            },
+          },
+        })
+        // Second relation succeeds
+        .mockResolvedValueOnce({
+          issueRelationCreate: {
+            success: true,
+            issueRelation: {
+              id: REL_UUID_2,
+              type: "related",
+              createdAt: "2025-01-15T10:31:00.000Z",
+              issue: { id: UUID_1, identifier: "ABC-123", title: "Source" },
+              relatedIssue: { id: UUID_3, identifier: "GHI-789", title: "Target 2" },
+            },
+          },
+        })
+        // Third relation fails
+        .mockResolvedValueOnce({
+          issueRelationCreate: {
+            success: false,
+          },
+        });
+
+      await expect(
+        service.addIssueRelations(UUID_1, [UUID_2, UUID_3, UUID_4], "related"),
+      ).rejects.toThrow(
+        `Failed to create relation to issue ${UUID_4} (2 relation(s) were created before this failure)`,
+      );
+    });
+  });
+
+  describe("removeIssueRelation", () => {
+    it("should delete relation successfully", async () => {
+      mockGraphQLService.rawRequest = vi.fn().mockResolvedValue({
+        issueRelationDelete: {
+          success: true,
+        },
+      });
+
+      const result = await service.removeIssueRelation(REL_UUID_1);
+
+      expect(result).toEqual({ success: true });
+    });
+
+    it("should throw error when deletion fails", async () => {
+      mockGraphQLService.rawRequest = vi.fn().mockResolvedValue({
+        issueRelationDelete: {
+          success: false,
+        },
+      });
+
+      await expect(
+        service.removeIssueRelation(REL_UUID_1),
+      ).rejects.toThrow(`Failed to delete relation ${REL_UUID_1}`);
+    });
+
+    it("should throw error when relationId is not a valid UUID", async () => {
+      await expect(
+        service.removeIssueRelation("not-a-uuid"),
+      ).rejects.toThrow(
+        `Invalid relation ID "not-a-uuid": must be a valid UUID. Use 'issues relations list' to find relation IDs.`,
+      );
+
+      // Verify rawRequest was never called
+      expect(mockGraphQLService.rawRequest).not.toHaveBeenCalled();
+    });
+
+    it("should throw error when relationId looks like an issue identifier", async () => {
+      await expect(
+        service.removeIssueRelation("ABC-123"),
+      ).rejects.toThrow(
+        `Invalid relation ID "ABC-123": must be a valid UUID. Use 'issues relations list' to find relation IDs.`,
+      );
+    });
+  });
+
+  describe("relation type support", () => {
+    it.each(["blocks", "duplicate", "related", "similar"] as const)(
+      "should support %s relation type",
+      async (type) => {
+        mockGraphQLService.rawRequest = vi.fn().mockResolvedValueOnce({
+          issueRelationCreate: {
+            success: true,
+            issueRelation: {
+              id: REL_UUID_1,
+              type: type,
+              createdAt: "2025-01-15T10:30:00.000Z",
+              issue: { id: UUID_1, identifier: "ABC-123", title: "Source" },
+              relatedIssue: { id: UUID_2, identifier: "DEF-456", title: "Target" },
+            },
+          },
+        });
+
+        const result = await service.addIssueRelations(
+          UUID_1,
+          [UUID_2],
+          type,
+        );
+
+        expect(result[0].type).toBe(type);
+      },
+    );
+  });
+
+  describe("relation data validation", () => {
+    it("should throw error when relation.issue is null", async () => {
+      mockGraphQLService.rawRequest = vi.fn().mockResolvedValue({
+        issue: {
+          id: UUID_1,
+          identifier: "ABC-123",
+          relations: {
+            nodes: [
+              {
+                id: REL_UUID_1,
+                type: "blocks",
+                createdAt: "2025-01-15T10:30:00.000Z",
+                issue: null,
+                relatedIssue: { id: UUID_2, identifier: "DEF-456", title: "Target" },
+              },
+            ],
+          },
+          inverseRelations: { nodes: [] },
+        },
+      });
+
+      await expect(
+        service.getIssueRelations(UUID_1),
+      ).rejects.toThrow("Invalid relation data: missing issue field");
+    });
+
+    it("should throw error when relation.relatedIssue is null", async () => {
+      mockGraphQLService.rawRequest = vi.fn().mockResolvedValue({
+        issue: {
+          id: UUID_1,
+          identifier: "ABC-123",
+          relations: {
+            nodes: [
+              {
+                id: REL_UUID_1,
+                type: "blocks",
+                createdAt: "2025-01-15T10:30:00.000Z",
+                issue: { id: UUID_1, identifier: "ABC-123", title: "Source" },
+                relatedIssue: null,
+              },
+            ],
+          },
+          inverseRelations: { nodes: [] },
+        },
+      });
+
+      await expect(
+        service.getIssueRelations(UUID_1),
+      ).rejects.toThrow("Invalid relation data: missing relatedIssue field");
+    });
+
+    it("should throw error when relation.issue is undefined", async () => {
+      mockGraphQLService.rawRequest = vi.fn().mockResolvedValue({
+        issue: {
+          id: UUID_1,
+          identifier: "ABC-123",
+          relations: {
+            nodes: [
+              {
+                id: REL_UUID_1,
+                type: "blocks",
+                createdAt: "2025-01-15T10:30:00.000Z",
+                // issue field is missing (undefined)
+                relatedIssue: { id: UUID_2, identifier: "DEF-456", title: "Target" },
+              },
+            ],
+          },
+          inverseRelations: { nodes: [] },
+        },
+      });
+
+      await expect(
+        service.getIssueRelations(UUID_1),
+      ).rejects.toThrow("Invalid relation data: missing issue field");
+    });
+  });
+});


### PR DESCRIPTION
## Why Issue Relations Matter for AI Agents

When AI agents work on complex projects, understanding **task dependencies** is critical. An agent needs to know:

- Which issues are **blocked** by others (don't start work until blockers are resolved)
- Which issues are **related** (changes in one may affect the other)
- Which issues are **duplicates** (avoid redundant work)

Without visibility into these relationships, agents make suboptimal decisions—starting blocked work, missing related context, or duplicating effort. Linearis, being designed for LLM agents, should expose this relationship data to enable smarter task planning and execution.

## Summary

This PR adds comprehensive issue relations support through a new `issues relations` subcommand group:

- **List relations**: `linearis issues relations list ABC-123`
- **Add relations**: `linearis issues relations add ABC-123 --blocks DEF-456,DEF-789`
- **Remove relations**: `linearis issues relations remove <relation-uuid>`

All four Linear relation types are supported:
- `--blocks` - This issue blocks the specified issues
- `--related` - General relationship between issues
- `--duplicate` - This issue is a duplicate of another
- `--similar` - Similar issues (note: typically AI-generated by Linear)

Relations are also now included in `issues read` output, giving agents complete context when examining an issue.

## Example Usage

```bash
# List all relations for an issue
linearis issues relations list ABC-123

# Add blocking relations (multiple targets supported)
linearis issues relations add ABC-123 --blocks DEF-456,DEF-789

# Add related issues
linearis issues relations add ABC-123 --related GHI-101

# Remove a relation (use UUID from list output)
linearis issues relations remove 550e8400-e29b-12d3-a456-426614174000

# Relations now appear in issue read output
linearis issues read ABC-123
```

## Output Format

```json
{
  "issueId": "550e8400-e29b-12d3-a456-426614174000",
  "identifier": "ABC-123",
  "relations": [
    {
      "id": "660e8400-e29b-12d3-a456-426614174001",
      "type": "blocks",
      "issue": {"id": "...", "identifier": "ABC-123", "title": "Parent task"},
      "relatedIssue": {"id": "...", "identifier": "DEF-456", "title": "Blocked task"},
      "createdAt": "2025-01-15T10:30:00.000Z"
    }
  ]
}
```

## Technical Implementation

- New `ISSUE_RELATIONS_FRAGMENT` in GraphQL queries fetching both `relations` and `inverseRelations`
- `LinearIssueRelation` TypeScript interface for type safety
- Human-friendly ID resolution (TEAM-123 → UUID) for all relation operations
- Proper validation:
  - Null/undefined checks for nested relation data
  - UUID validation for relation removal
  - Partial success reporting when batch creation fails
- Applied feedback from PR #21 (`_options: unknown` with explanatory comments)

## Test Plan

- [x] Unit tests: 23 tests covering all relation methods and edge cases
- [x] Integration tests: CLI validation tests (skipped tests document expected behavior without creating test data)
- [x] All existing tests pass
- [x] Manual testing with real Linear workspace

🤖 Generated with [Claude Code](https://claude.com/claude-code)