### PR TITLE
ci: pin publish workflow to minimum supported Node version

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -47,7 +47,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "22" # Pin to minimum supported version for publishing
           registry-url: "https://registry.npmjs.org"
 
       - name: Clean install

--- a/renovate.json
+++ b/renovate.json
@@ -26,6 +26,13 @@
       "description": "Group GitHub Actions updates",
       "matchManagers": ["github-actions"],
       "groupName": "github actions"
+    },
+    {
+      "description": "Pin publish workflow to minimum supported Node version",
+      "matchManagers": ["github-actions"],
+      "matchPackageNames": ["node"],
+      "matchFileNames": [".github/workflows/publish.yml"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
## Summary

Pin the publish workflow to Node 22 (the minimum supported version) and prevent Renovate from bumping it.

## Motivation

PR #106 proposes upgrading the publish workflow from Node 22 → 24. However, the publish workflow should use the **minimum supported version** (`engines.node >= 22.0.0`) to ensure maximum compatibility for all users. The CI matrix already validates both Node 22 and 24, so there is no need to also publish on 24.

Publishing with a newer Node/npm version can introduce subtle differences in package artifacts that may not be compatible with the minimum supported runtime.

## Changes

- **`.github/workflows/publish.yml`**: Added a comment clarifying the intentional pin to Node 22
- **`renovate.json`**: Added a package rule to disable Renovate updates of the Node version in the publish workflow

## Related

Refs #106 — once this is merged, #106 can be closed.