### PR TITLE
build: add prepare script for source installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,10 @@
     "LICENSE.md"
   ],
   "scripts": {
-    "build": "tsc && chmod +x dist/main.js",
+    "build": "tsc && node scripts/make-executable.mjs",
     "clean": "rm -rf dist/",
     "start": "tsx src/main.ts",
+    "prepare": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",

--- a/scripts/make-executable.mjs
+++ b/scripts/make-executable.mjs
@@ -1,0 +1,8 @@
+import { chmodSync, existsSync } from "fs";
+import { join } from "path";
+
+const entrypoint = join(process.cwd(), "dist", "main.js");
+
+if (existsSync(entrypoint)) {
+  chmodSync(entrypoint, 0o755);
+}


### PR DESCRIPTION
## Summary
- replace the POSIX-only chmod shell call with a small Node-based executable-bit helper
- add a prepare script so git-based installs build dist/ before the package manager links the CLI
- keep the normal build flow unchanged for releases and local development

## Validation
- 
pm run build
- 
pm pack --dry-run
