### PR TITLE
chore: disable renovate dependency dashboard

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended"],
+  "extends": ["config:recommended", ":disableDependencyDashboard"],
   "minimumReleaseAge": "3 days",
   "prConcurrentLimit": 5,
   "schedule": ["before 9am on monday"],


### PR DESCRIPTION
Disable the Renovate dependency dashboard issue by adding `:disableDependencyDashboard` preset to the extends config.