### PR TITLE
build: remove unnecessary chmod from build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "USAGE.md"
   ],
   "scripts": {
-    "build": "tsc && chmod +x dist/main.js",
+    "build": "tsc",
     "clean": "rm -rf dist/",
     "start": "tsx src/main.ts",
     "test": "vitest run",
@@ -35,7 +35,7 @@
     "postinstall": "npm run generate && lefthook install",
     "prebuild": "npm run generate && npm run generate:usage",
     "prepare": "lefthook install",
-    "prepublishOnly": "npm run build && npm run test && test -x dist/main.js"
+    "prepublishOnly": "npm run build && npm run test"
   },
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## Summary

Remove two POSIX-only shell commands from `package.json` that are redundant because npm's internal `bin-links` package already sets executable permissions on every `bin` entry during install.

### Changes

- **`build`**: `tsc && chmod +x dist/main.js` → `tsc`
- **`prepublishOnly`**: `npm run build && npm run test && test -x dist/main.js` → `npm run build && npm run test`

### Why this is safe

- npm's `bin-links/lib/fix-bin.js` calls `chmod(file, 0o777 & (~process.umask()))` on every `bin` entry during install
- Integration tests invoke via `node dist/main.js`, not `./dist/main.js`
- `npm start` uses `tsx src/main.ts` (source, not dist)
- Major CLI tools (TypeScript, Vitest, ESLint) ship without manual chmod

### Verification

- [x] `npm run build` succeeds without chmod
- [x] `npm run check:ci` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (203/203)
- [x] `npm pack --dry-run` includes `dist/main.js`

Closes #78
Refs #67, #58