### PR TITLE
fix: replace empty catch blocks with handling

### DIFF
--- a/src/commands/documents.ts
+++ b/src/commands/documents.ts
@@ -74,7 +74,7 @@ export function extractDocumentIdFromUrl(url: string): string | null {
     }
 
     return docSlug.substring(lastHyphenIndex + 1) || null;
-  } catch {
+  } catch (_error) {
     // URL constructor throws on malformed URLs - treat as non-Linear URL
     // This is intentional: attachments may contain arbitrary URLs that aren't
     // valid, and we simply skip them rather than failing the entire operation

--- a/src/utils/embed-parser.ts
+++ b/src/utils/embed-parser.ts
@@ -112,7 +112,8 @@ export function isLinearUploadUrl(url: string): boolean {
   try {
     const urlObj = new URL(url);
     return urlObj.hostname === "uploads.linear.app";
-  } catch {
+  } catch (_error) {
+    // Invalid URLs are expected when parsing arbitrary markdown content.
     return false;
   }
 }
@@ -127,7 +128,8 @@ export function extractFilenameFromUrl(url: string): string {
     const pathname = urlObj.pathname;
     const parts = pathname.split("/");
     return parts[parts.length - 1] || "download";
-  } catch {
+  } catch (_error) {
+    // Fall back to a generic filename when the URL cannot be parsed.
     return "download";
   }
 }

--- a/src/utils/file-service.ts
+++ b/src/utils/file-service.ts
@@ -74,6 +74,13 @@ function getMimeType(filePath: string): string {
   return MIME_TYPES[ext] || "application/octet-stream";
 }
 
+function isMissingFileError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    (("code" in error && error.code === "ENOENT") || error.message === "ENOENT")
+  );
+}
+
 export interface DownloadOptions {
   /** Custom output file path (defaults to filename from URL) */
   output?: string;
@@ -172,8 +179,15 @@ export class FileService {
           error:
             `File already exists: ${outputPath}. Use --overwrite to replace.`,
         };
-      } catch {
-        // File doesn't exist, we can proceed
+      } catch (error) {
+        if (isMissingFileError(error)) {
+          // Missing output path is expected here; we'll create it below.
+        } else {
+          return {
+            success: false,
+            error: error instanceof Error ? error.message : String(error),
+          };
+        }
       }
     }
 
@@ -255,10 +269,17 @@ export class FileService {
     // Check if file exists
     try {
       await access(filePath);
-    } catch {
+    } catch (error) {
+      if (isMissingFileError(error)) {
+        return {
+          success: false,
+          error: `File not found: ${filePath}`,
+        };
+      }
+
       return {
         success: false,
-        error: `File not found: ${filePath}`,
+        error: error instanceof Error ? error.message : String(error),
       };
     }
 

--- a/src/utils/identifier-parser.ts
+++ b/src/utils/identifier-parser.ts
@@ -60,7 +60,8 @@ export function parseIssueIdentifier(identifier: string): ParsedIssueIdentifier 
 export function tryParseIssueIdentifier(identifier: string): ParsedIssueIdentifier | null {
   try {
     return parseIssueIdentifier(identifier);
-  } catch {
+  } catch (_error) {
+    // Invalid TEAM-123 values are expected in permissive parsing paths.
     return null;
   }
 }

--- a/src/utils/linear-service.ts
+++ b/src/utils/linear-service.ts
@@ -251,8 +251,8 @@ export class LinearService {
         teamKeyOrNameOrId,
       );
       return team.id;
-    } catch {
-      // If not found by key, try by name
+    } catch (_error) {
+      // Not every caller passes a team key; fall back to an exact name lookup.
       const team = await executeLinearQuery(
         () =>
           this.client.teams({


### PR DESCRIPTION
## Summary
- remove the remaining silent catch {} blocks from the current src/ tree
- keep intentional fallback paths, but document them inline so they are no longer silent swallows
- surface unexpected file access errors instead of flattening them into misleading not-found behavior

## Validation
- 
px vitest run tests/unit/documents-url-parsing.test.ts tests/unit/file-service-upload.test.ts
- 
px tsc --noEmit
