### PR TITLE
fix: handle null user in comment transform

### DIFF
--- a/src/utils/graphql-issues-service.ts
+++ b/src/utils/graphql-issues-service.ts
@@ -881,10 +881,12 @@ export class GraphQLIssuesService {
         id: comment.id,
         body: comment.body,
         embeds: extractEmbeds(comment.body),
-        user: {
-          id: comment.user.id,
-          name: comment.user.name,
-        },
+        user: comment.user
+          ? {
+              id: comment.user.id,
+              name: comment.user.name,
+            }
+          : undefined,
         createdAt: comment.createdAt instanceof Date
           ? comment.createdAt.toISOString()
           : (comment.createdAt

--- a/src/utils/linear-types.d.ts
+++ b/src/utils/linear-types.d.ts
@@ -153,7 +153,7 @@ export interface CreateCommentArgs {
 export interface LinearComment {
   id: string;
   body: string;
-  user: {
+  user?: {
     id: string;
     name: string;
   };


### PR DESCRIPTION
## Summary

Fix crash when transforming issues that contain comments with `user: null`.

## Problem

When running `linearis issues update` (or `read`) on an issue that has comments created by Linear's Agent Protocol, the CLI crashes with:

```
Cannot read properties of null (reading 'id')
```

**Stack trace:**
```
TypeError: Cannot read properties of null (reading 'id')
    at GraphQLIssuesService.doTransformIssueData (graphql-issues-service.js:577:38)
```

## Root Cause

Linear's Agent Protocol creates system comments (e.g., "This thread is for an agent session with bobbin.") where `user` is `null`. The transform code at line 889-892 assumes `comment.user` always exists:

```typescript
user: {
  id: comment.user.id,      // Fails when comment.user is null
  name: comment.user.name,
},
```

## Example Data That Fails

From the raw API response, these comments have `user: null`:

```json
{
  "id": "ec4c235a-f2f3-4650-abfa-587bb51610ef",
  "body": "This thread is for an agent session with bobbin.",
  "createdAt": "2025-12-28T12:13:47.400Z",
  "updatedAt": "2025-12-28T12:18:06.594Z",
  "user": null
}
```

## Fix

1. Made `user` optional in `LinearComment` interface (`user?:` instead of `user:`)
2. Added null-check in transform, following the same pattern used for `assignee`:

```typescript
user: comment.user
  ? {
      id: comment.user.id,
      name: comment.user.name,
    }
  : undefined,
```

## Testing

After the fix, issues with agent protocol comments are processed correctly. Comments with null users simply omit the `user` field in the output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)