### PR TITLE
ci: add content permission to ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,9 @@ on:
       - ready_for_review
       - reopened
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true


### PR DESCRIPTION
Potential fix for [https://github.com/linearis-oss/linearis/security/code-scanning/2](https://github.com/linearis-oss/linearis/security/code-scanning/2)

In general, fix this issue by adding an explicit `permissions` key either at the workflow root (applies to all jobs) or per job, granting only the minimum scopes required. For pure CI jobs that only need to read repository contents, `permissions: contents: read` is usually sufficient.

For this specific workflow, neither `test` nor `lint` jobs perform any GitHub write operations; they only check out code and run Node.js commands. The best fix without changing functionality is to add a root‑level `permissions` block just after the `on:` section, setting `contents: read`. This will apply to both jobs because they do not define their own `permissions`. No imports or additional methods are needed, as this is purely a YAML configuration change.

Concretely, in `.github/workflows/ci.yml`, insert:

```yaml
permissions:
  contents: read
```

between the `on:` block (lines 3–12) and the `concurrency:` block (line 14). This will satisfy CodeQL and constrain the `GITHUB_TOKEN` to read‑only repository contents for this workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
