### PR TITLE
fix(ci): remove global npm upgrade from publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -51,10 +51,6 @@ jobs:
           node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
-      # Ensure npm 11.5.1 or later is installed
-      - name: Update npm
-        run: npm install -g npm@latest
-
       - name: Clean install
         run: npm install
 


### PR DESCRIPTION
## Problem

The publish workflow fails at the `Update npm` step with:

```
npm error code MODULE_NOT_FOUND
npm error Cannot find module 'promise-retry'
```

`npm install -g npm@latest` on Node 22.22.2 GitHub runners corrupts npm's own internal dependencies during the self-upgrade.

See: https://github.com/czottmann/linearis/actions/runs/24092632590/job/70282838576

## Fix

Remove the `npm install -g npm@latest` step entirely. Node 22 ships with npm 10.x which already supports `--provenance` publishing (requires npm ≥ 9.5.0). The forced global upgrade is unnecessary.

## After merge

Re-tag and push to re-trigger the publish:

```bash
git tag -d v2026.4.1
git push origin :refs/tags/v2026.4.1
git tag -a v2026.4.1 -m "Release 2026.4.1"
git push origin v2026.4.1
```