### PR TITLE
feat(attachments): add attachments CRUD command group and --with-attachments flag

### DIFF
--- a/graphql/queries/attachments.graphql
+++ b/graphql/queries/attachments.graphql
@@ -17,6 +17,9 @@ fragment AttachmentFields on Attachment {
   title
   subtitle
   url
+  sourceType
+  metadata
+  source
   createdAt
   updatedAt
 }
@@ -24,9 +27,9 @@ fragment AttachmentFields on Attachment {
 # List attachments on an issue
 #
 # Fetches a list of attachments for a given issue.
-query ListAttachments($issueId: String!) {
+query ListAttachments($issueId: String!, $filter: AttachmentFilter) {
   issue(id: $issueId) {
-    attachments {
+    attachments(filter: $filter) {
       nodes {
         ...AttachmentFields
       }

--- a/graphql/queries/issues.graphql
+++ b/graphql/queries/issues.graphql
@@ -470,3 +470,32 @@ query BatchResolveForCreate(
 
   # Resolve cycles by name (team-scoped lookup is preferred but we also provide global fallback)
 }
+
+# Complete issue fragment with attachments
+fragment CompleteIssueWithAttachmentsFields on Issue {
+  ...CompleteIssueWithCommentsFields
+  attachments {
+    nodes {
+      ...AttachmentFields
+    }
+  }
+}
+
+# Get single issue by UUID with attachments
+query GetIssueByIdWithAttachments($id: String!) {
+  issue(id: $id) {
+    ...CompleteIssueWithAttachmentsFields
+  }
+}
+
+# Get issue by identifier with attachments
+query GetIssueByIdentifierWithAttachments($teamKey: String!, $number: Float!) {
+  issues(
+    filter: { team: { key: { eq: $teamKey } }, number: { eq: $number } }
+    first: 1
+  ) {
+    nodes {
+      ...CompleteIssueWithAttachmentsFields
+    }
+  }
+}

--- a/src/commands/attachments.ts
+++ b/src/commands/attachments.ts
@@ -1,0 +1,141 @@
+import type { Command } from "commander";
+import { createContext } from "../common/context.js";
+import { handleCommand, outputSuccess } from "../common/output.js";
+import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
+import type { AttachmentFilter } from "../gql/graphql.js";
+import { resolveIssueId } from "../resolvers/issue-resolver.js";
+import {
+  createAttachment,
+  deleteAttachment,
+  listAttachments,
+} from "../services/attachment-service.js";
+
+export const ATTACHMENTS_META: DomainMeta = {
+  name: "attachments",
+  summary: "linked external resources on issues (PRs, commits, URLs)",
+  context: [
+    "attachments link external resources to issues. they represent GitHub",
+    "pull requests, commits, Slack messages, or arbitrary URLs. each has a",
+    "title, subtitle, sourceType (e.g. 'github', 'slack'), and metadata",
+    "with integration-specific data. creating an attachment with the same",
+    "url on the same issue updates the existing record (idempotent).",
+  ].join("\n"),
+  arguments: {
+    issue: "issue identifier (UUID or ABC-123)",
+    id: "attachment UUID",
+  },
+  seeAlso: ["issues read --with-attachments"],
+};
+
+interface ListOptions {
+  sourceType?: string;
+  title?: string;
+  createdAfter?: string;
+  createdBefore?: string;
+}
+
+interface CreateOptions {
+  title: string;
+  url: string;
+  subtitle?: string;
+}
+
+function buildAttachmentFilter(
+  options: ListOptions,
+): AttachmentFilter | undefined {
+  const filters: AttachmentFilter[] = [];
+
+  if (options.sourceType) {
+    filters.push({ sourceType: { eq: options.sourceType } });
+  }
+  if (options.title) {
+    filters.push({ title: { eqIgnoreCase: options.title } });
+  }
+  if (options.createdAfter) {
+    filters.push({ createdAt: { gte: options.createdAfter } });
+  }
+  if (options.createdBefore) {
+    filters.push({ createdAt: { lt: options.createdBefore } });
+  }
+
+  if (filters.length === 0) return undefined;
+  if (filters.length === 1) return filters[0];
+  return { and: filters };
+}
+
+export function setupAttachmentsCommands(program: Command): void {
+  const attachments = program
+    .command("attachments")
+    .description("Attachment operations");
+
+  attachments.action(() => attachments.help());
+
+  attachments
+    .command("list <issue>")
+    .description("list attachments on an issue")
+    .option(
+      "--source-type <type>",
+      "filter by source type (e.g. github, slack)",
+    )
+    .option("--title <title>", "filter by title (case-insensitive)")
+    .option("--created-after <date>", "created after date (YYYY-MM-DD)")
+    .option("--created-before <date>", "created before date (YYYY-MM-DD)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [issue, options, command] = args as [
+          string,
+          ListOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+        const issueId = await resolveIssueId(ctx.sdk, issue);
+        const filter = buildAttachmentFilter(options);
+        const result = await listAttachments(ctx.gql, issueId, filter);
+        outputSuccess(result);
+      }),
+    );
+
+  attachments
+    .command("create <issue>")
+    .description("create an attachment on an issue")
+    .requiredOption("--title <title>", "attachment title")
+    .requiredOption("--url <url>", "attachment URL")
+    .option("--subtitle <text>", "attachment subtitle")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [issue, options, command] = args as [
+          string,
+          CreateOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+        const issueId = await resolveIssueId(ctx.sdk, issue);
+        const result = await createAttachment(ctx.gql, {
+          issueId,
+          title: options.title,
+          url: options.url,
+          ...(options.subtitle && { subtitle: options.subtitle }),
+        });
+        outputSuccess(result);
+      }),
+    );
+
+  attachments
+    .command("delete <id>")
+    .description("delete an attachment by UUID")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [id, , command] = args as [string, unknown, Command];
+        const ctx = createContext(command.parent!.parent!.opts());
+        const result = await deleteAttachment(ctx.gql, id);
+        outputSuccess(result);
+      }),
+    );
+
+  attachments
+    .command("usage")
+    .description("show detailed usage for attachments")
+    .action(() => {
+      console.log(formatDomainUsage(attachments, ATTACHMENTS_META));
+    });
+}

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -33,6 +33,8 @@ import {
   createIssue,
   getIssue,
   getIssueByIdentifier,
+  getIssueByIdentifierWithAttachments,
+  getIssueWithAttachments,
   listIssues,
   searchIssues,
   updateIssue,
@@ -289,16 +291,34 @@ export function setupIssuesCommands(program: Command): void {
   issues
     .command("read <issue>")
     .description("get full issue details including description")
+    .option("--with-attachments", "include issue attachments")
     .addHelpText(
       "after",
       `\nWhen passing issue IDs, both UUID and identifiers like ABC-123 are supported.`,
     )
     .action(
       handleCommand(async (...args: unknown[]) => {
-        const [issue, , command] = args as [string, unknown, Command];
+        const [issue, options, command] = args as [
+          string,
+          { withAttachments?: boolean },
+          Command,
+        ];
         const ctx = createContext(command.parent!.parent!.opts());
 
-        if (isUuid(issue)) {
+        if (options.withAttachments) {
+          if (isUuid(issue)) {
+            const result = await getIssueWithAttachments(ctx.gql, issue);
+            outputSuccess(result);
+          } else {
+            const { teamKey, issueNumber } = parseIssueIdentifier(issue);
+            const result = await getIssueByIdentifierWithAttachments(
+              ctx.gql,
+              teamKey,
+              issueNumber,
+            );
+            outputSuccess(result);
+          }
+        } else if (isUuid(issue)) {
           const result = await getIssue(ctx.gql, issue);
           outputSuccess(result);
         } else {

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -111,7 +111,12 @@ export const ISSUES_META: DomainMeta = {
     title: "string",
     query: "full-text search term",
   },
-  seeAlso: ["comments create <issue>", "documents list --issue <issue>"],
+  seeAlso: [
+    "comments create <issue>",
+    "documents list --issue <issue>",
+    "attachments list <issue>",
+    "issues read --with-attachments",
+  ],
 };
 
 interface RelationFlags {

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -9,7 +9,9 @@ import type {
   DocumentUpdateMutation,
   GetDocumentQuery,
   GetIssueByIdentifierQuery,
+  GetIssueByIdentifierWithAttachmentsQuery,
   GetIssueByIdQuery,
+  GetIssueByIdWithAttachmentsQuery,
   GetIssuesQuery,
   GetProjectMilestoneByIdQuery,
   GetProjectQuery,
@@ -43,6 +45,11 @@ export interface PaginationOptions {
 export type Issue = GetIssuesQuery["issues"]["nodes"][0];
 export type IssueDetail = NonNullable<GetIssueByIdQuery["issue"]>;
 export type IssueByIdentifier = GetIssueByIdentifierQuery["issues"]["nodes"][0];
+export type IssueDetailWithAttachments = NonNullable<
+  GetIssueByIdWithAttachmentsQuery["issue"]
+>;
+export type IssueByIdentifierWithAttachments =
+  GetIssueByIdentifierWithAttachmentsQuery["issues"]["nodes"][0];
 export type IssueSearchResult = SearchIssuesQuery["searchIssues"]["nodes"][0];
 export type CreatedIssue = NonNullable<
   CreateIssueMutation["issueCreate"]["issue"]

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,6 +2,10 @@
 
 import { Option, program } from "commander";
 import pkg from "../package.json" with { type: "json" };
+import {
+  ATTACHMENTS_META,
+  setupAttachmentsCommands,
+} from "./commands/attachments.js";
 import { AUTH_META, setupAuthCommands } from "./commands/auth.js";
 import { COMMENTS_META, setupCommentsCommands } from "./commands/comments.js";
 import { CYCLES_META, setupCyclesCommands } from "./commands/cycles.js";
@@ -41,6 +45,7 @@ const allMetas: DomainMeta[] = [
   MILESTONES_META,
   DOCUMENTS_META,
   FILES_META,
+  ATTACHMENTS_META,
   TEAMS_META,
   USERS_META,
 ];
@@ -55,6 +60,7 @@ setupProjectsCommands(program);
 setupCyclesCommands(program);
 setupMilestonesCommands(program);
 setupFilesCommands(program);
+setupAttachmentsCommands(program);
 setupTeamsCommands(program);
 setupUsersCommands(program);
 setupDocumentsCommands(program);

--- a/src/services/attachment-service.ts
+++ b/src/services/attachment-service.ts
@@ -6,6 +6,7 @@ import {
   type AttachmentCreateMutation,
   AttachmentDeleteDocument,
   type AttachmentDeleteMutation,
+  type AttachmentFilter,
   ListAttachmentsDocument,
   type ListAttachmentsQuery,
 } from "../gql/graphql.js";
@@ -45,10 +46,11 @@ export async function deleteAttachment(
 export async function listAttachments(
   client: GraphQLClient,
   issueId: string,
+  filter?: AttachmentFilter,
 ): Promise<Attachment[]> {
   const result = await client.request<ListAttachmentsQuery>(
     ListAttachmentsDocument,
-    { issueId },
+    { issueId, ...(filter && { filter }) },
   );
 
   if (!result.issue) {

--- a/src/services/issue-service.ts
+++ b/src/services/issue-service.ts
@@ -3,7 +3,9 @@ import type {
   CreatedIssue,
   Issue,
   IssueByIdentifier,
+  IssueByIdentifierWithAttachments,
   IssueDetail,
+  IssueDetailWithAttachments,
   IssueSearchResult,
   PaginatedResult,
   PaginationOptions,
@@ -17,7 +19,11 @@ import {
   GetIssueByIdDocument,
   GetIssueByIdentifierDocument,
   type GetIssueByIdentifierQuery,
+  GetIssueByIdentifierWithAttachmentsDocument,
+  type GetIssueByIdentifierWithAttachmentsQuery,
   type GetIssueByIdQuery,
+  GetIssueByIdWithAttachmentsDocument,
+  type GetIssueByIdWithAttachmentsQuery,
   GetIssuesDocument,
   type GetIssuesQuery,
   type IssueCreateInput,
@@ -95,6 +101,37 @@ export async function getIssueByIdentifier(
 ): Promise<IssueByIdentifier> {
   const result = await client.request<GetIssueByIdentifierQuery>(
     GetIssueByIdentifierDocument,
+    { teamKey, number: issueNumber },
+  );
+  if (!result.issues.nodes.length) {
+    throw new Error(
+      `Issue with identifier "${teamKey}-${issueNumber}" not found`,
+    );
+  }
+  return result.issues.nodes[0];
+}
+
+export async function getIssueWithAttachments(
+  client: GraphQLClient,
+  id: string,
+): Promise<IssueDetailWithAttachments> {
+  const result = await client.request<GetIssueByIdWithAttachmentsQuery>(
+    GetIssueByIdWithAttachmentsDocument,
+    { id },
+  );
+  if (!result.issue) {
+    throw new Error(`Issue with ID "${id}" not found`);
+  }
+  return result.issue;
+}
+
+export async function getIssueByIdentifierWithAttachments(
+  client: GraphQLClient,
+  teamKey: string,
+  issueNumber: number,
+): Promise<IssueByIdentifierWithAttachments> {
+  const result = await client.request<GetIssueByIdentifierWithAttachmentsQuery>(
+    GetIssueByIdentifierWithAttachmentsDocument,
     { teamKey, number: issueNumber },
   );
   if (!result.issues.nodes.length) {

--- a/tests/unit/commands/attachments.test.ts
+++ b/tests/unit/commands/attachments.test.ts
@@ -1,0 +1,203 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/common/context.js", () => ({
+  createContext: vi.fn(() => ({
+    gql: { request: vi.fn() },
+    sdk: {},
+  })),
+}));
+
+vi.mock("../../../src/common/output.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../src/common/output.js")>();
+  return {
+    ...actual,
+    outputSuccess: vi.fn(),
+  };
+});
+
+vi.mock("../../../src/resolvers/issue-resolver.js", () => ({
+  resolveIssueId: vi.fn().mockResolvedValue("resolved-issue-uuid"),
+}));
+
+vi.mock("../../../src/services/attachment-service.js", () => ({
+  createAttachment: vi.fn().mockResolvedValue({
+    id: "att-1",
+    title: "Test",
+    url: "https://example.com",
+  }),
+  deleteAttachment: vi.fn().mockResolvedValue({
+    id: "att-1",
+    success: true,
+  }),
+  listAttachments: vi
+    .fn()
+    .mockResolvedValue([
+      { id: "att-1", title: "PR #42", sourceType: "github" },
+    ]),
+}));
+
+import { setupAttachmentsCommands } from "../../../src/commands/attachments.js";
+import { resolveIssueId } from "../../../src/resolvers/issue-resolver.js";
+import {
+  createAttachment,
+  deleteAttachment,
+  listAttachments,
+} from "../../../src/services/attachment-service.js";
+
+function createProgram(): Command {
+  const program = new Command();
+  program.option("--api-token <token>");
+  setupAttachmentsCommands(program);
+  return program;
+}
+
+describe("attachments list", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("resolves issue and lists attachments", async () => {
+    const program = createProgram();
+    await program.parseAsync(["node", "test", "attachments", "list", "ENG-42"]);
+
+    expect(resolveIssueId).toHaveBeenCalledWith(expect.anything(), "ENG-42");
+    expect(listAttachments).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+      undefined,
+    );
+  });
+
+  it("passes source-type filter", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "attachments",
+      "list",
+      "ENG-42",
+      "--source-type",
+      "github",
+    ]);
+
+    expect(listAttachments).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+      { sourceType: { eq: "github" } },
+    );
+  });
+
+  it("combines multiple filters with AND", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "attachments",
+      "list",
+      "ENG-42",
+      "--source-type",
+      "github",
+      "--title",
+      "Fix bug",
+      "--created-after",
+      "2024-01-01",
+      "--created-before",
+      "2024-12-31",
+    ]);
+
+    expect(listAttachments).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+      {
+        and: [
+          { sourceType: { eq: "github" } },
+          { title: { eqIgnoreCase: "Fix bug" } },
+          { createdAt: { gte: "2024-01-01" } },
+          { createdAt: { lt: "2024-12-31" } },
+        ],
+      },
+    );
+  });
+});
+
+describe("attachments create", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("resolves issue and creates attachment", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "attachments",
+      "create",
+      "ENG-42",
+      "--title",
+      "My PR",
+      "--url",
+      "https://github.com/org/repo/pull/1",
+    ]);
+
+    expect(resolveIssueId).toHaveBeenCalledWith(expect.anything(), "ENG-42");
+    expect(createAttachment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        issueId: "resolved-issue-uuid",
+        title: "My PR",
+        url: "https://github.com/org/repo/pull/1",
+      }),
+    );
+  });
+
+  it("passes optional subtitle", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "attachments",
+      "create",
+      "ENG-42",
+      "--title",
+      "My PR",
+      "--url",
+      "https://github.com/org/repo/pull/1",
+      "--subtitle",
+      "merged pull request",
+    ]);
+
+    expect(createAttachment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        subtitle: "merged pull request",
+      }),
+    );
+  });
+});
+
+describe("attachments delete", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("deletes attachment by UUID", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "attachments",
+      "delete",
+      "att-uuid-123",
+    ]);
+
+    expect(deleteAttachment).toHaveBeenCalledWith(
+      expect.anything(),
+      "att-uuid-123",
+    );
+  });
+});

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -80,6 +80,7 @@ import { setupIssuesCommands } from "../../../src/commands/issues.js";
 import { resolveUserId } from "../../../src/resolvers/user-resolver.js";
 import {
   createIssue,
+  getIssueByIdentifierWithAttachments,
   getIssueWithAttachments,
   listIssues,
   searchIssues,
@@ -626,6 +627,24 @@ describe("issues read --with-attachments", () => {
     expect(getIssueWithAttachments).toHaveBeenCalledWith(
       expect.anything(),
       "550e8400-e29b-41d4-a716-446655440000",
+    );
+  });
+
+  it("calls getIssueByIdentifierWithAttachments when flag is set with identifier", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "read",
+      "ENG-42",
+      "--with-attachments",
+    ]);
+
+    expect(getIssueByIdentifierWithAttachments).toHaveBeenCalledWith(
+      expect.anything(),
+      "ENG",
+      42,
     );
   });
 });

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -61,6 +61,11 @@ vi.mock("../../../src/services/issue-service.js", () => ({
     labels: { nodes: [] },
   }),
   getIssueByIdentifier: vi.fn(),
+  getIssueWithAttachments: vi.fn().mockResolvedValue({
+    id: "resolved-issue-uuid",
+    attachments: { nodes: [{ id: "att-1", title: "PR #42" }] },
+  }),
+  getIssueByIdentifierWithAttachments: vi.fn(),
   listIssues: vi.fn().mockResolvedValue([]),
   searchIssues: vi.fn().mockResolvedValue([]),
 }));
