### PR TITLE
fix(ci): restore token auth with provenance for npm publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -44,12 +44,11 @@ jobs:
           fi
           echo "Version check passed: $PACKAGE_VERSION"
 
-      # Do not use registry-url — it creates an .npmrc with a token
-      # placeholder that would bypass OIDC trusted publishing.
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: "22"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Clean install
         run: npm install
@@ -62,6 +61,8 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Verify publish success
         run: |


### PR DESCRIPTION
## Problem

`npm publish --provenance` without a token fails with `ENEEDAUTH`. OIDC provenance does **not** replace token authentication — it adds a signed attestation alongside the publish. The trusted publisher config on npmjs.com makes provenance **mandatory**, but a token is still required to authorize the request.

## Fix

Restore `registry-url` and `NODE_AUTH_TOKEN` from `NPM_TOKEN` secret. Combined with `--provenance` and `id-token: write`, this gives us both token auth and provenance attestation.

## Setup required

The `NPM_TOKEN` secret in the `npm-publish` environment must be a **granular access token** (not a classic/automation token):

1. npmjs.com → **Access Tokens → Generate New Token → Granular Access Token**
2. Packages: select `linearis`, permission **Read and write**
3. Store as `NPM_TOKEN` in **Settings → Environments → npm-publish → Secrets**

Granular tokens bypass 2FA by design, avoiding the `EOTP` error that classic tokens cause in CI.

## After merge

```bash
git pull origin main
git tag -d v2026.4.1
git push origin :refs/tags/v2026.4.1
git tag -a v2026.4.1 -m "Release 2026.4.1"
git push origin v2026.4.1
```