### PR TITLE
fix: add prepack script for git-based installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "postinstall": "npm run generate && lefthook install",
     "prebuild": "npm run generate && npm run generate:usage",
     "prepare": "lefthook install",
-    "prepublishOnly": "npm run build && npm run test"
+    "prepack": "npm run build",
+    "prepublishOnly": "npm test"
   },
   "engines": {
     "node": ">=22.0.0"


### PR DESCRIPTION
## Summary

Git-based installs (`npm install github:linearis-oss/linearis`) fail because `dist/` is not committed and no lifecycle hook triggers the build. This adds a `prepack` script that runs the full build chain.

### Changes

- **Add `prepack`**: `npm run build` — runs before packing on `npm pack`, `npm publish`, and git-based installs
- **Simplify `prepublishOnly`**: `npm run build && npm run test` → `npm test` — avoids double-build on publish since `prepack` now owns the build

### Lifecycle coverage

| Scenario | Hooks | Result |
|---|---|---|
| `npm publish` | `prepublishOnly` (test) → `prepack` (build) | ✅ tested + built |
| `npm pack` | `prepack` (build) | ✅ built |
| `npm install github:…` | `prepack` (build) | ✅ **fixes #58** |
| Local `npm install` | `prepare` (lefthook) | ✅ unchanged |
| Yarn v1 git install | `prepack` (build) — no devDeps | ❌ known Yarn v1 limitation |

### Why `prepack` and not `prepare`

`prepare` is already used for `lefthook install`. Overloading it would either break git hooks for contributors or require conditional logic. `prepack` runs in exactly the right scenarios (pack, publish, git install) without touching local dev setup.

### Verification

- [x] `npm run check:ci` passes
- [x] `npx tsc --noEmit` passes
- [x] `npm test` passes (203/203)
- [x] `npm run build` succeeds
- [x] `npm pack --dry-run` includes `dist/main.js`

Closes #58
Refs #67, #78