### PR TITLE
ci: expand CI matrix to test Node.js 22 and 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,7 +25,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [22, 24]
 
     steps:
       - name: Checkout code
@@ -49,7 +49,7 @@ jobs:
   lint:
     strategy:
       matrix:
-        node-version: [22]
+        node-version: [22, 24]
 
     name: Code checks on node v${{ matrix.node-version }}
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds Node.js 24 to the CI strategy matrix for both the `test` and `lint` jobs, ensuring build, unit tests, linting, and type-checking pass on all supported major versions.

## Changes

- `.github/workflows/ci.yml`: `node-version: [22]` → `[22, 24]` in both jobs

Closes #111
Refs #105