### PR TITLE
fix(issues): restore list filters and search subcommand

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file. The format 
 
 ---
 
+## [Unreleased]
+
+### Changed
+
+- Restored the dedicated `issues search <query>` subcommand while keeping `issues list --query <query>` as a deprecated compatibility path for one release window; both commands now share the same filter flags [#121](https://github.com/linearis-oss/linearis/issues/121), [PR#124](https://github.com/linearis-oss/linearis/pull/124)
+
+---
+
 ## [2026.4.3] - 2026-04-08
 
 [2026.4.3]: https://github.com/linearis-oss/linearis/compare/v2026.4.2...v2026.4.3

--- a/README.md
+++ b/README.md
@@ -48,121 +48,32 @@ linearis usage                # overview of all domains
 linearis issues usage         # detailed usage for one domain
 ```
 
-### Issues
+### Quick Start
 
 ```bash
+# Discover available commands
+linearis usage
+
+# Drill into a domain
+linearis issues usage
+
 # List recent issues
 linearis issues list --limit 10
 
-# Search issues by text
-linearis issues list --query "authentication" --team Platform
+# Search for issues
+linearis issues search "authentication bug"
 
 # Create an issue
-linearis issues create "Fix login timeout" --team Backend \
-  --assignee "Jane Doe" --labels "Bug,Critical" --priority 1 \
-  --description "Users report session expiry after 5 minutes"
+linearis issues create "Fix login flow" --team Platform --priority 2
 
-# Read issue details (supports ABC-123 identifiers)
-linearis issues read DEV-456
-
-# Update status, priority, labels
-linearis issues update ABC-123 --status "In Review" --priority 2
-linearis issues update DEV-789 --labels "Frontend,UX" --label-mode add
-linearis issues update ABC-123 --clear-labels
-
-# Parent-child relationships
-linearis issues update SUB-001 --parent-ticket EPIC-100
-
-# Issue relations
-linearis issues create "Blocked task" --team Backend --blocked-by DEV-123
-linearis issues update ABC-123 --blocks DEV-456
-linearis issues update ABC-123 --relates-to DEV-789
-linearis issues update ABC-123 --remove-relation DEV-456
+# Add a comment
+linearis comments create ENG-42 --body "Investigating this now"
 ```
 
-### Comments
+For the full reference of every command and flag, run:
 
 ```bash
-linearis comments create ABC-123 --body "Fixed in PR #456"
-```
-
-### Documents
-
-```bash
-# Create a document (optionally link to a project and/or issue)
-linearis documents create --title "API Design" --content "# Overview..."
-linearis documents create --title "Bug Analysis" --project "Backend" --issue ABC-123
-
-# List documents
-linearis documents list
-linearis documents list --project "Backend"
-linearis documents list --issue ABC-123
-
-# Read, update, delete
-linearis documents read <document-id>
-linearis documents update <document-id> --title "New Title" --content "Updated content"
-linearis documents delete <document-id>
-```
-
-### Cycles
-
-```bash
-# List cycles for a team
-linearis cycles list --team Backend --limit 10
-
-# Active cycle only
-linearis cycles list --team Backend --active
-
-# Active cycle +/- 3 neighbors
-linearis cycles list --team Backend --window 3
-
-# Read cycle details
-linearis cycles read "Sprint 2025-10" --team Backend
-```
-
-### Milestones
-
-```bash
-# List milestones in a project
-linearis milestones list --project "Backend"
-
-# Read milestone details
-linearis milestones read "Beta Release" --project "Backend"
-
-# Create and update milestones
-linearis milestones create "v2.0" --project "Backend" --target-date 2025-06-01
-linearis milestones update "v2.0" --project "Backend" --description "Major release"
-```
-
-### Files
-
-```bash
-# Download a file from Linear storage
-linearis files download "https://uploads.linear.app/.../file.png" --output ./screenshot.png
-
-# Upload and reference in a comment
-URL=$(linearis files upload ./bug.png | jq -r .assetUrl)
-linearis comments create ABC-123 --body "Screenshot: ![$URL]($URL)"
-```
-
-### Projects, Labels, Teams, Users
-
-```bash
-linearis projects list
-linearis labels list --team Backend
-linearis teams list
-linearis users list --active
-```
-
-### Pagination
-
-All list commands support cursor-based pagination:
-
-```bash
-linearis issues list --limit 25
-# Response includes pageInfo with endCursor and hasNextPage
-
-linearis issues list --limit 25 --after "cursor-from-previous-response"
+linearis <domain> usage
 ```
 
 ## AI Agent Integration

--- a/graphql/queries/issues.graphql
+++ b/graphql/queries/issues.graphql
@@ -250,11 +250,17 @@ query GetIssueTeam($issueId: String!) {
 #
 # Provides full-text search across Linear issues with complete
 # relationship data for each match.
-query SearchIssues($term: String!, $first: Int!, $after: String) {
+query SearchIssues(
+  $term: String!
+  $first: Int!
+  $after: String
+  $filter: IssueFilter
+) {
   searchIssues(
     term: $term
     first: $first
     after: $after
+    filter: $filter
     includeArchived: false
   ) {
     nodes {
@@ -290,42 +296,6 @@ query FilteredSearchIssues(
     pageInfo {
       hasNextPage
       endCursor
-    }
-  }
-}
-
-# Batch resolve query for search filters
-#
-# Resolves human-readable identifiers to UUIDs in a single batch query.
-# Used to pre-resolve teams, projects, and assignees before executing
-# main search query to avoid N+1 queries.
-query BatchResolveForSearch(
-  $teamKey: String
-  $teamName: String
-  $projectName: String
-  $assigneeEmail: String
-) {
-  teams(
-    filter: { or: [{ key: { eq: $teamKey } }, { name: { eq: $teamName } }] }
-    first: 1
-  ) {
-    nodes {
-      id
-      key
-      name
-    }
-  }
-  projects(filter: { name: { eqIgnoreCase: $projectName } }, first: 1) {
-    nodes {
-      id
-      name
-    }
-  }
-  users(filter: { email: { eq: $assigneeEmail } }, first: 1) {
-    nodes {
-      id
-      name
-      email
     }
   }
 }

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -6,7 +6,9 @@ import {
   parseDueDate,
   parseIssueIdentifier,
 } from "../common/identifier.js";
+import type { RawFilterFlags } from "../common/issue-filter.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
+import { resolveFilterOptions } from "../common/resolve-filters.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import {
   type IssueCreateInput,
@@ -21,6 +23,7 @@ import { resolveProjectId } from "../resolvers/project-resolver.js";
 import { resolveStatusId } from "../resolvers/status-resolver.js";
 import { resolveTeamId } from "../resolvers/team-resolver.js";
 import { resolveUserId } from "../resolvers/user-resolver.js";
+import { buildIssueFilter } from "../services/issue-filter.js";
 import {
   createIssueRelation,
   deleteIssueRelation,
@@ -35,10 +38,10 @@ import {
   updateIssue,
 } from "../services/issue-service.js";
 
-interface ListOptions {
-  query?: string;
+interface FilterOptions extends RawFilterFlags {
   limit: string;
   after?: string;
+  query?: string;
 }
 
 interface CreateOptions {
@@ -104,6 +107,7 @@ export const ISSUES_META: DomainMeta = {
   arguments: {
     issue: "issue identifier (UUID or ABC-123)",
     title: "string",
+    query: "full-text search term",
   },
   seeAlso: ["comments create <issue>", "documents list --issue <issue>"],
 };
@@ -178,40 +182,109 @@ async function applyRelation(
   }
 }
 
+function addFilterOptions(cmd: ReturnType<Command["command"]>): typeof cmd {
+  return cmd
+    .option("--team <team>", "filter by team")
+    .option("--assignee <user>", "filter by assignee")
+    .option("--creator <user>", "filter by creator")
+    .option("--project <project>", "filter by project")
+    .option(
+      "--status <statuses>",
+      "filter by status (comma-separated, requires --team)",
+    )
+    .option("--label <labels>", "filter by labels (comma-separated)")
+    .option("--cycle <cycle>", "filter by cycle (requires --team)")
+    .option("--parent <issue>", "filter by parent issue")
+    .option(
+      "--milestone <milestone>",
+      "filter by milestone (requires --project)",
+    )
+    .option("--priority <n>", "filter by priority (0-4)")
+    .option("--estimate <n>", "filter by estimate")
+    .option("--due-before <date>", "due before date (YYYY-MM-DD)")
+    .option("--due-after <date>", "due after date (YYYY-MM-DD)")
+    .option("--created-after <date>", "created after date (YYYY-MM-DD)")
+    .option("--created-before <date>", "created before date (YYYY-MM-DD)")
+    .option("--completed-after <date>", "completed after date (YYYY-MM-DD)")
+    .option("--completed-before <date>", "completed before date (YYYY-MM-DD)")
+    .option("--updated-after <date>", "updated after date (YYYY-MM-DD)")
+    .option("--updated-before <date>", "updated before date (YYYY-MM-DD)")
+    .option("--has-blockers", "only issues that are blocked")
+    .option("--is-blocking", "only issues that block others");
+}
+
 export function setupIssuesCommands(program: Command): void {
   const issues = program.command("issues").description("Issue operations");
 
   issues.action(() => issues.help());
 
-  issues
-    .command("list")
-    .description("list issues with optional filters")
-    .option("--query <text>", "filter by text search")
-    .option("-l, --limit <n>", "max results", "50")
-    .option("--after <cursor>", "cursor for next page")
-    .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [options, command] = args as [ListOptions, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+  addFilterOptions(
+    issues
+      .command("list")
+      .description("list issues with optional filters")
+      .option("--query <query>", "deprecated: use `issues search <query>`")
+      .option("-l, --limit <n>", "max results", "50")
+      .option("--after <cursor>", "cursor for next page"),
+  ).action(
+    handleCommand(async (...args: unknown[]) => {
+      const [options, command] = args as [FilterOptions, Command];
+      const ctx = createContext(command.parent!.parent!.opts());
 
-        const paginationOptions = {
-          limit: parseLimit(options.limit),
-          after: options.after,
-        };
+      const paginationOptions = {
+        limit: parseLimit(options.limit),
+        after: options.after,
+      };
 
-        if (options.query) {
-          const result = await searchIssues(
-            ctx.gql,
-            options.query,
-            paginationOptions,
-          );
-          outputSuccess(result);
-        } else {
-          const result = await listIssues(ctx.gql, paginationOptions);
-          outputSuccess(result);
-        }
-      }),
-    );
+      const filterOptions = await resolveFilterOptions(ctx, options);
+      const filter = buildIssueFilter(filterOptions);
+
+      if (options.query) {
+        const result = await searchIssues(
+          ctx.gql,
+          options.query,
+          paginationOptions,
+          filter,
+        );
+        outputSuccess(result);
+        return;
+      }
+
+      const result = await listIssues(ctx.gql, paginationOptions, filter);
+      outputSuccess(result);
+    }),
+  );
+
+  addFilterOptions(
+    issues
+      .command("search <query>")
+      .description("full-text search issues")
+      .option("-l, --limit <n>", "max results", "50")
+      .option("--after <cursor>", "cursor for next page"),
+  ).action(
+    handleCommand(async (...args: unknown[]) => {
+      const [query, options, command] = args as [
+        string,
+        FilterOptions,
+        Command,
+      ];
+      const ctx = createContext(command.parent!.parent!.opts());
+
+      const paginationOptions = {
+        limit: parseLimit(options.limit),
+        after: options.after,
+      };
+
+      const filterOptions = await resolveFilterOptions(ctx, options);
+      const filter = buildIssueFilter(filterOptions);
+      const result = await searchIssues(
+        ctx.gql,
+        query,
+        paginationOptions,
+        filter,
+      );
+      outputSuccess(result);
+    }),
+  );
 
   issues
     .command("read <issue>")

--- a/src/common/issue-filter.ts
+++ b/src/common/issue-filter.ts
@@ -1,0 +1,108 @@
+import { invalidParameterError, requiresParameterError } from "./errors.js";
+import { isUuid } from "./identifier.js";
+
+export interface IssueFilterOptions {
+  teamId?: string;
+  assigneeId?: string;
+  creatorId?: string;
+  projectId?: string;
+  stateIds?: string[];
+  labelIds?: string[];
+  cycleId?: string;
+  parentId?: string;
+  milestoneId?: string;
+  priority?: number;
+  estimate?: number;
+  dueBefore?: string;
+  dueAfter?: string;
+  createdAfter?: string;
+  createdBefore?: string;
+  completedAfter?: string;
+  completedBefore?: string;
+  updatedAfter?: string;
+  updatedBefore?: string;
+  hasBlockers?: boolean;
+  isBlocking?: boolean;
+}
+
+export interface RawFilterFlags {
+  team?: string;
+  assignee?: string;
+  creator?: string;
+  project?: string;
+  status?: string;
+  label?: string;
+  cycle?: string;
+  parent?: string;
+  milestone?: string;
+  priority?: string;
+  estimate?: string;
+  dueBefore?: string;
+  dueAfter?: string;
+  createdAfter?: string;
+  createdBefore?: string;
+  completedAfter?: string;
+  completedBefore?: string;
+  updatedAfter?: string;
+  updatedBefore?: string;
+  hasBlockers?: boolean;
+  isBlocking?: boolean;
+}
+
+export function validatePriority(value: number): void {
+  if (!Number.isInteger(value) || value < 0 || value > 4) {
+    throw invalidParameterError(
+      "priority",
+      "must be an integer between 0 and 4",
+    );
+  }
+}
+
+export function validateEstimate(value: number): void {
+  if (!Number.isInteger(value) || value < 0) {
+    throw invalidParameterError("estimate", "must be a non-negative integer");
+  }
+}
+
+export function validateDateRange(
+  after: string | undefined,
+  before: string | undefined,
+  label: string,
+): void {
+  if (after && before && after >= before) {
+    throw invalidParameterError(
+      label,
+      `range is contradictory: after (${after}) must be before (${before})`,
+    );
+  }
+}
+
+export function validateFilterDependencies(
+  flags: Pick<
+    RawFilterFlags,
+    "status" | "cycle" | "milestone" | "team" | "project"
+  >,
+): void {
+  if (flags.status && !isUuid(flags.status) && !flags.team) {
+    throw requiresParameterError("--status", "--team");
+  }
+  if (flags.cycle && !isUuid(flags.cycle) && !flags.team) {
+    throw requiresParameterError("--cycle", "--team");
+  }
+  if (flags.milestone && !isUuid(flags.milestone) && !flags.project) {
+    throw requiresParameterError("--milestone", "--project");
+  }
+}
+
+export function parseCommaSeparated(value: string): string[] {
+  const parts = value.split(",").map((s) => s.trim());
+  for (const part of parts) {
+    if (part === "") {
+      throw invalidParameterError(
+        "comma-separated list",
+        "contains empty segments",
+      );
+    }
+  }
+  return parts;
+}

--- a/src/common/resolve-filters.ts
+++ b/src/common/resolve-filters.ts
@@ -1,0 +1,162 @@
+import { resolveCycleId } from "../resolvers/cycle-resolver.js";
+import { resolveIssueId } from "../resolvers/issue-resolver.js";
+import { resolveLabelIds } from "../resolvers/label-resolver.js";
+import { resolveMilestoneId } from "../resolvers/milestone-resolver.js";
+import { resolveProjectId } from "../resolvers/project-resolver.js";
+import { resolveStatusId } from "../resolvers/status-resolver.js";
+import { resolveTeamId } from "../resolvers/team-resolver.js";
+import { resolveUserId } from "../resolvers/user-resolver.js";
+import type { CommandContext } from "./context.js";
+import { invalidParameterError } from "./errors.js";
+import { parseDueDate } from "./identifier.js";
+import {
+  type IssueFilterOptions,
+  parseCommaSeparated,
+  type RawFilterFlags,
+  validateDateRange,
+  validateEstimate,
+  validateFilterDependencies,
+  validatePriority,
+} from "./issue-filter.js";
+
+/**
+ * Resolves raw CLI filter flags into validated IssueFilterOptions with UUIDs.
+ *
+ * Validation order: format → dependency → date ranges → ID resolution.
+ * Fails fast before making any API calls when input is invalid.
+ *
+ * @param ctx - Command context with SDK and GraphQL clients
+ * @param opts - Raw filter flags from CLI options
+ * @returns Resolved filter options with UUIDs ready for buildIssueFilter()
+ */
+export async function resolveFilterOptions(
+  ctx: CommandContext,
+  opts: RawFilterFlags,
+): Promise<IssueFilterOptions> {
+  // 1. Format validation
+  const validateDateOption = (
+    value: string | undefined,
+    flag: string,
+  ): void => {
+    if (!value) {
+      return;
+    }
+
+    try {
+      parseDueDate(value);
+    } catch {
+      throw invalidParameterError(
+        flag,
+        "must be a valid date in YYYY-MM-DD format",
+      );
+    }
+  };
+
+  validateDateOption(opts.dueBefore, "--due-before");
+  validateDateOption(opts.dueAfter, "--due-after");
+  validateDateOption(opts.createdAfter, "--created-after");
+  validateDateOption(opts.createdBefore, "--created-before");
+  validateDateOption(opts.completedAfter, "--completed-after");
+  validateDateOption(opts.completedBefore, "--completed-before");
+  validateDateOption(opts.updatedAfter, "--updated-after");
+  validateDateOption(opts.updatedBefore, "--updated-before");
+
+  const parseIntegerOption = (value: string, flag: string): number => {
+    if (!/^-?\d+$/.test(value)) {
+      throw invalidParameterError(flag, "must be an integer");
+    }
+    return Number.parseInt(value, 10);
+  };
+
+  const parsedStatusNames = opts.status
+    ? parseCommaSeparated(opts.status)
+    : undefined;
+  const parsedLabelNames = opts.label
+    ? parseCommaSeparated(opts.label)
+    : undefined;
+
+  let parsedPriority: number | undefined;
+  if (opts.priority) {
+    parsedPriority = parseIntegerOption(opts.priority, "--priority");
+    validatePriority(parsedPriority);
+  }
+
+  let parsedEstimate: number | undefined;
+  if (opts.estimate) {
+    parsedEstimate = parseIntegerOption(opts.estimate, "--estimate");
+    validateEstimate(parsedEstimate);
+  }
+
+  // 2. Dependency validation
+  validateFilterDependencies(opts);
+
+  // 3. Date range validation
+  validateDateRange(opts.dueAfter, opts.dueBefore, "due date");
+  validateDateRange(opts.createdAfter, opts.createdBefore, "created date");
+  validateDateRange(
+    opts.completedAfter,
+    opts.completedBefore,
+    "completed date",
+  );
+  validateDateRange(opts.updatedAfter, opts.updatedBefore, "updated date");
+
+  // 4. ID resolution
+  const resolved: IssueFilterOptions = {};
+
+  if (opts.team) {
+    resolved.teamId = await resolveTeamId(ctx.sdk, opts.team);
+  }
+  if (opts.assignee) {
+    resolved.assigneeId = await resolveUserId(ctx.sdk, opts.assignee);
+  }
+  if (opts.creator) {
+    resolved.creatorId = await resolveUserId(ctx.sdk, opts.creator);
+  }
+  if (opts.project) {
+    resolved.projectId = await resolveProjectId(ctx.sdk, opts.project);
+  }
+  if (parsedStatusNames) {
+    const statusIds = await Promise.all(
+      parsedStatusNames.map((s) =>
+        resolveStatusId(ctx.sdk, s, resolved.teamId),
+      ),
+    );
+    resolved.stateIds = statusIds;
+  }
+  if (parsedLabelNames) {
+    resolved.labelIds = await resolveLabelIds(ctx.sdk, parsedLabelNames);
+  }
+  if (opts.cycle) {
+    resolved.cycleId = await resolveCycleId(
+      ctx.sdk,
+      opts.cycle,
+      resolved.teamId,
+    );
+  }
+  if (opts.parent) {
+    resolved.parentId = await resolveIssueId(ctx.sdk, opts.parent);
+  }
+  if (opts.milestone) {
+    resolved.milestoneId = await resolveMilestoneId(
+      ctx.gql,
+      ctx.sdk,
+      opts.milestone,
+      resolved.projectId,
+    );
+  }
+
+  resolved.priority = parsedPriority;
+  resolved.estimate = parsedEstimate;
+  resolved.dueBefore = opts.dueBefore;
+  resolved.dueAfter = opts.dueAfter;
+  resolved.createdAfter = opts.createdAfter;
+  resolved.createdBefore = opts.createdBefore;
+  resolved.completedAfter = opts.completedAfter;
+  resolved.completedBefore = opts.completedBefore;
+  resolved.updatedAfter = opts.updatedAfter;
+  resolved.updatedBefore = opts.updatedBefore;
+  resolved.hasBlockers = opts.hasBlockers;
+  resolved.isBlocking = opts.isBlocking;
+
+  return resolved;
+}

--- a/src/services/issue-filter.ts
+++ b/src/services/issue-filter.ts
@@ -1,0 +1,78 @@
+import type { IssueFilterOptions } from "../common/issue-filter.js";
+import type { IssueFilter } from "../gql/graphql.js";
+
+export function buildIssueFilter(
+  options: IssueFilterOptions,
+): IssueFilter | undefined {
+  const fragments: IssueFilter[] = [];
+
+  if (options.teamId) {
+    fragments.push({ team: { id: { eq: options.teamId } } });
+  }
+  if (options.assigneeId) {
+    fragments.push({ assignee: { id: { eq: options.assigneeId } } });
+  }
+  if (options.creatorId) {
+    fragments.push({ creator: { id: { eq: options.creatorId } } });
+  }
+  if (options.projectId) {
+    fragments.push({ project: { id: { eq: options.projectId } } });
+  }
+  if (options.stateIds && options.stateIds.length > 0) {
+    fragments.push({ state: { id: { in: options.stateIds } } });
+  }
+  if (options.labelIds && options.labelIds.length > 0) {
+    fragments.push({ labels: { some: { id: { in: options.labelIds } } } });
+  }
+  if (options.cycleId) {
+    fragments.push({ cycle: { id: { eq: options.cycleId } } });
+  }
+  if (options.parentId) {
+    fragments.push({ parent: { id: { eq: options.parentId } } });
+  }
+  if (options.milestoneId) {
+    fragments.push({ projectMilestone: { id: { eq: options.milestoneId } } });
+  }
+  if (options.priority !== undefined) {
+    fragments.push({ priority: { eq: options.priority } });
+  }
+  if (options.estimate !== undefined) {
+    fragments.push({ estimate: { eq: options.estimate } });
+  }
+  if (options.dueAfter) {
+    fragments.push({ dueDate: { gt: options.dueAfter } });
+  }
+  if (options.dueBefore) {
+    fragments.push({ dueDate: { lt: options.dueBefore } });
+  }
+  if (options.createdAfter) {
+    fragments.push({ createdAt: { gt: options.createdAfter } });
+  }
+  if (options.createdBefore) {
+    fragments.push({ createdAt: { lt: options.createdBefore } });
+  }
+  if (options.completedAfter) {
+    fragments.push({ completedAt: { gt: options.completedAfter } });
+  }
+  if (options.completedBefore) {
+    fragments.push({ completedAt: { lt: options.completedBefore } });
+  }
+  if (options.updatedAfter) {
+    fragments.push({ updatedAt: { gt: options.updatedAfter } });
+  }
+  if (options.updatedBefore) {
+    fragments.push({ updatedAt: { lt: options.updatedBefore } });
+  }
+  if (options.hasBlockers !== undefined) {
+    fragments.push({ hasBlockedByRelations: { eq: options.hasBlockers } });
+  }
+  if (options.isBlocking !== undefined) {
+    fragments.push({ hasBlockingRelations: { eq: options.isBlocking } });
+  }
+
+  if (fragments.length === 0) {
+    return undefined;
+  }
+
+  return { and: fragments };
+}

--- a/src/services/issue-service.ts
+++ b/src/services/issue-service.ts
@@ -12,6 +12,8 @@ import type {
 import {
   CreateIssueDocument,
   type CreateIssueMutation,
+  FilteredSearchIssuesDocument,
+  type FilteredSearchIssuesQuery,
   GetIssueByIdDocument,
   GetIssueByIdentifierDocument,
   type GetIssueByIdentifierQuery,
@@ -19,22 +21,53 @@ import {
   GetIssuesDocument,
   type GetIssuesQuery,
   type IssueCreateInput,
+  type IssueFilter,
   type IssueUpdateInput,
+  PaginationOrderBy,
   SearchIssuesDocument,
   type SearchIssuesQuery,
+  type SearchIssuesQueryVariables,
   UpdateIssueDocument,
   type UpdateIssueMutation,
 } from "../gql/graphql.js";
 
+const NON_COMPLETED_ISSUES_FILTER: IssueFilter = {
+  state: { type: { neq: "completed" } },
+};
+
+function buildListIssuesFilter(filter: IssueFilter): IssueFilter {
+  return {
+    and: [NON_COMPLETED_ISSUES_FILTER, filter],
+  };
+}
+
 export async function listIssues(
   client: GraphQLClient,
   options: PaginationOptions = {},
+  filter?: IssueFilter,
 ): Promise<PaginatedResult<Issue>> {
   const { limit = 25, after } = options;
+
+  if (filter) {
+    const result = await client.request<FilteredSearchIssuesQuery>(
+      FilteredSearchIssuesDocument,
+      {
+        first: limit,
+        after,
+        filter: buildListIssuesFilter(filter),
+        orderBy: PaginationOrderBy.UpdatedAt,
+      },
+    );
+    return {
+      nodes: result.issues?.nodes ?? [],
+      pageInfo: result.issues.pageInfo,
+    };
+  }
+
   const result = await client.request<GetIssuesQuery>(GetIssuesDocument, {
     first: limit,
     after,
-    orderBy: "updatedAt",
+    orderBy: PaginationOrderBy.UpdatedAt,
   });
   return {
     nodes: result.issues?.nodes ?? [],
@@ -76,13 +109,19 @@ export async function searchIssues(
   client: GraphQLClient,
   term: string,
   options: PaginationOptions = {},
+  filter?: IssueFilter,
 ): Promise<PaginatedResult<IssueSearchResult>> {
   const { limit = 25, after } = options;
-  const result = await client.request<SearchIssuesQuery>(SearchIssuesDocument, {
+  const variables: SearchIssuesQueryVariables = {
     term,
     first: limit,
     after,
-  });
+    ...(filter && { filter }),
+  };
+  const result = await client.request<SearchIssuesQuery>(
+    SearchIssuesDocument,
+    variables,
+  );
   return {
     nodes: result.searchIssues?.nodes ?? [],
     pageInfo: result.searchIssues.pageInfo,

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -75,6 +75,8 @@ import { setupIssuesCommands } from "../../../src/commands/issues.js";
 import { resolveUserId } from "../../../src/resolvers/user-resolver.js";
 import {
   createIssue,
+  listIssues,
+  searchIssues,
   updateIssue,
 } from "../../../src/services/issue-service.js";
 
@@ -449,6 +451,106 @@ describe("issues update --due-date", () => {
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("Invalid due date"),
     );
+  });
+});
+
+describe("issues list/search filters", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("passes resolved filters to issues list", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "list",
+      "--team",
+      "ENG",
+      "--status",
+      "Todo",
+      "--limit",
+      "10",
+      "--after",
+      "cursor-1",
+    ]);
+
+    expect(listIssues).toHaveBeenCalledWith(
+      expect.anything(),
+      { limit: 10, after: "cursor-1" },
+      {
+        and: [
+          { team: { id: { eq: "resolved-team-uuid" } } },
+          { state: { id: { in: ["resolved-status-uuid"] } } },
+        ],
+      },
+    );
+  });
+
+  it("passes resolved filters to issues search", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "search",
+      "authentication bug",
+      "--team",
+      "ENG",
+      "--status",
+      "Todo",
+      "--limit",
+      "10",
+    ]);
+
+    expect(searchIssues).toHaveBeenCalledWith(
+      expect.anything(),
+      "authentication bug",
+      { limit: 10, after: undefined },
+      {
+        and: [
+          { team: { id: { eq: "resolved-team-uuid" } } },
+          { state: { id: { in: ["resolved-status-uuid"] } } },
+        ],
+      },
+    );
+  });
+
+  it("keeps issues list --query as a deprecated search compatibility path", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "list",
+      "--query",
+      "authentication bug",
+      "--team",
+      "ENG",
+      "--status",
+      "Todo",
+      "--limit",
+      "10",
+      "--after",
+      "cursor-1",
+    ]);
+
+    expect(searchIssues).toHaveBeenCalledWith(
+      expect.anything(),
+      "authentication bug",
+      { limit: 10, after: "cursor-1" },
+      {
+        and: [
+          { team: { id: { eq: "resolved-team-uuid" } } },
+          { state: { id: { in: ["resolved-status-uuid"] } } },
+        ],
+      },
+    );
+    expect(listIssues).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/common/issue-filter.test.ts
+++ b/tests/unit/common/issue-filter.test.ts
@@ -1,0 +1,160 @@
+import { describe, expect, it } from "vitest";
+import {
+  parseCommaSeparated,
+  validateDateRange,
+  validateEstimate,
+  validateFilterDependencies,
+  validatePriority,
+} from "../../../src/common/issue-filter.js";
+
+describe("validatePriority", () => {
+  it("accepts valid priorities 0-4", () => {
+    for (const p of [0, 1, 2, 3, 4]) {
+      expect(() => validatePriority(p)).not.toThrow();
+    }
+  });
+
+  it("rejects priority below 0", () => {
+    expect(() => validatePriority(-1)).toThrow("priority");
+  });
+
+  it("rejects priority above 4", () => {
+    expect(() => validatePriority(5)).toThrow("priority");
+  });
+
+  it("rejects non-integer priority", () => {
+    expect(() => validatePriority(1.5)).toThrow("priority");
+  });
+});
+
+describe("validateEstimate", () => {
+  it("accepts non-negative integers", () => {
+    expect(() => validateEstimate(0)).not.toThrow();
+    expect(() => validateEstimate(8)).not.toThrow();
+  });
+
+  it("rejects negative estimate", () => {
+    expect(() => validateEstimate(-1)).toThrow("estimate");
+  });
+
+  it("rejects non-integer estimate", () => {
+    expect(() => validateEstimate(2.5)).toThrow("estimate");
+  });
+});
+
+describe("validateDateRange", () => {
+  it("accepts valid range where after < before", () => {
+    expect(() =>
+      validateDateRange("2025-01-01", "2025-12-31", "due date"),
+    ).not.toThrow();
+  });
+
+  it("rejects contradictory range where after >= before", () => {
+    expect(() =>
+      validateDateRange("2025-12-31", "2025-01-01", "due date"),
+    ).toThrow("due date");
+  });
+
+  it("does nothing when only one bound is set", () => {
+    expect(() =>
+      validateDateRange("2025-01-01", undefined, "due date"),
+    ).not.toThrow();
+    expect(() =>
+      validateDateRange(undefined, "2025-12-31", "due date"),
+    ).not.toThrow();
+  });
+
+  it("does nothing when neither bound is set", () => {
+    expect(() =>
+      validateDateRange(undefined, undefined, "due date"),
+    ).not.toThrow();
+  });
+});
+
+describe("validateFilterDependencies", () => {
+  it("throws when --status used without --team", () => {
+    expect(() => validateFilterDependencies({ status: "In Progress" })).toThrow(
+      "--team",
+    );
+  });
+
+  it("allows --status with --team", () => {
+    expect(() =>
+      validateFilterDependencies({ status: "In Progress", team: "ENG" }),
+    ).not.toThrow();
+  });
+
+  it("allows --status UUID without --team", () => {
+    expect(() =>
+      validateFilterDependencies({
+        status: "550e8400-e29b-41d4-a716-446655440000",
+      }),
+    ).not.toThrow();
+  });
+
+  it("throws when --cycle used without --team", () => {
+    expect(() => validateFilterDependencies({ cycle: "Sprint 1" })).toThrow(
+      "--team",
+    );
+  });
+
+  it("allows --cycle with --team", () => {
+    expect(() =>
+      validateFilterDependencies({ cycle: "Sprint 1", team: "ENG" }),
+    ).not.toThrow();
+  });
+
+  it("allows --cycle UUID without --team", () => {
+    expect(() =>
+      validateFilterDependencies({
+        cycle: "550e8400-e29b-41d4-a716-446655440001",
+      }),
+    ).not.toThrow();
+  });
+
+  it("throws when --milestone used without --project", () => {
+    expect(() => validateFilterDependencies({ milestone: "v1.0" })).toThrow(
+      "--project",
+    );
+  });
+
+  it("allows --milestone with --project", () => {
+    expect(() =>
+      validateFilterDependencies({ milestone: "v1.0", project: "MyProject" }),
+    ).not.toThrow();
+  });
+
+  it("allows --milestone UUID without --project", () => {
+    expect(() =>
+      validateFilterDependencies({
+        milestone: "550e8400-e29b-41d4-a716-446655440002",
+      }),
+    ).not.toThrow();
+  });
+
+  it("does nothing with no dependency flags", () => {
+    expect(() => validateFilterDependencies({ team: "ENG" })).not.toThrow();
+  });
+});
+
+describe("parseCommaSeparated", () => {
+  it("splits comma-separated values and trims whitespace", () => {
+    expect(parseCommaSeparated("a, b , c")).toEqual(["a", "b", "c"]);
+  });
+
+  it("returns single value as array", () => {
+    expect(parseCommaSeparated("done")).toEqual(["done"]);
+  });
+
+  it("throws on empty segments", () => {
+    expect(() => parseCommaSeparated("a,,b")).toThrow("empty");
+  });
+
+  it("throws on empty string", () => {
+    expect(() => parseCommaSeparated("")).toThrow("empty");
+  });
+
+  it("throws on only whitespace segment", () => {
+    expect(() => parseCommaSeparated("a, ,b")).toThrow("empty");
+  });
+});

--- a/tests/unit/common/resolve-filters.test.ts
+++ b/tests/unit/common/resolve-filters.test.ts
@@ -1,0 +1,393 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import type { LinearSdkClient } from "../../../src/client/linear-client.js";
+import type { CommandContext } from "../../../src/common/context.js";
+import { resolveFilterOptions } from "../../../src/common/resolve-filters.js";
+
+vi.mock("../../../src/resolvers/team-resolver.js", () => ({
+  resolveTeamId: vi.fn().mockResolvedValue("team-uuid"),
+}));
+vi.mock("../../../src/resolvers/user-resolver.js", () => ({
+  resolveUserId: vi.fn().mockResolvedValue("user-uuid"),
+}));
+vi.mock("../../../src/resolvers/project-resolver.js", () => ({
+  resolveProjectId: vi.fn().mockResolvedValue("project-uuid"),
+}));
+vi.mock("../../../src/resolvers/status-resolver.js", () => ({
+  resolveStatusId: vi.fn().mockResolvedValue("status-uuid"),
+}));
+vi.mock("../../../src/resolvers/label-resolver.js", () => ({
+  resolveLabelIds: vi.fn().mockResolvedValue(["label-uuid-1", "label-uuid-2"]),
+}));
+vi.mock("../../../src/resolvers/cycle-resolver.js", () => ({
+  resolveCycleId: vi.fn().mockResolvedValue("cycle-uuid"),
+}));
+vi.mock("../../../src/resolvers/issue-resolver.js", () => ({
+  resolveIssueId: vi.fn().mockResolvedValue("issue-uuid"),
+}));
+vi.mock("../../../src/resolvers/milestone-resolver.js", () => ({
+  resolveMilestoneId: vi.fn().mockResolvedValue("milestone-uuid"),
+}));
+
+function mockContext(): CommandContext {
+  return {
+    gql: {} as unknown as GraphQLClient,
+    sdk: {} as unknown as LinearSdkClient,
+  };
+}
+
+describe("resolveFilterOptions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns empty options when no flags provided", async () => {
+    const ctx = mockContext();
+    const result = await resolveFilterOptions(ctx, {});
+    expect(result).toEqual({
+      priority: undefined,
+      estimate: undefined,
+      dueBefore: undefined,
+      dueAfter: undefined,
+      createdAfter: undefined,
+      createdBefore: undefined,
+      completedAfter: undefined,
+      completedBefore: undefined,
+      updatedAfter: undefined,
+      updatedBefore: undefined,
+      hasBlockers: undefined,
+      isBlocking: undefined,
+    });
+  });
+
+  it("resolves team ID via resolver", async () => {
+    const { resolveTeamId } = await import(
+      "../../../src/resolvers/team-resolver.js"
+    );
+    const ctx = mockContext();
+    const result = await resolveFilterOptions(ctx, { team: "ENG" });
+    expect(resolveTeamId).toHaveBeenCalledWith(ctx.sdk, "ENG");
+    expect(result.teamId).toBe("team-uuid");
+  });
+
+  it("resolves assignee ID via resolver", async () => {
+    const { resolveUserId } = await import(
+      "../../../src/resolvers/user-resolver.js"
+    );
+    const ctx = mockContext();
+    const result = await resolveFilterOptions(ctx, { assignee: "alice" });
+    expect(resolveUserId).toHaveBeenCalledWith(ctx.sdk, "alice");
+    expect(result.assigneeId).toBe("user-uuid");
+  });
+
+  it("resolves creator ID via resolver", async () => {
+    const { resolveUserId } = await import(
+      "../../../src/resolvers/user-resolver.js"
+    );
+    const ctx = mockContext();
+    const result = await resolveFilterOptions(ctx, { creator: "bob" });
+    expect(resolveUserId).toHaveBeenCalledWith(ctx.sdk, "bob");
+    expect(result.creatorId).toBe("user-uuid");
+  });
+
+  it("resolves project ID via resolver", async () => {
+    const { resolveProjectId } = await import(
+      "../../../src/resolvers/project-resolver.js"
+    );
+    const ctx = mockContext();
+    const result = await resolveFilterOptions(ctx, { project: "Backend" });
+    expect(resolveProjectId).toHaveBeenCalledWith(ctx.sdk, "Backend");
+    expect(result.projectId).toBe("project-uuid");
+  });
+
+  it("resolves comma-separated status IDs with team dependency", async () => {
+    const { resolveStatusId } = await import(
+      "../../../src/resolvers/status-resolver.js"
+    );
+    const ctx = mockContext();
+    const result = await resolveFilterOptions(ctx, {
+      team: "ENG",
+      status: "Todo,In Progress",
+    });
+    expect(resolveStatusId).toHaveBeenCalledWith(ctx.sdk, "Todo", "team-uuid");
+    expect(resolveStatusId).toHaveBeenCalledWith(
+      ctx.sdk,
+      "In Progress",
+      "team-uuid",
+    );
+    expect(result.stateIds).toEqual(["status-uuid", "status-uuid"]);
+  });
+
+  it("resolves comma-separated label IDs", async () => {
+    const { resolveLabelIds } = await import(
+      "../../../src/resolvers/label-resolver.js"
+    );
+    const ctx = mockContext();
+    const result = await resolveFilterOptions(ctx, { label: "Bug,Critical" });
+    expect(resolveLabelIds).toHaveBeenCalledWith(ctx.sdk, ["Bug", "Critical"]);
+    expect(result.labelIds).toEqual(["label-uuid-1", "label-uuid-2"]);
+  });
+
+  it("resolves cycle ID with resolved team ID", async () => {
+    const { resolveCycleId } = await import(
+      "../../../src/resolvers/cycle-resolver.js"
+    );
+    const ctx = mockContext();
+    const result = await resolveFilterOptions(ctx, {
+      team: "ENG",
+      cycle: "Sprint 1",
+    });
+    expect(resolveCycleId).toHaveBeenCalledWith(
+      ctx.sdk,
+      "Sprint 1",
+      "team-uuid",
+    );
+    expect(result.cycleId).toBe("cycle-uuid");
+  });
+
+  it("resolves parent issue ID", async () => {
+    const { resolveIssueId } = await import(
+      "../../../src/resolvers/issue-resolver.js"
+    );
+    const ctx = mockContext();
+    const result = await resolveFilterOptions(ctx, { parent: "ENG-123" });
+    expect(resolveIssueId).toHaveBeenCalledWith(ctx.sdk, "ENG-123");
+    expect(result.parentId).toBe("issue-uuid");
+  });
+
+  it("resolves milestone ID with resolved project ID", async () => {
+    const { resolveMilestoneId } = await import(
+      "../../../src/resolvers/milestone-resolver.js"
+    );
+    const ctx = mockContext();
+    const result = await resolveFilterOptions(ctx, {
+      project: "Backend",
+      milestone: "v1.0",
+    });
+    expect(resolveMilestoneId).toHaveBeenCalledWith(
+      ctx.gql,
+      ctx.sdk,
+      "v1.0",
+      "project-uuid",
+    );
+    expect(result.milestoneId).toBe("milestone-uuid");
+  });
+
+  it("parses priority string to number", async () => {
+    const ctx = mockContext();
+    const result = await resolveFilterOptions(ctx, { priority: "2" });
+    expect(result.priority).toBe(2);
+  });
+
+  it("parses estimate string to number", async () => {
+    const ctx = mockContext();
+    const result = await resolveFilterOptions(ctx, { estimate: "5" });
+    expect(result.estimate).toBe(5);
+  });
+
+  it("passes through date values unchanged", async () => {
+    const ctx = mockContext();
+    const result = await resolveFilterOptions(ctx, {
+      dueBefore: "2025-12-31",
+      dueAfter: "2025-01-01",
+      createdAfter: "2025-02-01",
+      createdBefore: "2025-11-01",
+    });
+    expect(result.dueBefore).toBe("2025-12-31");
+    expect(result.dueAfter).toBe("2025-01-01");
+    expect(result.createdAfter).toBe("2025-02-01");
+    expect(result.createdBefore).toBe("2025-11-01");
+  });
+
+  it("passes through boolean flags", async () => {
+    const ctx = mockContext();
+    const result = await resolveFilterOptions(ctx, {
+      hasBlockers: true,
+      isBlocking: true,
+    });
+    expect(result.hasBlockers).toBe(true);
+    expect(result.isBlocking).toBe(true);
+  });
+
+  // Validation error cases
+  it("throws on invalid priority string", async () => {
+    const ctx = mockContext();
+    await expect(
+      resolveFilterOptions(ctx, { priority: "abc" }),
+    ).rejects.toThrow("--priority");
+  });
+
+  it("throws on decimal priority", async () => {
+    const ctx = mockContext();
+    await expect(
+      resolveFilterOptions(ctx, { priority: "1.5" }),
+    ).rejects.toThrow("--priority");
+  });
+
+  it("throws on out-of-range priority", async () => {
+    const ctx = mockContext();
+    await expect(resolveFilterOptions(ctx, { priority: "5" })).rejects.toThrow(
+      "priority",
+    );
+  });
+
+  it("throws on invalid estimate string", async () => {
+    const ctx = mockContext();
+    await expect(
+      resolveFilterOptions(ctx, { estimate: "abc" }),
+    ).rejects.toThrow("--estimate");
+  });
+
+  it("throws on partially numeric estimate", async () => {
+    const ctx = mockContext();
+    await expect(
+      resolveFilterOptions(ctx, { estimate: "2abc" }),
+    ).rejects.toThrow("--estimate");
+  });
+
+  it("throws on negative estimate", async () => {
+    const ctx = mockContext();
+    await expect(resolveFilterOptions(ctx, { estimate: "-1" })).rejects.toThrow(
+      "estimate",
+    );
+  });
+
+  it("throws when --status used without --team", async () => {
+    const ctx = mockContext();
+    await expect(
+      resolveFilterOptions(ctx, { status: "In Progress" }),
+    ).rejects.toThrow("--team");
+  });
+
+  it("allows status UUID without --team", async () => {
+    const { resolveTeamId } = await import(
+      "../../../src/resolvers/team-resolver.js"
+    );
+    const { resolveStatusId } = await import(
+      "../../../src/resolvers/status-resolver.js"
+    );
+    const ctx = mockContext();
+    const result = await resolveFilterOptions(ctx, {
+      status: "550e8400-e29b-41d4-a716-446655440000",
+    });
+    expect(resolveTeamId).not.toHaveBeenCalled();
+    expect(resolveStatusId).toHaveBeenCalledWith(
+      ctx.sdk,
+      "550e8400-e29b-41d4-a716-446655440000",
+      undefined,
+    );
+    expect(result.stateIds).toEqual(["status-uuid"]);
+  });
+
+  it("throws on malformed status list before making resolver calls", async () => {
+    const { resolveTeamId } = await import(
+      "../../../src/resolvers/team-resolver.js"
+    );
+    const { resolveStatusId } = await import(
+      "../../../src/resolvers/status-resolver.js"
+    );
+    const ctx = mockContext();
+    await expect(
+      resolveFilterOptions(ctx, { team: "ENG", status: "Todo,,Done" }),
+    ).rejects.toThrow("empty");
+    expect(resolveTeamId).not.toHaveBeenCalled();
+    expect(resolveStatusId).not.toHaveBeenCalled();
+  });
+
+  it("throws on malformed label list before making resolver calls", async () => {
+    const { resolveLabelIds } = await import(
+      "../../../src/resolvers/label-resolver.js"
+    );
+    const ctx = mockContext();
+    await expect(
+      resolveFilterOptions(ctx, { label: "bug, ,ux" }),
+    ).rejects.toThrow("empty");
+    expect(resolveLabelIds).not.toHaveBeenCalled();
+  });
+
+  it("throws when --cycle used without --team", async () => {
+    const ctx = mockContext();
+    await expect(
+      resolveFilterOptions(ctx, { cycle: "Sprint 1" }),
+    ).rejects.toThrow("--team");
+  });
+
+  it("allows cycle UUID without --team", async () => {
+    const { resolveTeamId } = await import(
+      "../../../src/resolvers/team-resolver.js"
+    );
+    const { resolveCycleId } = await import(
+      "../../../src/resolvers/cycle-resolver.js"
+    );
+    const ctx = mockContext();
+    const result = await resolveFilterOptions(ctx, {
+      cycle: "550e8400-e29b-41d4-a716-446655440001",
+    });
+    expect(resolveTeamId).not.toHaveBeenCalled();
+    expect(resolveCycleId).toHaveBeenCalledWith(
+      ctx.sdk,
+      "550e8400-e29b-41d4-a716-446655440001",
+      undefined,
+    );
+    expect(result.cycleId).toBe("cycle-uuid");
+  });
+
+  it("throws when --milestone used without --project", async () => {
+    const ctx = mockContext();
+    await expect(
+      resolveFilterOptions(ctx, { milestone: "v1.0" }),
+    ).rejects.toThrow("--project");
+  });
+
+  it("allows milestone UUID without --project", async () => {
+    const { resolveProjectId } = await import(
+      "../../../src/resolvers/project-resolver.js"
+    );
+    const { resolveMilestoneId } = await import(
+      "../../../src/resolvers/milestone-resolver.js"
+    );
+    const ctx = mockContext();
+    const result = await resolveFilterOptions(ctx, {
+      milestone: "550e8400-e29b-41d4-a716-446655440002",
+    });
+    expect(resolveProjectId).not.toHaveBeenCalled();
+    expect(resolveMilestoneId).toHaveBeenCalledWith(
+      ctx.gql,
+      ctx.sdk,
+      "550e8400-e29b-41d4-a716-446655440002",
+      undefined,
+    );
+    expect(result.milestoneId).toBe("milestone-uuid");
+  });
+
+  it("throws on contradictory date range", async () => {
+    const ctx = mockContext();
+    await expect(
+      resolveFilterOptions(ctx, {
+        dueAfter: "2025-12-31",
+        dueBefore: "2025-01-01",
+      }),
+    ).rejects.toThrow("due date");
+  });
+
+  it("throws on invalid due date format with flag-specific message", async () => {
+    const ctx = mockContext();
+    await expect(
+      resolveFilterOptions(ctx, { dueBefore: "not-a-date" }),
+    ).rejects.toThrow("--due-before");
+  });
+
+  it("throws on invalid created date format with flag-specific message", async () => {
+    const ctx = mockContext();
+    await expect(
+      resolveFilterOptions(ctx, { createdBefore: "not-a-date" }),
+    ).rejects.toThrow("--created-before");
+  });
+
+  it("throws on impossible completed date with flag-specific message", async () => {
+    const ctx = mockContext();
+    await expect(
+      resolveFilterOptions(ctx, { completedAfter: "2025-02-30" }),
+    ).rejects.toThrow("--completed-after");
+  });
+});

--- a/tests/unit/services/issue-filter.test.ts
+++ b/tests/unit/services/issue-filter.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from "vitest";
+import { buildIssueFilter } from "../../../src/services/issue-filter.js";
+
+describe("buildIssueFilter", () => {
+  it("returns undefined when no options provided", () => {
+    expect(buildIssueFilter({})).toBeUndefined();
+  });
+
+  it("builds team filter", () => {
+    const result = buildIssueFilter({ teamId: "team-uuid" });
+    expect(result).toEqual({
+      and: [{ team: { id: { eq: "team-uuid" } } }],
+    });
+  });
+
+  it("builds assignee filter", () => {
+    const result = buildIssueFilter({ assigneeId: "user-uuid" });
+    expect(result).toEqual({
+      and: [{ assignee: { id: { eq: "user-uuid" } } }],
+    });
+  });
+
+  it("builds creator filter", () => {
+    const result = buildIssueFilter({ creatorId: "user-uuid" });
+    expect(result).toEqual({
+      and: [{ creator: { id: { eq: "user-uuid" } } }],
+    });
+  });
+
+  it("builds project filter", () => {
+    const result = buildIssueFilter({ projectId: "proj-uuid" });
+    expect(result).toEqual({
+      and: [{ project: { id: { eq: "proj-uuid" } } }],
+    });
+  });
+
+  it("builds state filter with multiple IDs", () => {
+    const result = buildIssueFilter({ stateIds: ["s1", "s2"] });
+    expect(result).toEqual({
+      and: [{ state: { id: { in: ["s1", "s2"] } } }],
+    });
+  });
+
+  it("builds label filter with multiple IDs", () => {
+    const result = buildIssueFilter({ labelIds: ["l1", "l2"] });
+    expect(result).toEqual({
+      and: [{ labels: { some: { id: { in: ["l1", "l2"] } } } }],
+    });
+  });
+
+  it("builds cycle filter", () => {
+    const result = buildIssueFilter({ cycleId: "cycle-uuid" });
+    expect(result).toEqual({
+      and: [{ cycle: { id: { eq: "cycle-uuid" } } }],
+    });
+  });
+
+  it("builds parent filter", () => {
+    const result = buildIssueFilter({ parentId: "parent-uuid" });
+    expect(result).toEqual({
+      and: [{ parent: { id: { eq: "parent-uuid" } } }],
+    });
+  });
+
+  it("builds milestone filter", () => {
+    const result = buildIssueFilter({ milestoneId: "ms-uuid" });
+    expect(result).toEqual({
+      and: [{ projectMilestone: { id: { eq: "ms-uuid" } } }],
+    });
+  });
+
+  it("builds priority filter", () => {
+    const result = buildIssueFilter({ priority: 2 });
+    expect(result).toEqual({
+      and: [{ priority: { eq: 2 } }],
+    });
+  });
+
+  it("builds estimate filter", () => {
+    const result = buildIssueFilter({ estimate: 5 });
+    expect(result).toEqual({
+      and: [{ estimate: { eq: 5 } }],
+    });
+  });
+
+  it("builds due date before filter", () => {
+    const result = buildIssueFilter({ dueBefore: "2025-12-31" });
+    expect(result).toEqual({
+      and: [{ dueDate: { lt: "2025-12-31" } }],
+    });
+  });
+
+  it("builds due date after filter", () => {
+    const result = buildIssueFilter({ dueAfter: "2025-01-01" });
+    expect(result).toEqual({
+      and: [{ dueDate: { gt: "2025-01-01" } }],
+    });
+  });
+
+  it("builds combined due date range filter", () => {
+    const result = buildIssueFilter({
+      dueAfter: "2025-01-01",
+      dueBefore: "2025-12-31",
+    });
+    expect(result).toEqual({
+      and: [
+        { dueDate: { gt: "2025-01-01" } },
+        { dueDate: { lt: "2025-12-31" } },
+      ],
+    });
+  });
+
+  it("builds created date filters", () => {
+    const result = buildIssueFilter({ createdAfter: "2025-01-01" });
+    expect(result).toEqual({
+      and: [{ createdAt: { gt: "2025-01-01" } }],
+    });
+  });
+
+  it("builds completed date filters", () => {
+    const result = buildIssueFilter({ completedBefore: "2025-06-01" });
+    expect(result).toEqual({
+      and: [{ completedAt: { lt: "2025-06-01" } }],
+    });
+  });
+
+  it("builds updated date filters", () => {
+    const result = buildIssueFilter({ updatedAfter: "2025-03-01" });
+    expect(result).toEqual({
+      and: [{ updatedAt: { gt: "2025-03-01" } }],
+    });
+  });
+
+  it("builds has-blockers filter", () => {
+    const result = buildIssueFilter({ hasBlockers: true });
+    expect(result).toEqual({
+      and: [{ hasBlockedByRelations: { eq: true } }],
+    });
+  });
+
+  it("builds is-blocking filter", () => {
+    const result = buildIssueFilter({ isBlocking: true });
+    expect(result).toEqual({
+      and: [{ hasBlockingRelations: { eq: true } }],
+    });
+  });
+
+  it("builds has-blockers false filter", () => {
+    const result = buildIssueFilter({ hasBlockers: false });
+    expect(result).toEqual({
+      and: [{ hasBlockedByRelations: { eq: false } }],
+    });
+  });
+
+  it("builds is-blocking false filter", () => {
+    const result = buildIssueFilter({ isBlocking: false });
+    expect(result).toEqual({
+      and: [{ hasBlockingRelations: { eq: false } }],
+    });
+  });
+
+  it("ignores empty stateIds array", () => {
+    const result = buildIssueFilter({ stateIds: [] });
+    expect(result).toBeUndefined();
+  });
+
+  it("ignores empty labelIds array", () => {
+    const result = buildIssueFilter({ labelIds: [] });
+    expect(result).toBeUndefined();
+  });
+
+  it("combines multiple filters with and", () => {
+    const result = buildIssueFilter({
+      teamId: "team-uuid",
+      priority: 1,
+      hasBlockers: true,
+    });
+    expect(result).toEqual({
+      and: [
+        { team: { id: { eq: "team-uuid" } } },
+        { priority: { eq: 1 } },
+        { hasBlockedByRelations: { eq: true } },
+      ],
+    });
+  });
+});

--- a/tests/unit/services/issue-service.test.ts
+++ b/tests/unit/services/issue-service.test.ts
@@ -1,6 +1,11 @@
-// tests/unit/services/issue-service.test.ts
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import {
+  FilteredSearchIssuesDocument,
+  GetIssuesDocument,
+  PaginationOrderBy,
+  SearchIssuesDocument,
+} from "../../../src/gql/graphql.js";
 import {
   createIssue,
   getIssue,
@@ -56,7 +61,7 @@ describe("listIssues", () => {
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       first: 25,
       after: undefined,
-      orderBy: "updatedAt",
+      orderBy: PaginationOrderBy.UpdatedAt,
     });
   });
 
@@ -71,7 +76,7 @@ describe("listIssues", () => {
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       first: 5,
       after: "cursor1",
-      orderBy: "updatedAt",
+      orderBy: PaginationOrderBy.UpdatedAt,
     });
   });
 
@@ -86,6 +91,44 @@ describe("listIssues", () => {
     expect(result.pageInfo).toEqual({
       hasNextPage: true,
       endCursor: "nextCursor",
+    });
+  });
+
+  it("passes filter to FilteredSearchIssues when filter provided", async () => {
+    const client = mockGqlClient({
+      issues: {
+        nodes: [{ id: "1", title: "Filtered" }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+    const filter = { team: { id: { eq: "team-uuid" } } };
+    const result = await listIssues(client, { limit: 10 }, filter);
+    expect(result.nodes).toHaveLength(1);
+    expect(client.request).toHaveBeenCalledWith(FilteredSearchIssuesDocument, {
+      first: 10,
+      after: undefined,
+      filter: {
+        and: [
+          { state: { type: { neq: "completed" } } },
+          { team: { id: { eq: "team-uuid" } } },
+        ],
+      },
+      orderBy: PaginationOrderBy.UpdatedAt,
+    });
+  });
+
+  it("uses GetIssues query when no filter provided (no regression)", async () => {
+    const client = mockGqlClient({
+      issues: {
+        nodes: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+    await listIssues(client);
+    expect(client.request).toHaveBeenCalledWith(GetIssuesDocument, {
+      first: 25,
+      after: undefined,
+      orderBy: PaginationOrderBy.UpdatedAt,
     });
   });
 });
@@ -231,6 +274,39 @@ describe("searchIssues", () => {
       term: "query",
       first: 5,
       after: "prevCursor",
+    });
+  });
+
+  it("passes filter to SearchIssues query when filter provided", async () => {
+    const client = mockGqlClient({
+      searchIssues: {
+        nodes: [{ id: "1", title: "Match" }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+    const filter = { priority: { eq: 1 } };
+    const result = await searchIssues(client, "bug", { limit: 10 }, filter);
+    expect(result.nodes).toHaveLength(1);
+    expect(client.request).toHaveBeenCalledWith(SearchIssuesDocument, {
+      term: "bug",
+      first: 10,
+      after: undefined,
+      filter,
+    });
+  });
+
+  it("omits filter when not provided (no regression)", async () => {
+    const client = mockGqlClient({
+      searchIssues: {
+        nodes: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+    await searchIssues(client, "test");
+    expect(client.request).toHaveBeenCalledWith(SearchIssuesDocument, {
+      term: "test",
+      first: 25,
+      after: undefined,
     });
   });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes the v2026.4.x regression reported in #121 by restoring the documented filter flags on `issues list` and bringing back `issues search <query>` as the explicit full-text search entry point.

Both commands now share the same filter parsing, validation, and ID-resolution path, so human-friendly filter values are resolved before the service layer and invalid combinations fail before any API call. `issues list --query <query>` stays available as a deprecated compatibility path for one release window while callers migrate to `issues search <query>`.

Closes #121

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Verified in this branch with:

```bash
npm run check:ci
npx tsc --noEmit
npm test
```

`npm test` currently passes with 36 test files / 362 tests.

Manual verification against a real Linear workspace:

```bash
npm run build

node dist/main.js issues list --team ENG --status "Todo,In Progress" -l 5
node dist/main.js issues list --assignee me --priority 1 -l 5
node dist/main.js issues search "authentication bug" --team ENG --label "Bug" -l 5
node dist/main.js issues list --query "authentication bug" --team ENG -l 5
```

Validation should fail before any API call for bad flag combinations or malformed values, for example:

```bash
node dist/main.js issues list --status "Todo"
node dist/main.js issues list --priority 9
node dist/main.js issues list --due-after 2026-12-31 --due-before 2026-01-01
```

## Notes for reviewers

- `src/common/resolve-filters.ts` centralizes filter parsing, dependency checks, date validation, and resolver calls so commands stay thin and services continue to accept UUIDs only.
- Filtered `issues list` uses `FilteredSearchIssuesDocument` because the existing `GetIssuesDocument` does not accept a caller-provided `IssueFilter`. The service still wraps filtered list queries with the existing non-completed constraint, so `list` keeps its current "active issues" semantics.
- `issues list --query` is intentionally still wired to `searchIssues` as a deprecated compatibility path. Docs and help text now point users to `issues search <query>`.
- This PR does **not** change the paginated `{ nodes, pageInfo }` response shape introduced in v2026.4.x. Scope here is restoring the missing filtering/search CLI surface from #121.
