### PR TITLE
feat(issues): add --estimate to issues update

### DIFF
--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -252,6 +252,9 @@ export function setupIssuesCommands(program: Command): void {
       "set cycle (can use name or ID, will try to resolve within team context first)",
     )
     .option("--clear-cycle", "clear existing cycle assignment")
+    .optionsGroup("Estimate-related options:")
+    .option("--estimate <points>", "set point estimate")
+    .option("--clear-estimate", "clear existing point estimate")
     .action(
       handleAsyncCommand(
         async (issueId: string, options: any, command: Command) => {
@@ -273,6 +276,13 @@ export function setupIssuesCommands(program: Command): void {
           if (options.cycle && options.clearCycle) {
             throw new Error(
               "Cannot use --cycle and --clear-cycle together",
+            );
+          }
+
+          // Check for mutually exclusive estimate flags
+          if (options.estimate && options.clearEstimate) {
+            throw new Error(
+              "Cannot use --estimate and --clear-estimate together",
             );
           }
 
@@ -339,6 +349,9 @@ export function setupIssuesCommands(program: Command): void {
             milestoneId: options.projectMilestone ||
               (options.clearProjectMilestone ? null : undefined),
             cycleId: options.cycle || (options.clearCycle ? null : undefined),
+            estimate: options.estimate
+              ? parseInt(options.estimate)
+              : (options.clearEstimate ? null : undefined),
           };
 
           const labelMode = options.labelBy || "adding";

--- a/src/utils/linear-types.d.ts
+++ b/src/utils/linear-types.d.ts
@@ -115,7 +115,7 @@ export interface UpdateIssueArgs {
   assigneeId?: string;
   projectId?: string;
   labelIds?: string[];
-  estimate?: number;
+  estimate?: number | null;
   parentId?: string;
   milestoneId?: string | null;
   cycleId?: string | null;


### PR DESCRIPTION
## Summary

Adds `--estimate` and `--clear-estimate` options to the `issues update` command, allowing users to set or clear point estimates on issues.

## Changes

- Added `--estimate <points>` option to set point estimate
- Added `--clear-estimate` option to clear existing estimate
- Added validation to prevent using both flags together
- Updated `UpdateIssueArgs` type to allow `null` for clearing

## Usage

```bash
# Set estimate
linearis issues update ABC-123 --estimate 5

# Clear estimate
linearis issues update ABC-123 --clear-estimate
```