### PR TITLE
fix: update repository URLs from czottmann/linearis to linearis-oss/linearis

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: true
 contact_links:
   - name: Security Vulnerability
-    url: https://github.com/czottmann/linearis/blob/main/SECURITY.md
+    url: https://github.com/linearis-oss/linearis/blob/main/SECURITY.md
     about: Please report security issues privately via email, not as public issues.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [2026.4.1] - 2026-04-07
 
-[2026.4.1]: https://github.com/czottmann/linearis/compare/v2025.12.3...v2026.4.1
+[2026.4.1]: https://github.com/linearis-oss/linearis/compare/v2025.12.3...v2026.4.1
 
 ### Breaking Changes
 
-- **Complete architecture rewrite** to a strict five-layer architecture: CLI Input → Command → Resolver → Service → JSON Output. [#45](https://github.com/czottmann/linearis/issues/45), [#27](https://github.com/czottmann/linearis/issues/27), [#43](https://github.com/czottmann/linearis/issues/43), [#47](https://github.com/czottmann/linearis/issues/47), [PR#49](https://github.com/czottmann/linearis/pull/49)
+- **Complete architecture rewrite** to a strict five-layer architecture: CLI Input → Command → Resolver → Service → JSON Output. [#45](https://github.com/linearis-oss/linearis/issues/45), [#27](https://github.com/linearis-oss/linearis/issues/27), [#43](https://github.com/linearis-oss/linearis/issues/43), [#47](https://github.com/linearis-oss/linearis/issues/47), [PR#49](https://github.com/linearis-oss/linearis/pull/49)
 - **`embeds` commands renamed to `files`** — `embeds download` → `files download`, `embeds upload` → `files upload`
 - **`project-milestones` commands renamed to `milestones`**
 - **`search` subcommands merged into `list`** — use `issues list --status ...` instead of `issues search --status ...`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ First up, because sadly its necessary: Fascists and brownshirts (US ICE etc.) ne
 Requires **Node.js >= 22**.
 
 ```bash
-git clone https://github.com/czottmann/linearis.git
+git clone https://github.com/linearis-oss/linearis.git
 cd linearis
 npm install        # Install deps + GraphQL codegen + lefthook
 npm start          # Development mode (tsx, no compilation)

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -9,7 +9,7 @@ Linearis is a CLI tool for Linear.app that compiles from TypeScript to JavaScrip
 Clone and install:
 
 ```bash
-git clone https://github.com/czottmann/linearis.git
+git clone https://github.com/linearis-oss/linearis.git
 cd linearis
 npm install
 ```
@@ -31,7 +31,7 @@ This creates the `linearis` command, pointing to `dist/main.js`.
 ### Direct Git Install
 
 ```bash
-npm install git+https://github.com/czottmann/linearis.git
+npm install git+https://github.com/linearis-oss/linearis.git
 ```
 
 This runs `postinstall` to generate GraphQL types. You still need to run `npm run build` separately to compile TypeScript.

--- a/package.json
+++ b/package.json
@@ -54,12 +54,12 @@
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/czottmann/linearis.git"
+    "url": "git+https://github.com/linearis-oss/linearis.git"
   },
   "bugs": {
-    "url": "https://github.com/czottmann/linearis/issues"
+    "url": "https://github.com/linearis-oss/linearis/issues"
   },
-  "homepage": "https://github.com/czottmann/linearis#readme",
+  "homepage": "https://github.com/linearis-oss/linearis#readme",
   "dependencies": {
     "@linear/sdk": "58.1.0",
     "commander": "14.0.2"


### PR DESCRIPTION
## Problem

`npm publish --provenance` fails with `E404` because the OIDC token issued by GitHub Actions for `linearis-oss/linearis` does not match the `czottmann/linearis` repository URL in `package.json`. npm's provenance verification rejects the mismatch.

See: https://github.com/linearis-oss/linearis/actions/runs/24093992364/job/70287901207

## Fix

Update all repository references from `czottmann/linearis` to `linearis-oss/linearis`:

- `package.json`: `repository.url`, `bugs.url`, `homepage`
- `CHANGELOG.md`: v2026.4.1 compare/issue links
- `docs/deployment.md`: clone and install URLs
- `CONTRIBUTING.md`: clone URL
- `.github/ISSUE_TEMPLATE/config.yml`: security policy link

Historical CHANGELOG entries (≤ v2025.12.3) intentionally keep the old URLs since those PRs/issues live on the original repo.

## After merge

Re-tag and push to re-trigger the publish:

```bash
git tag -d v2026.4.1
git push origin :refs/tags/v2026.4.1
git tag -a v2026.4.1 -m "Release 2026.4.1"
git push origin v2026.4.1
```