### PR TITLE
chore: ignore pi pr-writing artifacts directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ docs/superpowers/
 
 # pi
 /.pi/superpowers*.json
+/.pi/pr-writing-artifacts/
 
 # ------------------------------------------------------------
 # DO NOT EDIT THE PATHS BELOW THIS LINE


### PR DESCRIPTION
## What does this PR do?

Adds `/.pi/pr-writing-artifacts/` to `.gitignore` to prevent tracking of transient JSON artifacts produced by the pi PR-writing skill. These files are local-only and regenerated on each run.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [x] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [ ] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

N/A: gitignore-only change, no production code affected.

## Testing

- `npm test` — 378 tests passing in worktree baseline
- `npm run check:ci` — clean
- Verified `git check-ignore .pi/pr-writing-artifacts/` returns positive

## Notes for reviewers

- Single-line `.gitignore` addition next to the existing `/.pi/superpowers*.json` entry. No runtime or build behavior change.
