### PR TITLE
feat(issues): batch resolve issue refs

### DIFF
--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -16,12 +16,12 @@ import {
   type IssueUpdateInput,
 } from "../gql/graphql.js";
 import { resolveCycleId } from "../resolvers/cycle-resolver.js";
+import {
+  resolveIssueCreateRefs,
+  resolveIssueUpdateRefs,
+} from "../resolvers/issue-batch-resolver.js";
 import { resolveIssueId } from "../resolvers/issue-resolver.js";
-import { resolveLabelIds } from "../resolvers/label-resolver.js";
-import { resolveMilestoneId } from "../resolvers/milestone-resolver.js";
-import { resolveProjectId } from "../resolvers/project-resolver.js";
 import { resolveStatusId } from "../resolvers/status-resolver.js";
-import { resolveTeamId } from "../resolvers/team-resolver.js";
 import { resolveUserId } from "../resolvers/user-resolver.js";
 import { buildIssueFilter } from "../services/issue-filter.js";
 import {
@@ -346,11 +346,19 @@ export function setupIssuesCommands(program: Command): void {
         if (!options.team) {
           throw new Error("--team is required");
         }
-        const teamId = await resolveTeamId(ctx.sdk, options.team);
+
+        const labelNames = options.labels?.split(",").map((l) => l.trim());
+        const resolvedRefs = await resolveIssueCreateRefs(ctx.gql, {
+          team: options.team,
+          project: options.project,
+          labels: labelNames,
+          parentTicket: options.parentTicket,
+          projectMilestone: options.projectMilestone,
+        });
 
         const input: IssueCreateInput = {
           title,
-          teamId,
+          teamId: resolvedRefs.teamId,
         };
 
         if (options.description) {
@@ -369,27 +377,16 @@ export function setupIssuesCommands(program: Command): void {
           input.estimate = parseInt(options.estimate, 10);
         }
 
-        if (options.project) {
-          input.projectId = await resolveProjectId(ctx.sdk, options.project);
+        if (resolvedRefs.projectId) {
+          input.projectId = resolvedRefs.projectId;
         }
 
-        if (options.labels) {
-          const labelNames = options.labels.split(",").map((l) => l.trim());
-          input.labelIds = await resolveLabelIds(ctx.sdk, labelNames);
+        if (resolvedRefs.labelIds) {
+          input.labelIds = resolvedRefs.labelIds;
         }
 
-        if (options.projectMilestone) {
-          if (!options.project) {
-            throw new Error(
-              "--project-milestone requires --project to be specified",
-            );
-          }
-          input.projectMilestoneId = await resolveMilestoneId(
-            ctx.gql,
-            ctx.sdk,
-            options.projectMilestone,
-            options.project,
-          );
+        if (resolvedRefs.projectMilestoneId) {
+          input.projectMilestoneId = resolvedRefs.projectMilestoneId;
         }
 
         if (options.cycle) {
@@ -404,12 +401,12 @@ export function setupIssuesCommands(program: Command): void {
           input.stateId = await resolveStatusId(
             ctx.sdk,
             options.status,
-            teamId,
+            resolvedRefs.teamId,
           );
         }
 
-        if (options.parentTicket) {
-          input.parentId = await resolveIssueId(ctx.sdk, options.parentTicket);
+        if (resolvedRefs.parentId) {
+          input.parentId = resolvedRefs.parentId;
         }
 
         if (options.dueDate) {
@@ -564,50 +561,59 @@ export function setupIssuesCommands(program: Command): void {
           input.assigneeId = await resolveUserId(ctx.sdk, options.assignee);
         }
 
-        if (options.project) {
-          input.projectId = await resolveProjectId(ctx.sdk, options.project);
+        const labelNames = options.labels?.split(",").map((l) => l.trim());
+        const resolvedRefs = await resolveIssueUpdateRefs(ctx.gql, {
+          project: options.project,
+          labels: labelNames,
+          labelMode:
+            options.labelMode === "add" || options.labelMode === "overwrite"
+              ? options.labelMode
+              : undefined,
+          parentTicket: options.parentTicket,
+          projectMilestone: options.projectMilestone,
+          issueContext:
+            issueContext && "team" in issueContext
+              ? {
+                  team: issueContext.team,
+                  project: issueContext.project
+                    ? {
+                        id: issueContext.project.id,
+                        name: issueContext.project.name,
+                      }
+                    : null,
+                  labels: issueContext.labels,
+                }
+              : undefined,
+        });
+
+        if (resolvedRefs.projectId) {
+          input.projectId = resolvedRefs.projectId;
         }
 
         if (options.clearLabels) {
           input.labelIds = [];
-        } else if (options.labels) {
-          const labelNames = options.labels.split(",").map((l) => l.trim());
-          const labelIds = await resolveLabelIds(ctx.sdk, labelNames);
-
-          if (options.labelMode === "add") {
-            const currentLabels =
-              issueContext &&
-              "labels" in issueContext &&
-              issueContext.labels?.nodes
-                ? issueContext.labels.nodes.map((l) => l.id)
-                : [];
-            input.labelIds = [...new Set([...currentLabels, ...labelIds])];
-          } else {
-            input.labelIds = labelIds;
-          }
+        } else if (resolvedRefs.labelIds) {
+          input.labelIds =
+            options.labelMode === "add"
+              ? [
+                  ...new Set([
+                    ...(resolvedRefs.currentLabelIds ?? []),
+                    ...resolvedRefs.labelIds,
+                  ]),
+                ]
+              : resolvedRefs.labelIds;
         }
 
         if (options.clearParentTicket) {
           input.parentId = null;
-        } else if (options.parentTicket) {
-          input.parentId = await resolveIssueId(ctx.sdk, options.parentTicket);
+        } else if (resolvedRefs.parentId) {
+          input.parentId = resolvedRefs.parentId;
         }
 
         if (options.clearProjectMilestone) {
           input.projectMilestoneId = null;
-        } else if (options.projectMilestone) {
-          const projectName =
-            issueContext &&
-            "project" in issueContext &&
-            issueContext.project?.name
-              ? issueContext.project.name
-              : undefined;
-          input.projectMilestoneId = await resolveMilestoneId(
-            ctx.gql,
-            ctx.sdk,
-            options.projectMilestone,
-            projectName,
-          );
+        } else if (resolvedRefs.projectMilestoneId) {
+          input.projectMilestoneId = resolvedRefs.projectMilestoneId;
         }
 
         if (options.clearCycle) {

--- a/src/resolvers/issue-batch-resolver.ts
+++ b/src/resolvers/issue-batch-resolver.ts
@@ -1,0 +1,329 @@
+import type { GraphQLClient } from "../client/graphql-client.js";
+import { notFoundError } from "../common/errors.js";
+import { isUuid, parseIssueIdentifier } from "../common/identifier.js";
+import {
+  BatchResolveForCreateDocument,
+  type BatchResolveForCreateQuery,
+  BatchResolveForUpdateDocument,
+  type BatchResolveForUpdateQuery,
+} from "../gql/graphql.js";
+
+type BatchIssueContext = {
+  team?: { id: string; key: string; name?: string } | null;
+  project?: { id?: string; name?: string } | null;
+  labels?: { nodes?: Array<{ id: string; name: string }> } | null;
+};
+
+type ResolveIssueCreateRefsInput = {
+  team?: string;
+  project?: string;
+  labels?: string[];
+  parentTicket?: string;
+  projectMilestone?: string;
+};
+
+type ResolveIssueUpdateRefsInput = {
+  project?: string;
+  labels?: string[];
+  labelMode?: "add" | "overwrite";
+  parentTicket?: string;
+  projectMilestone?: string;
+  issueContext?: BatchIssueContext;
+};
+
+type MilestoneNode = { id: string; name: string };
+type LabelNode = { id: string; name: string };
+type ProjectNode = {
+  id: string;
+  name: string;
+  projectMilestones: { nodes: MilestoneNode[] };
+};
+type ParentIssueNode = { id: string; identifier: string };
+
+export type ResolvedIssueCreateRefs = {
+  teamId: string;
+  projectId?: string;
+  labelIds?: string[];
+  parentId?: string;
+  projectMilestoneId?: string;
+};
+
+export type ResolvedIssueUpdateRefs = {
+  projectId?: string;
+  labelIds?: string[];
+  currentLabelIds?: string[];
+  parentId?: string;
+  projectMilestoneId?: string;
+};
+
+export async function resolveIssueCreateRefs(
+  client: GraphQLClient,
+  input: ResolveIssueCreateRefsInput,
+): Promise<ResolvedIssueCreateRefs> {
+  if (!input.team) {
+    throw new Error("--team is required");
+  }
+
+  if (input.projectMilestone && !input.project) {
+    throw new Error("--project-milestone requires --project to be specified");
+  }
+
+  const parentRef =
+    input.parentTicket && !isUuid(input.parentTicket)
+      ? parseIssueIdentifier(input.parentTicket)
+      : undefined;
+  const labelNames = (input.labels ?? []).filter((label) => !isUuid(label));
+
+  const result = await client.request<BatchResolveForCreateQuery>(
+    BatchResolveForCreateDocument,
+    {
+      teamKey: !isUuid(input.team) ? input.team : undefined,
+      teamName: !isUuid(input.team) ? input.team : undefined,
+      projectName:
+        input.project && !isUuid(input.project) ? input.project : undefined,
+      labelNames,
+      parentTeamKey: parentRef?.teamKey,
+      parentIssueNumber: parentRef?.issueNumber,
+    },
+  );
+
+  const teamId = isUuid(input.team)
+    ? input.team
+    : (result.teams.nodes[0]?.id ?? teamNotFound(input.team));
+
+  return {
+    teamId,
+    projectId: resolveProjectIdFromBatch(result.projects.nodes, input.project),
+    labelIds: resolveLabelIdsFromBatch(result.labels.nodes, input.labels),
+    parentId: resolveParentIdFromBatch(
+      result.parentIssues.nodes,
+      input.parentTicket,
+    ),
+    projectMilestoneId: resolveCreateMilestoneId(
+      result.projects.nodes,
+      input.project,
+      input.projectMilestone,
+    ),
+  };
+}
+
+export async function resolveIssueUpdateRefs(
+  client: GraphQLClient,
+  input: ResolveIssueUpdateRefsInput,
+): Promise<ResolvedIssueUpdateRefs> {
+  if (
+    input.projectMilestone &&
+    !input.project &&
+    !input.issueContext?.project?.id &&
+    !input.issueContext?.project?.name
+  ) {
+    throw new Error("--project-milestone requires project context");
+  }
+
+  const parentRef =
+    input.parentTicket && !isUuid(input.parentTicket)
+      ? parseIssueIdentifier(input.parentTicket)
+      : undefined;
+  const labelNames = (input.labels ?? []).filter((label) => !isUuid(label));
+
+  const result = await client.request<BatchResolveForUpdateQuery>(
+    BatchResolveForUpdateDocument,
+    {
+      labelNames,
+      projectName:
+        input.project && !isUuid(input.project) ? input.project : undefined,
+      teamKey: parentRef?.teamKey,
+      issueNumber: parentRef?.issueNumber,
+      milestoneName:
+        input.projectMilestone && !isUuid(input.projectMilestone)
+          ? input.projectMilestone
+          : undefined,
+    },
+  );
+
+  return {
+    projectId: resolveProjectIdFromBatch(result.projects.nodes, input.project),
+    labelIds: resolveLabelIdsFromBatch(result.labels.nodes, input.labels),
+    currentLabelIds:
+      input.labelMode === "add"
+        ? (input.issueContext?.labels?.nodes ?? []).map((label) => label.id)
+        : undefined,
+    parentId: resolveParentIdFromBatch(result.issues.nodes, input.parentTicket),
+    projectMilestoneId: resolveUpdateMilestoneId(
+      result,
+      input.project,
+      input.projectMilestone,
+      input.issueContext?.project?.id,
+    ),
+  };
+}
+
+function teamNotFound(team: string): never {
+  throw notFoundError("Team", team);
+}
+
+function normalize(value: string): string {
+  return value.toLowerCase();
+}
+
+function resolveProjectIdFromBatch(
+  projects: ProjectNode[],
+  project?: string,
+): string | undefined {
+  if (!project) {
+    return undefined;
+  }
+
+  if (isUuid(project)) {
+    return project;
+  }
+
+  const match = projects.find(
+    (candidate) => normalize(candidate.name) === normalize(project),
+  );
+
+  if (!match) {
+    throw notFoundError("Project", project);
+  }
+
+  return match.id;
+}
+
+function resolveLabelIdsFromBatch(
+  labels: LabelNode[],
+  requestedLabels?: string[],
+): string[] | undefined {
+  if (!requestedLabels || requestedLabels.length === 0) {
+    return undefined;
+  }
+
+  const labelsByName = new Map(
+    labels.map((label) => [normalize(label.name), label.id]),
+  );
+
+  return requestedLabels.map((label) => {
+    if (isUuid(label)) {
+      return label;
+    }
+
+    const match = labelsByName.get(normalize(label));
+    if (!match) {
+      throw notFoundError("Issue label", label);
+    }
+    return match;
+  });
+}
+
+function resolveParentIdFromBatch(
+  issues: ParentIssueNode[],
+  parentTicket?: string,
+): string | undefined {
+  if (!parentTicket) {
+    return undefined;
+  }
+
+  if (isUuid(parentTicket)) {
+    return parentTicket;
+  }
+
+  const match = issues.find((issue) => issue.identifier === parentTicket);
+  if (!match) {
+    throw notFoundError("Issue", parentTicket);
+  }
+
+  return match.id;
+}
+
+function resolveCreateMilestoneId(
+  projects: ProjectNode[],
+  project?: string,
+  milestone?: string,
+): string | undefined {
+  if (!milestone) {
+    return undefined;
+  }
+
+  if (isUuid(milestone)) {
+    return milestone;
+  }
+
+  const projectNode = findProjectNode(projects, project);
+  const match = findMilestoneByName(
+    projectNode?.projectMilestones.nodes ?? [],
+    milestone,
+  );
+  if (!match) {
+    throw notFoundError("Milestone", milestone);
+  }
+
+  return match.id;
+}
+
+function resolveUpdateMilestoneId(
+  result: BatchResolveForUpdateQuery,
+  project?: string,
+  milestone?: string,
+  existingProjectId?: string,
+): string | undefined {
+  if (!milestone) {
+    return undefined;
+  }
+
+  if (isUuid(milestone)) {
+    return milestone;
+  }
+
+  if (project) {
+    const projectNode = findProjectNode(result.projects.nodes, project);
+    const match = findMilestoneByName(
+      projectNode?.projectMilestones.nodes ?? [],
+      milestone,
+    );
+    if (!match) {
+      throw notFoundError("Milestone", milestone);
+    }
+    return match.id;
+  }
+
+  if (existingProjectId) {
+    const issueProject = result.issues.nodes[0]?.project;
+    if (issueProject?.id === existingProjectId) {
+      const match = findMilestoneByName(
+        issueProject.projectMilestones.nodes,
+        milestone,
+      );
+      if (match) {
+        return match.id;
+      }
+    }
+  }
+
+  const globalMatch = findMilestoneByName(result.milestones.nodes, milestone);
+  if (!globalMatch) {
+    throw notFoundError("Milestone", milestone);
+  }
+
+  return globalMatch.id;
+}
+
+function findProjectNode(
+  projects: ProjectNode[],
+  project?: string,
+): ProjectNode | undefined {
+  if (!project || isUuid(project)) {
+    return undefined;
+  }
+
+  return projects.find(
+    (candidate) => normalize(candidate.name) === normalize(project),
+  );
+}
+
+function findMilestoneByName(
+  milestones: MilestoneNode[],
+  milestone: string,
+): MilestoneNode | undefined {
+  return milestones.find(
+    (candidate) => normalize(candidate.name) === normalize(milestone),
+  );
+}

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -31,6 +31,23 @@ vi.mock("../../../src/resolvers/issue-resolver.js", () => ({
   resolveIssueId: vi.fn().mockResolvedValue("resolved-issue-uuid"),
 }));
 
+vi.mock("../../../src/resolvers/issue-batch-resolver.js", () => ({
+  resolveIssueCreateRefs: vi.fn().mockResolvedValue({
+    teamId: "resolved-team-uuid",
+    projectId: "resolved-project-uuid",
+    labelIds: ["resolved-label-uuid"],
+    parentId: "resolved-parent-uuid",
+    projectMilestoneId: "resolved-milestone-uuid",
+  }),
+  resolveIssueUpdateRefs: vi.fn().mockResolvedValue({
+    projectId: "resolved-project-uuid",
+    labelIds: ["resolved-label-uuid"],
+    currentLabelIds: ["current-label-uuid"],
+    parentId: "resolved-parent-uuid",
+    projectMilestoneId: "resolved-milestone-uuid",
+  }),
+}));
+
 vi.mock("../../../src/resolvers/project-resolver.js", () => ({
   resolveProjectId: vi.fn().mockResolvedValue("resolved-project-uuid"),
 }));
@@ -72,6 +89,10 @@ vi.mock("../../../src/services/issue-relation-service.js", () => ({
 }));
 
 import { setupIssuesCommands } from "../../../src/commands/issues.js";
+import {
+  resolveIssueCreateRefs,
+  resolveIssueUpdateRefs,
+} from "../../../src/resolvers/issue-batch-resolver.js";
 import { resolveUserId } from "../../../src/resolvers/user-resolver.js";
 import {
   createIssue,
@@ -156,6 +177,55 @@ describe("issues create --assignee", () => {
     expect(createIssue).toHaveBeenCalledWith(
       expect.anything(),
       expect.not.objectContaining({ assigneeId: expect.anything() }),
+    );
+  });
+});
+
+describe("issues create batches refs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("issues create batches team/project/labels/parent/milestone refs", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "create",
+      "Fix login bug",
+      "--team",
+      "ENG",
+      "--project",
+      "Platform",
+      "--labels",
+      "bug,backend",
+      "--parent-ticket",
+      "ENG-42",
+      "--project-milestone",
+      "Q2",
+    ]);
+
+    expect(resolveIssueCreateRefs).toHaveBeenCalledWith(expect.anything(), {
+      team: "ENG",
+      project: "Platform",
+      labels: ["bug", "backend"],
+      parentTicket: "ENG-42",
+      projectMilestone: "Q2",
+    });
+    expect(createIssue).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        teamId: "resolved-team-uuid",
+        projectId: "resolved-project-uuid",
+        labelIds: ["resolved-label-uuid"],
+        parentId: "resolved-parent-uuid",
+        projectMilestoneId: "resolved-milestone-uuid",
+      }),
     );
   });
 });
@@ -551,6 +621,73 @@ describe("issues list/search filters", () => {
       },
     );
     expect(listIssues).not.toHaveBeenCalled();
+  });
+});
+
+describe("issues update batches refs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("issues update batches project/labels/parent/milestone refs", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--project",
+      "Platform",
+      "--labels",
+      "bug",
+      "--parent-ticket",
+      "ENG-99",
+      "--project-milestone",
+      "Q3",
+    ]);
+
+    expect(resolveIssueUpdateRefs).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        project: "Platform",
+        labels: ["bug"],
+        parentTicket: "ENG-99",
+        projectMilestone: "Q3",
+      }),
+    );
+  });
+
+  it("issues update label add still merges current labels with resolved label IDs", async () => {
+    vi.mocked(resolveIssueUpdateRefs).mockResolvedValueOnce({
+      labelIds: ["resolved-label-uuid"],
+      currentLabelIds: ["current-label-uuid"],
+    });
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--labels",
+      "bug",
+      "--label-mode",
+      "add",
+    ]);
+
+    expect(updateIssue).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+      expect.objectContaining({
+        labelIds: ["current-label-uuid", "resolved-label-uuid"],
+      }),
+    );
   });
 });
 