@@ -75,6 +80,7 @@ import { setupIssuesCommands } from "../../../src/commands/issues.js";
 import { resolveUserId } from "../../../src/resolvers/user-resolver.js";
 import {
   createIssue,
+  getIssueWithAttachments,
   listIssues,
   searchIssues,
   updateIssue,
@@ -595,5 +601,31 @@ describe("issues update --assignee", () => {
     ]);
 
     expect(resolveUserId).not.toHaveBeenCalled();
+  });
+});
+
+describe("issues read --with-attachments", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("calls getIssueWithAttachments when flag is set with UUID", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "read",
+      "550e8400-e29b-41d4-a716-446655440000",
+      "--with-attachments",
+    ]);
+
+    expect(getIssueWithAttachments).toHaveBeenCalledWith(
+      expect.anything(),
+      "550e8400-e29b-41d4-a716-446655440000",
+    );
   });
 });

--- a/tests/unit/services/attachment-service.test.ts
+++ b/tests/unit/services/attachment-service.test.ts
@@ -94,4 +94,21 @@ describe("listAttachments", () => {
       "not found",
     );
   });
+
+  it("passes filter to GraphQL request", async () => {
+    const client = mockGqlClient({
+      issue: {
+        attachments: {
+          nodes: [{ id: "1", title: "PR #42", sourceType: "github" }],
+        },
+      },
+    });
+    const filter = { sourceType: { eq: "github" } };
+    const result = await listAttachments(client, "issue-1", filter);
+    expect(result).toHaveLength(1);
+    expect(client.request).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ filter }),
+    );
+  });
 });

