### PR TITLE
fix(auth): discriminate empty catch blocks; warn on decryption failure

### DIFF
--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -211,6 +211,7 @@ export function setupAuthCommands(program: Command): void {
           token = resolved.token;
           source = resolved.source;
         } catch {
+          // resolveApiToken throws when no token found — report unauthenticated
           outputSuccess({
             authenticated: false,
             message:
@@ -227,6 +228,7 @@ export function setupAuthCommands(program: Command): void {
             user: { id: viewer.id, name: viewer.name, email: viewer.email },
           });
         } catch {
+          // Token is invalid or expired — report unauthenticated with source
           outputSuccess({
             authenticated: false,
             source: SOURCE_LABELS[source],
@@ -255,6 +257,7 @@ export function setupAuthCommands(program: Command): void {
             warning: `A token is still active via ${SOURCE_LABELS[source]}.`,
           });
         } catch {
+          // No token remaining after logout — nothing to warn about
           outputSuccess({ message: "Authentication token removed." });
         }
       }),

--- a/src/commands/documents.ts
+++ b/src/commands/documents.ts
@@ -66,6 +66,7 @@ export function extractDocumentIdFromUrl(url: string): string | null {
 
     return docSlug.substring(lastHyphenIndex + 1) || null;
   } catch {
+    // URL constructor throws on malformed input — treat as unresolvable
     return null;
   }
 }

--- a/src/common/embed-parser.ts
+++ b/src/common/embed-parser.ts
@@ -60,6 +60,7 @@ export function isLinearUploadUrl(url: string): boolean {
     const urlObj = new URL(url);
     return urlObj.hostname === "uploads.linear.app";
   } catch {
+    // URL constructor throws on malformed input — not a Linear upload URL
     return false;
   }
 }
@@ -69,6 +70,7 @@ export function extractFilenameFromUrl(url: string): string {
     const parts = new URL(url).pathname.split("/");
     return parts[parts.length - 1] || "download";
   } catch {
+    // URL constructor throws on malformed input — fall back to generic filename
     return "download";
   }
 }

--- a/src/common/identifier.ts
+++ b/src/common/identifier.ts
@@ -36,6 +36,7 @@ export function tryParseIssueIdentifier(
   try {
     return parseIssueIdentifier(identifier);
   } catch {
+    // parseIssueIdentifier throws on invalid format — return null per try-parse contract
     return null;
   }
 }

--- a/src/common/token-storage.ts
+++ b/src/common/token-storage.ts
@@ -57,7 +57,19 @@ export function getStoredToken(): string | null {
         try {
           const encrypted = fs.readFileSync(legacy, "utf8").trim();
           return decryptToken(encrypted);
-        } catch {
+        } catch (err) {
+          // File disappeared between existsSync and readFileSync — treat as absent
+          if (
+            err instanceof Error &&
+            (err as NodeJS.ErrnoException).code === "ENOENT"
+          ) {
+            return null;
+          }
+          // Decryption failure, corrupt content, or permission error — warn and degrade
+          console.error(
+            "Warning: stored token could not be decrypted and will be ignored. " +
+              "Run 'linearis auth login' to reauthenticate.",
+          );
           return null;
         }
       }
@@ -67,7 +79,19 @@ export function getStoredToken(): string | null {
   try {
     const encrypted = fs.readFileSync(tokenPath, "utf8").trim();
     return decryptToken(encrypted);
-  } catch {
+  } catch (err) {
+    // File disappeared between existsSync and readFileSync — treat as absent
+    if (
+      err instanceof Error &&
+      (err as NodeJS.ErrnoException).code === "ENOENT"
+    ) {
+      return null;
+    }
+    // Decryption failure, corrupt content, or permission error — warn and degrade
+    console.error(
+      "Warning: stored token could not be decrypted and will be ignored. " +
+        "Run 'linearis auth login' to reauthenticate.",
+    );
     return null;
   }
 }

--- a/src/services/file-service.ts
+++ b/src/services/file-service.ts
@@ -267,6 +267,7 @@ export class FileService {
     try {
       await access(filePath);
     } catch {
+      // access() throws ENOENT when file does not exist
       return {
         success: false,
         error: `File not found: ${filePath}`,

--- a/tests/unit/common/token-storage.test.ts
+++ b/tests/unit/common/token-storage.test.ts
@@ -165,15 +165,59 @@ describe("getStoredToken", () => {
     expect(getStoredToken()).toBeNull();
   });
 
-  it("returns null when token file is corrupted", () => {
+  it("logs a warning to stderr when stored token cannot be decrypted", () => {
     setPlatform("darwin");
     vi.mocked(fs.existsSync).mockReturnValue(true);
     vi.mocked(fs.readFileSync).mockReturnValue("corrupted-data");
     vi.mocked(decryptToken).mockImplementationOnce(() => {
       throw new Error("Invalid encrypted token format");
     });
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
-    expect(getStoredToken()).toBeNull();
+    const result = getStoredToken();
+
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("could not be decrypted"),
+    );
+    consoleSpy.mockRestore();
+  });
+
+  it("returns null silently when file disappears between exists check and read", () => {
+    setPlatform("darwin");
+    vi.mocked(fs.existsSync).mockReturnValue(true);
+    const enoent = new Error("ENOENT") as NodeJS.ErrnoException;
+    enoent.code = "ENOENT";
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw enoent;
+    });
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = getStoredToken();
+
+    expect(result).toBeNull();
+    expect(consoleSpy).not.toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+
+  it("logs a warning when legacy token on Linux is corrupted", () => {
+    setPlatform("linux");
+    vi.mocked(fs.existsSync)
+      .mockReturnValueOnce(false) // XDG path
+      .mockReturnValueOnce(true); // legacy path
+    vi.mocked(fs.readFileSync).mockReturnValue("corrupted-data");
+    vi.mocked(decryptToken).mockImplementationOnce(() => {
+      throw new Error("Invalid encrypted token format");
+    });
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const result = getStoredToken();
+
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalledWith(
+      expect.stringContaining("could not be decrypted"),
+    );
+    consoleSpy.mockRestore();
   });
 
   it("falls back to legacy path on Linux", () => {


### PR DESCRIPTION
## Summary

Closes #60

12 catch blocks across the codebase used `catch {}` without capturing the error or documenting intent. The critical case: `token-storage.ts` silently swallowed decryption failures, making corrupted tokens indistinguishable from missing tokens.

## Changes

### Behavioral fix — `src/common/token-storage.ts`

Both catch blocks now discriminate by error type:
- **ENOENT** (file disappeared between `existsSync` and `readFileSync`): return `null` silently — expected race, not a fault.
- **Anything else** (decryption failure, corrupt content, permission error): print a warning to `stderr` and return `null`, so users know to reauthenticate rather than debugging a silent failure.

Callers are unchanged — they already handle `null`.

### Comment additions

Remaining empty catch blocks annotated with explanatory comments documenting what throws and why the error is intentionally discarded:

| File | Blocks |
|---|---|
| `src/commands/auth.ts` | 3 |
| `src/services/file-service.ts` | 1 |
| `src/commands/documents.ts` | 1 |
| `src/common/embed-parser.ts` | 2 |
| `src/common/identifier.ts` | 1 |

## Tests

- Updated: existing corrupt-token test now asserts `console.error` is called with "could not be decrypted"
- Added: ENOENT race condition — `console.error` must **not** be called
- Added: Linux legacy path corruption — same warning assertion