--- a/tests/unit/resolvers/issue-batch-resolver.test.ts
+++ b/tests/unit/resolvers/issue-batch-resolver.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import {
+  resolveIssueCreateRefs,
+  resolveIssueUpdateRefs,
+} from "../../../src/resolvers/issue-batch-resolver.js";
+
+function makeClient(response: unknown): GraphQLClient {
+  return {
+    request: vi.fn().mockResolvedValue(response),
+  } as unknown as GraphQLClient;
+}
+
+describe("resolveIssueCreateRefs", () => {
+  it("resolves team, project, labels, parent, and milestone in one batch", async () => {
+    const client = makeClient({
+      teams: { nodes: [{ id: "team-1", key: "ENG", name: "Engineering" }] },
+      projects: {
+        nodes: [
+          {
+            id: "project-1",
+            name: "Platform",
+            projectMilestones: { nodes: [{ id: "ms-1", name: "Q2" }] },
+          },
+        ],
+      },
+      labels: {
+        nodes: [
+          {
+            id: "label-1",
+            name: "bug",
+            isGroup: false,
+            parent: null,
+            children: { nodes: [] },
+          },
+          {
+            id: "label-2",
+            name: "backend",
+            isGroup: false,
+            parent: null,
+            children: { nodes: [] },
+          },
+        ],
+      },
+      parentIssues: { nodes: [{ id: "issue-1", identifier: "ENG-42" }] },
+    });
+
+    const result = await resolveIssueCreateRefs(client, {
+      team: "ENG",
+      project: "Platform",
+      labels: ["bug", "backend"],
+      parentTicket: "ENG-42",
+      projectMilestone: "Q2",
+    });
+
+    expect(result).toEqual({
+      teamId: "team-1",
+      projectId: "project-1",
+      labelIds: ["label-1", "label-2"],
+      parentId: "issue-1",
+      projectMilestoneId: "ms-1",
+    });
+    expect(client.request).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes UUID inputs through without lookup-dependent failures", async () => {
+    const client = makeClient({
+      teams: { nodes: [] },
+      projects: { nodes: [] },
+      labels: { nodes: [] },
+      parentIssues: { nodes: [] },
+    });
+
+    const result = await resolveIssueCreateRefs(client, {
+      team: "123e4567-e89b-12d3-a456-426614174000",
+      project: "123e4567-e89b-12d3-a456-426614174001",
+      labels: ["123e4567-e89b-12d3-a456-426614174002"],
+      parentTicket: "123e4567-e89b-12d3-a456-426614174003",
+      projectMilestone: "123e4567-e89b-12d3-a456-426614174004",
+    });
+
+    expect(result).toEqual({
+      teamId: "123e4567-e89b-12d3-a456-426614174000",
+      projectId: "123e4567-e89b-12d3-a456-426614174001",
+      labelIds: ["123e4567-e89b-12d3-a456-426614174002"],
+      parentId: "123e4567-e89b-12d3-a456-426614174003",
+      projectMilestoneId: "123e4567-e89b-12d3-a456-426614174004",
+    });
+  });
+
+  it("throws notFoundError-style error when team missing", async () => {
+    const client = makeClient({
+      teams: { nodes: [] },
+      projects: { nodes: [] },
+      labels: { nodes: [] },
+      parentIssues: { nodes: [] },
+    });
+
+    await expect(
+      resolveIssueCreateRefs(client, { team: "NOPE" }),
+    ).rejects.toThrow('Team "NOPE" not found');
+  });
+});
+
+describe("resolveIssueUpdateRefs", () => {
+  it("resolves project, labels, parent, milestone, and current labels for add mode", async () => {
+    const client = makeClient({
+      labels: {
+        nodes: [
+          {
+            id: "label-2",
+            name: "backend",
+            isGroup: false,
+            parent: null,
+            children: { nodes: [] },
+          },
+        ],
+      },
+      projects: {
+        nodes: [
+          {
+            id: "project-2",
+            name: "Platform",
+            projectMilestones: { nodes: [{ id: "ms-2", name: "Q3" }] },
+          },
+        ],
+      },
+      milestones: { nodes: [] },
+      issues: {
+        nodes: [
+          {
+            id: "issue-2",
+            identifier: "ENG-99",
+            labels: { nodes: [{ id: "label-1", name: "bug" }] },
+            team: { id: "team-1", key: "ENG", name: "Engineering" },
+            project: {
+              id: "project-1",
+              projectMilestones: { nodes: [{ id: "ms-old", name: "Q1" }] },
+            },
+          },
+        ],
+      },
+    });
+
+    const result = await resolveIssueUpdateRefs(client, {
+      project: "Platform",
+      labels: ["backend"],
+      labelMode: "add",
+      parentTicket: "ENG-99",
+      projectMilestone: "Q3",
+      issueContext: {
+        team: { id: "team-1", key: "ENG", name: "Engineering" },
+        project: { id: "project-1", name: "Legacy" },
+        labels: { nodes: [{ id: "label-1", name: "bug" }] },
+      },
+    });
+
+    expect(result).toEqual({
+      projectId: "project-2",
+      labelIds: ["label-2"],
+      currentLabelIds: ["label-1"],
+      parentId: "issue-2",
+      projectMilestoneId: "ms-2",
+    });
+  });
+
+  it("prefers new project when resolving update milestone", async () => {
+    const client = makeClient({
+      labels: { nodes: [] },
+      projects: {
+        nodes: [
+          {
+            id: "project-2",
+            name: "Platform",
+            projectMilestones: { nodes: [{ id: "ms-2", name: "Q3" }] },
+          },
+        ],
+      },
+      milestones: { nodes: [{ id: "ms-global", name: "Q3" }] },
+      issues: { nodes: [] },
+    });
+
+    const result = await resolveIssueUpdateRefs(client, {
+      project: "Platform",
+      projectMilestone: "Q3",
+      issueContext: {
+        team: { id: "team-1", key: "ENG", name: "Engineering" },
+        project: { id: "project-1", name: "Legacy" },
+        labels: { nodes: [] },
+      },
+    });
+
+    expect(result.projectMilestoneId).toBe("ms-2");
+  });
+
+  it("throws clear error when milestone has no project context on update", async () => {
+    const client = makeClient({
+      labels: { nodes: [] },
+      projects: { nodes: [] },
+      milestones: { nodes: [] },
+      issues: { nodes: [] },
+    });
+
+    await expect(
+      resolveIssueUpdateRefs(client, { projectMilestone: "Q3" }),
+    ).rejects.toThrow("--project-milestone requires project context");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds a batch resolver (`issue-batch-resolver.ts`) that consolidates per-field ID resolution in `issues create` and `issues update` into one or two batched GraphQL queries instead of N+1 individual resolver calls. Team, project, labels, parent issue, and project milestone are now resolved together in a single round-trip where possible.

Refs #63

## Type of change

- [x] New feature
- [x] Refactor (no behavior change)

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `npm test` — all unit tests pass
- New test files added:
  - `tests/unit/resolvers/issue-batch-resolver.test.ts` (208 lines) covers `resolveIssueCreateRefs` and `resolveIssueUpdateRefs` with happy path, missing-team error, milestone-without-project error, label deduplication in "add" mode, and null-context fallback
  - `tests/unit/commands/issues.test.ts` (137 lines) covers the command-layer integration with the batch resolver, including create and update flows

## Notes for reviewers

- The refactoring is purely structural — no behavior changes in the CLI output. The same IDs are resolved; they are just fetched in fewer GraphQL round-trips.
- `resolveIssueCreateRefs` and `resolveIssueUpdateRefs` use `GraphQLClient` (service layer client), not `LinearSdkClient`. This is intentional because the batch resolver constructs custom combined queries rather than using the typed SDK wrappers. The resolver naming follows the existing `*-resolver.ts` convention, but the client choice differs from typical resolvers — see `src/resolvers/issue-batch-resolver.ts` header comment for rationale.
- The update-path resolver receives an optional `issueContext` parameter to avoid re-fetching data the command already has (current labels, project name for milestone lookup).

## Related issues

- Refs #63
