### PR TITLE
chore: ignore local worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -329,3 +329,4 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/macos,windows,linux,visualstudiocode,node,dotenv,test
+/.worktrees/


### PR DESCRIPTION
## What does this PR do?
- Ignore project-local `.worktrees/` directories in git to prevent accidental tracking of local worktree contents.

## Type of change
- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [x] Build / CI

## Checklist
- [ ] `npm run check:ci` passes (lint + format)
- [ ] `npx tsc --noEmit` passes (type check)
- [ ] `npm test` passes (unit tests)
- [ ] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing
- Not run. Gitignore-only change.

## Notes for reviewers
- Single-line `.gitignore` update only. No runtime or build behavior change.
