### PR TITLE
ci: add GitHub release creation to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,7 +7,7 @@ on:
 
 permissions:
   id-token: write
-  contents: read
+  contents: write
 
 jobs:
   publish:
@@ -64,7 +64,48 @@ jobs:
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
+      - name: Extract release notes from CHANGELOG
+        run: |
+          VERSION="${{ steps.extract_version.outputs.version }}"
+
+          # Extract compare URL from reference link
+          COMPARE_URL=$(grep -E "^\[${VERSION}\]: " CHANGELOG.md | sed "s/^\[${VERSION}\]: //")
+
+          # Extract body: convert ### to ##, strip --- separators, collapse blank lines
+          NOTES=$(awk -v ver="$VERSION" '
+            /^## \[/ {
+              if (found) exit
+              if ($0 ~ "\\[" ver "\\]") { found=1; next }
+            }
+            /^\[.*\]: https/ { next }
+            found { print }
+          ' CHANGELOG.md \
+            | sed 's/^### /## /' \
+            | sed '/^---$/d' \
+            | sed '/^$/N;/^\n$/d')
+
+          # Combine: Full Changelog link + body
+          {
+            if [ -n "$COMPARE_URL" ]; then
+              printf "**Full Changelog**: %s\n\n" "$COMPARE_URL"
+            fi
+            printf '%s\n' "$NOTES"
+          } > /tmp/release-notes.md
+
+          echo "Extracted release notes for v$VERSION"
+
+      - name: Create GitHub release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          VERSION="${{ steps.extract_version.outputs.version }}"
+          gh release create "v${VERSION}" \
+            --title "v${VERSION}" \
+            --notes-file /tmp/release-notes.md \
+            --verify-tag
+
       - name: Verify publish success
         run: |
           echo "✅ Successfully published linearis@${{ steps.extract_version.outputs.version }}"
           echo "📦 Package URL: https://www.npmjs.com/package/linearis"
+          echo "📋 Release: https://github.com/${{ github.repository }}/releases/tag/v${{ steps.extract_version.outputs.version }}"


### PR DESCRIPTION
## Summary

After publishing to npm, the publish workflow now automatically creates a GitHub release with release notes extracted from `CHANGELOG.md`, matching the format of previous releases (e.g. v2025.12.3, v2025.12.2).

## Changes

- **`contents` permission**: `read` → `write` (required for `gh release create`)
- **Changelog extraction step**:
  - Extracts the version section body via `awk`
  - Extracts the compare URL from the `[version]: url` reference link
  - Converts `###` headings to `##` (CHANGELOG nests under `## [version]`, releases use top-level `##`)
  - Strips `---` separators and collapses blank lines
  - Prepends `**Full Changelog**: <compare-url>` header
- **Release creation step**: Runs `gh release create` with `--verify-tag` and the extracted notes
- **Verify step**: Now includes the release URL in output

## Context

v2026.4.1 was published to npm but no GitHub release was created. The existing v2026.4.1 release has been manually fixed to match the format of previous releases. This PR ensures all future tag-triggered publishes create a correctly formatted GitHub release automatically.

## Testing

- Changelog extraction tested locally against v2026.4.1 and v2025.12.3 — output matches the established release format
- Workflow-only change, no code changes — all existing CI checks pass