### PR TITLE
refactor: add root command options helper

### DIFF
--- a/src/commands/comments.ts
+++ b/src/commands/comments.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { getRootOpts } from "../utils/context.js";
 import { createLinearService } from "../utils/linear-service.js";
 import { handleAsyncCommand, outputSuccess } from "../utils/output.js";
 
@@ -44,7 +45,7 @@ export function setupCommentsCommands(program: Command): void {
         async (issueId: string, options: any, command: Command) => {
           // Initialize Linear service with authentication
           const service = await createLinearService(
-            command.parent!.parent!.opts(),
+            getRootOpts(command),
           );
 
           // Validate required body flag

--- a/src/commands/cycles.ts
+++ b/src/commands/cycles.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { getRootOpts } from "../utils/context.js";
 import { createLinearService } from "../utils/linear-service.js";
 import { handleAsyncCommand, outputSuccess } from "../utils/output.js";
 import type {
@@ -35,7 +36,7 @@ export function setupCyclesCommands(program: Command): void {
           }
 
           const linearService = await createLinearService(
-            command.parent!.parent!.opts(),
+            getRootOpts(command),
           );
 
           // Fetch cycles with automatic pagination
@@ -93,7 +94,7 @@ export function setupCyclesCommands(program: Command): void {
           command: Command,
         ) => {
           const linearService = await createLinearService(
-            command.parent!.parent!.opts(),
+            getRootOpts(command),
           );
 
           // Resolve cycle ID (handles both UUID and name-based lookup)

--- a/src/commands/documents.ts
+++ b/src/commands/documents.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { getRootOpts } from "../utils/context.js";
 import { createLinearService } from "../utils/linear-service.js";
 import { createGraphQLDocumentsService } from "../utils/graphql-documents-service.js";
 import {
@@ -120,7 +121,7 @@ export function setupDocumentsCommands(program: Command): void {
     .action(
       handleAsyncCommand(
         async (options: DocumentCreateOptions, command: Command) => {
-          const rootOpts = command.parent!.parent!.opts();
+          const rootOpts = getRootOpts(command);
           const [documentsService, linearService] = await Promise.all([
             createGraphQLDocumentsService(rootOpts),
             createLinearService(rootOpts),
@@ -197,7 +198,7 @@ export function setupDocumentsCommands(program: Command): void {
           options: DocumentUpdateOptions,
           command: Command,
         ) => {
-          const rootOpts = command.parent!.parent!.opts();
+          const rootOpts = getRootOpts(command);
           const [documentsService, linearService] = await Promise.all([
             createGraphQLDocumentsService(rootOpts),
             createLinearService(rootOpts),
@@ -235,7 +236,7 @@ export function setupDocumentsCommands(program: Command): void {
     .action(
       // Note: _options parameter is required by Commander.js signature (arg, options, command)
       handleAsyncCommand(async (documentId: string, _options: unknown, command: Command) => {
-        const rootOpts = command.parent!.parent!.opts();
+        const rootOpts = getRootOpts(command);
         const documentsService = await createGraphQLDocumentsService(rootOpts);
 
         const document = await documentsService.getDocument(documentId);
@@ -268,7 +269,7 @@ export function setupDocumentsCommands(program: Command): void {
             );
           }
 
-          const rootOpts = command.parent!.parent!.opts();
+          const rootOpts = getRootOpts(command);
           const [documentsService, linearService] = await Promise.all([
             createGraphQLDocumentsService(rootOpts),
             createLinearService(rootOpts),
@@ -341,7 +342,7 @@ export function setupDocumentsCommands(program: Command): void {
       // Note: _options parameter is required by Commander.js signature (arg, options, command)
       handleAsyncCommand(
         async (documentId: string, _options: unknown, command: Command) => {
-          const rootOpts = command.parent!.parent!.opts();
+          const rootOpts = getRootOpts(command);
           const documentsService = await createGraphQLDocumentsService(rootOpts);
 
           await documentsService.deleteDocument(documentId);

--- a/src/commands/embeds.ts
+++ b/src/commands/embeds.ts
@@ -1,5 +1,6 @@
 import { Command } from "commander";
 import { getApiToken } from "../utils/auth.js";
+import { getRootOpts } from "../utils/context.js";
 import { handleAsyncCommand, outputSuccess } from "../utils/output.js";
 import { FileService } from "../utils/file-service.js";
 
@@ -49,7 +50,7 @@ export function setupEmbedsCommands(program: Command): void {
       handleAsyncCommand(
         async (url: string, options: any, command: Command) => {
           // Get API token from parent command options for authentication
-          const apiToken = await getApiToken(command.parent!.parent!.opts());
+          const apiToken = await getApiToken(getRootOpts(command));
 
           // Create file service and initiate download
           const fileService = new FileService(apiToken);
@@ -96,7 +97,7 @@ export function setupEmbedsCommands(program: Command): void {
       handleAsyncCommand(
         async (filePath: string, _options: any, command: Command) => {
           // Get API token from parent command options for authentication
-          const apiToken = await getApiToken(command.parent!.parent!.opts());
+          const apiToken = await getApiToken(getRootOpts(command));
 
           // Create file service and initiate upload
           const fileService = new FileService(apiToken);

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { getRootOpts } from "../utils/context.js";
 import { createGraphQLService } from "../utils/graphql-service.js";
 import { GraphQLIssuesService } from "../utils/graphql-issues-service.js";
 import { createLinearService } from "../utils/linear-service.js";
@@ -43,10 +44,11 @@ export function setupIssuesCommands(program: Command): void {
     .action(
       handleAsyncCommand(
         async (options: any, command: Command) => {
+          const rootOpts = getRootOpts(command);
           // Initialize both services for comprehensive issue data
           const [graphQLService, linearService] = await Promise.all([
-            createGraphQLService(command.parent!.parent!.opts()),
-            createLinearService(command.parent!.parent!.opts()),
+            createGraphQLService(rootOpts),
+            createLinearService(rootOpts),
           ]);
           const issuesService = new GraphQLIssuesService(
             graphQLService,
@@ -78,9 +80,10 @@ export function setupIssuesCommands(program: Command): void {
     .action(
       handleAsyncCommand(
         async (query: string, options: any, command: Command) => {
+          const rootOpts = getRootOpts(command);
           const [graphQLService, linearService] = await Promise.all([
-            createGraphQLService(command.parent!.parent!.opts()),
-            createLinearService(command.parent!.parent!.opts()),
+            createGraphQLService(rootOpts),
+            createLinearService(rootOpts),
           ]);
           const issuesService = new GraphQLIssuesService(
             graphQLService,
@@ -134,9 +137,10 @@ export function setupIssuesCommands(program: Command): void {
     .action(
       handleAsyncCommand(
         async (title: string, options: any, command: Command) => {
+          const rootOpts = getRootOpts(command);
           const [graphQLService, linearService] = await Promise.all([
-            createGraphQLService(command.parent!.parent!.opts()),
-            createLinearService(command.parent!.parent!.opts()),
+            createGraphQLService(rootOpts),
+            createLinearService(rootOpts),
           ]);
           const issuesService = new GraphQLIssuesService(
             graphQLService,
@@ -186,10 +190,11 @@ export function setupIssuesCommands(program: Command): void {
     .action(
       handleAsyncCommand(
         async (issueId: string, _options: any, command: Command) => {
+          const rootOpts = getRootOpts(command);
           // Initialize both services for comprehensive issue data
           const [graphQLService, linearService] = await Promise.all([
-            createGraphQLService(command.parent!.parent!.opts()),
-            createLinearService(command.parent!.parent!.opts()),
+            createGraphQLService(rootOpts),
+            createLinearService(rootOpts),
           ]);
           const issuesService = new GraphQLIssuesService(
             graphQLService,
@@ -305,9 +310,10 @@ export function setupIssuesCommands(program: Command): void {
             );
           }
 
+          const rootOpts = getRootOpts(command);
           const [graphQLService, linearService] = await Promise.all([
-            createGraphQLService(command.parent!.parent!.opts()),
-            createLinearService(command.parent!.parent!.opts()),
+            createGraphQLService(rootOpts),
+            createLinearService(rootOpts),
           ]);
           const issuesService = new GraphQLIssuesService(
             graphQLService,

--- a/src/commands/labels.ts
+++ b/src/commands/labels.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { getRootOpts } from "../utils/context.js";
 import { createLinearService } from "../utils/linear-service.js";
 import { handleAsyncCommand, outputSuccess } from "../utils/output.js";
 
@@ -39,7 +40,7 @@ export function setupLabelsCommands(program: Command): void {
     .option("--team <team>", "filter by team key, name, or ID")
     .action(handleAsyncCommand(async (options: any, command: Command) => {
       // Initialize Linear service for label operations
-      const service = await createLinearService(command.parent!.parent!.opts());
+      const service = await createLinearService(getRootOpts(command));
       
       // Fetch labels with optional team filtering
       const result = await service.getLabels(options.team);

--- a/src/commands/project-milestones.ts
+++ b/src/commands/project-milestones.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { getRootOpts } from "../utils/context.js";
 import { createGraphQLService } from "../utils/graphql-service.js";
 import { createLinearService } from "../utils/linear-service.js";
 import { handleAsyncCommand, outputSuccess } from "../utils/output.js";
@@ -96,9 +97,10 @@ export function setupProjectMilestonesCommands(program: Command): void {
     .action(
       handleAsyncCommand(
         async (options: MilestoneListOptions, command: Command) => {
+          const rootOpts = getRootOpts(command);
           const [graphQLService, linearService] = await Promise.all([
-            createGraphQLService(command.parent!.parent!.opts()),
-            createLinearService(command.parent!.parent!.opts()),
+            createGraphQLService(rootOpts),
+            createLinearService(rootOpts),
           ]);
 
           // Resolve project ID using LinearService
@@ -134,9 +136,10 @@ export function setupProjectMilestonesCommands(program: Command): void {
           options: MilestoneReadOptions,
           command: Command,
         ) => {
+          const rootOpts = getRootOpts(command);
           const [graphQLService, linearService] = await Promise.all([
-            createGraphQLService(command.parent!.parent!.opts()),
-            createLinearService(command.parent!.parent!.opts()),
+            createGraphQLService(rootOpts),
+            createLinearService(rootOpts),
           ]);
 
           const milestoneId = await resolveMilestoneId(
@@ -173,9 +176,10 @@ export function setupProjectMilestonesCommands(program: Command): void {
           options: MilestoneCreateOptions,
           command: Command,
         ) => {
+          const rootOpts = getRootOpts(command);
           const [graphQLService, linearService] = await Promise.all([
-            createGraphQLService(command.parent!.parent!.opts()),
-            createLinearService(command.parent!.parent!.opts()),
+            createGraphQLService(rootOpts),
+            createLinearService(rootOpts),
           ]);
 
           // Resolve project ID using LinearService
@@ -223,9 +227,10 @@ export function setupProjectMilestonesCommands(program: Command): void {
           options: MilestoneUpdateOptions,
           command: Command,
         ) => {
+          const rootOpts = getRootOpts(command);
           const [graphQLService, linearService] = await Promise.all([
-            createGraphQLService(command.parent!.parent!.opts()),
-            createLinearService(command.parent!.parent!.opts()),
+            createGraphQLService(rootOpts),
+            createLinearService(rootOpts),
           ]);
 
           const milestoneId = await resolveMilestoneId(

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { getRootOpts } from "../utils/context.js";
 import { createLinearService } from "../utils/linear-service.js";
 import { handleAsyncCommand, outputSuccess } from "../utils/output.js";
 
@@ -44,7 +45,7 @@ export function setupProjectsCommands(program: Command): void {
     )
     .action(handleAsyncCommand(async (_options: any, command: Command) => {
       // Initialize Linear service for project operations
-      const service = await createLinearService(command.parent!.parent!.opts());
+      const service = await createLinearService(getRootOpts(command));
       
       // Fetch all projects with their relationships
       const result = await service.getProjects();

--- a/src/commands/teams.ts
+++ b/src/commands/teams.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { getRootOpts } from "../utils/context.js";
 import { createLinearService } from "../utils/linear-service.js";
 import { handleAsyncCommand, outputSuccess } from "../utils/output.js";
 
@@ -40,7 +41,7 @@ export function setupTeamsCommands(program: Command): void {
     .action(
       handleAsyncCommand(async (options: any, command: Command) => {
         // Initialize Linear service for team operations
-        const service = await createLinearService(command.parent!.parent!.opts());
+        const service = await createLinearService(getRootOpts(command));
 
         // Fetch all teams from the workspace
         const result = await service.getTeams();

--- a/src/commands/users.ts
+++ b/src/commands/users.ts
@@ -1,4 +1,5 @@
 import { Command } from "commander";
+import { getRootOpts } from "../utils/context.js";
 import { createLinearService } from "../utils/linear-service.js";
 import { handleAsyncCommand, outputSuccess } from "../utils/output.js";
 
@@ -42,7 +43,7 @@ export function setupUsersCommands(program: Command): void {
     .action(
       handleAsyncCommand(async (options: any, command: Command) => {
         // Initialize Linear service for user operations
-        const service = await createLinearService(command.parent!.parent!.opts());
+        const service = await createLinearService(getRootOpts(command));
 
         // Fetch all users from the workspace
         const result = await service.getUsers(options.active);

--- a/src/utils/context.ts
+++ b/src/utils/context.ts
@@ -1,0 +1,15 @@
+import type { Command } from "commander";
+import type { CommandOptions } from "./auth.js";
+
+/**
+ * Walk up the Commander tree and return the root command options.
+ */
+export function getRootOpts(command: Command): CommandOptions {
+  let current: Command = command;
+
+  while (current.parent) {
+    current = current.parent;
+  }
+
+  return current.opts<CommandOptions>();
+}

--- a/tests/unit/context.test.ts
+++ b/tests/unit/context.test.ts
@@ -1,0 +1,26 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { getRootOpts } from "../../src/utils/context.js";
+
+describe("getRootOpts", () => {
+  it("returns the root command options from nested subcommands", () => {
+    const root = new Command();
+    root.option("--api-token <token>");
+    root.parse(["node", "linearis", "--api-token", "pat_123"], {
+      from: "node",
+    });
+
+    const child = root.command("issues");
+    const grandchild = child.command("list");
+
+    expect(getRootOpts(grandchild)).toEqual({ apiToken: "pat_123" });
+  });
+
+  it("works when the provided command is already the root command", () => {
+    const root = new Command();
+    root.option("--api-token <token>");
+    root.parse(["node", "linearis"], { from: "node" });
+
+    expect(getRootOpts(root)).toEqual({ apiToken: undefined });
+  });
+});


### PR DESCRIPTION
## Summary
- add a getRootOpts() helper that walks up to the root Commander command
- replace fragile command.parent!.parent!.opts() access across the command layer
- add a focused unit test for nested and root command resolution

## Validation
- 
px vitest run tests/unit/context.test.ts
- 
px tsc --noEmit

## Note
- 
pm run build compiles successfully on this machine until the repo's POSIX-only chmod step, which is unavailable in Windows PowerShell
