### PR TITLE
fix(ci): use OIDC trusted publishing without npm token

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,11 +6,11 @@ on:
       - "v*.*.*"
 
 permissions:
+  id-token: write
   contents: read
 
 jobs:
   publish:
-    # Only run on main branch
     if: github.ref_name == github.event.repository.default_branch || startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment: npm-publish
@@ -44,11 +44,12 @@ jobs:
           fi
           echo "Version check passed: $PACKAGE_VERSION"
 
+      # Do not use registry-url — it creates an .npmrc with a token
+      # placeholder that would bypass OIDC trusted publishing.
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "22"
-          registry-url: "https://registry.npmjs.org"
 
       - name: Clean install
         run: npm install
@@ -60,9 +61,7 @@ jobs:
         run: npm test
 
       - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
 
       - name: Verify publish success
         run: |


### PR DESCRIPTION
## Problem

Publishing fails because `actions/setup-node` with `registry-url` writes `${NODE_AUTH_TOKEN}` into `.npmrc`. The `npm-publish` environment injects a token via this variable, so npm authenticates with it instead of OIDC — hitting either `EOTP` (2FA required) or `E404` (token lacks publish access).

## Fix

Remove `registry-url` from `setup-node` so no `.npmrc` with a token placeholder is created. Without a token, npm authenticates via the OIDC provenance statement against the trusted publisher config on npmjs.com.

Verified via Sigstore transparency log (`logIndex 1247596048`) that the OIDC claims are correct after the org transfer:

| Claim | Value |
|---|---|
| Repository | `linearis-oss/linearis` |
| Workflow | `publish.yml` |
| Environment | `npm-publish` |

## After merge

```bash
git pull origin main
git tag -d v2026.4.1
git push origin :refs/tags/v2026.4.1
git tag -a v2026.4.1 -m "Release 2026.4.1"
git push origin v2026.4.1
```