### PR TITLE
fix(ci): use npm token instead of OIDC provenance for publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,6 @@ on:
       - "v*.*.*"
 
 permissions:
-  id-token: write # Required for OIDC
   contents: read
 
 jobs:
@@ -61,7 +60,9 @@ jobs:
         run: npm test
 
       - name: Publish to npm
-        run: npm publish --provenance --access public
+        run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Verify publish success
         run: |


### PR DESCRIPTION
## Problem

`npm publish --provenance` fails with E404 after the repository transfer to `linearis-oss`. npm's OIDC trusted publisher verification rejects the publish even with the trusted publisher config updated on npmjs.com.

See: https://github.com/linearis-oss/linearis/actions/runs/24093992364/job/70287901207

## Root cause

npm provenance uses OIDC tokens whose claims must exactly match the trusted publisher configuration. After the org transfer, the verification continues to fail — likely due to npm-side propagation or claim mismatch.

## Fix

Switch from OIDC provenance to explicit npm token authentication:

- Drop `--provenance` flag from `npm publish`
- Remove `id-token: write` permission (no longer needed)
- Set `NODE_AUTH_TOKEN` explicitly from `NPM_TOKEN` secret

## Setup required

1. Generate an npm **granular access token** with publish permission for the `linearis` package
2. Add it as `NPM_TOKEN` secret in the repo's `npm-publish` environment (**Settings → Environments → npm-publish → Secrets**)

## After merge

Re-tag to trigger publish:

```bash
git pull origin main
git tag -d v2026.4.1
git push origin :refs/tags/v2026.4.1
git tag -a v2026.4.1 -m "Release 2026.4.1"
git push origin v2026.4.1
```