--- a/tests/unit/services/issue-service.test.ts
+++ b/tests/unit/services/issue-service.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import {
   FilteredSearchIssuesDocument,
+  GetIssueByIdentifierWithAttachmentsDocument,
+  GetIssueByIdWithAttachmentsDocument,
   GetIssuesDocument,
   PaginationOrderBy,
   SearchIssuesDocument,
@@ -10,6 +12,8 @@ import {
   createIssue,
   getIssue,
   getIssueByIdentifier,
+  getIssueByIdentifierWithAttachments,
+  getIssueWithAttachments,
   listIssues,
   searchIssues,
   updateIssue,
@@ -242,6 +246,64 @@ describe("updateIssue", () => {
     await expect(
       updateIssue(client, "issue-id", { title: "Fail" }),
     ).rejects.toThrow("Failed to update issue");
+  });
+});
+
+describe("getIssueWithAttachments", () => {
+  it("returns issue with attachments by UUID", async () => {
+    const client = mockGqlClient({
+      issue: {
+        id: "issue-1",
+        title: "Found",
+        attachments: {
+          nodes: [{ id: "att-1", title: "PR #42", sourceType: "github" }],
+        },
+      },
+    });
+    const result = await getIssueWithAttachments(client, "issue-1");
+    expect(result.id).toBe("issue-1");
+    expect(client.request).toHaveBeenCalledWith(
+      GetIssueByIdWithAttachmentsDocument,
+      { id: "issue-1" },
+    );
+  });
+
+  it("throws when issue not found", async () => {
+    const client = mockGqlClient({ issue: null });
+    await expect(getIssueWithAttachments(client, "missing")).rejects.toThrow(
+      "not found",
+    );
+  });
+});
+
+describe("getIssueByIdentifierWithAttachments", () => {
+  it("returns issue with attachments by identifier", async () => {
+    const client = mockGqlClient({
+      issues: {
+        nodes: [
+          {
+            id: "issue-1",
+            title: "Found",
+            attachments: {
+              nodes: [{ id: "att-1", title: "PR #42" }],
+            },
+          },
+        ],
+      },
+    });
+    const result = await getIssueByIdentifierWithAttachments(client, "ENG", 42);
+    expect(result.id).toBe("issue-1");
+    expect(client.request).toHaveBeenCalledWith(
+      GetIssueByIdentifierWithAttachmentsDocument,
+      { teamKey: "ENG", number: 42 },
+    );
+  });
+
+  it("throws when issue not found", async () => {
+    const client = mockGqlClient({ issues: { nodes: [] } });
+    await expect(
+      getIssueByIdentifierWithAttachments(client, "ENG", 999),
+    ).rejects.toThrow("not found");
   });
 });
 


### PR DESCRIPTION
## What does this PR do?

Adds full attachments support to Linearis, allowing users to list, create, and delete issue attachments (linked PRs, commits, URLs) from the CLI. Also adds a `--with-attachments` flag on `issues read` to include attachment data in issue output.

Closes #28

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

All 390 unit tests pass (12 new tests added). The new test suites cover:

- `tests/unit/services/attachment-service.test.ts` — filter parameter passed through to GraphQL
- `tests/unit/services/issue-service.test.ts` — `getIssueWithAttachments` and `getIssueByIdentifierWithAttachments` happy path and not-found errors
- `tests/unit/commands/attachments.test.ts` — `list` with filters (single + combined AND), `create` with required and optional fields, `delete` by UUID
- `tests/unit/commands/issues.test.ts` — `--with-attachments` flag invokes the correct service function

## Notes for reviewers

- Run `npm run generate` after checkout to produce the codegen output in `src/gql/` (gitignored).
- The implementation follows the existing architecture: resolvers for ID resolution, services for GraphQL CRUD, commands for CLI orchestration.