### PR TITLE
ci(guard): reject docs/plans/*.md in PR branch history

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,3 +100,46 @@ jobs:
           npm install -g ./linearis-*.tgz
           linearis --help
           npm uninstall -g linearis
+
+  guard-plan-files:
+    name: Reject plan files
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - name: Check for docs/plans/*.md in branch history
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          plan_files=$(git log main...HEAD \
+            --diff-filter=A --name-only --pretty=format: \
+            -- 'docs/plans/*.md' | sed '/^$/d')
+
+          if [ -n "$plan_files" ]; then
+            echo "::error::Found plan files in branch history"
+
+            printf '%s\n' \
+              '<!-- linearis:guard-plan-files -->' \
+              '' \
+              '> [!WARNING]' \
+              '> Found `docs/plans/*.md` files in this branch'"'"'s history.' \
+              '>' \
+              '> Plan files in `docs/plans/` are working artifacts created by AI agents during the design phase. Once the implementation they describe is complete and the PR is ready for review, these files serve no further purpose — they are not reference docs, not changelogs, and not part of the shipped project.' \
+              '>' \
+              '> Leaving them in the commit history would add noise and suggest unresolved or incomplete work.' \
+              '>' \
+              '> **Remove them by rebasing and dropping the commits that introduced them:**' \
+              '> ```bash' \
+              '> git rebase -i main' \
+              '> # drop the commits that added docs/plans/*.md, then force-push' \
+              '> git push --force-with-lease' \
+              '> ```' \
+            | gh pr comment ${{ github.event.pull_request.number }} --body-file -
+
+            exit 1
+          fi
+          echo "No plan files found — OK"


### PR DESCRIPTION
## What does this PR do?

Adds a CI guard job that fails pull requests when `docs/plans/*.md` files appear anywhere in the branch's commit history, including files that were added and later deleted.

The job comments the PR with a GitHub `> [!WARNING]` notice explaining why the files must be removed and how to fix the branch. Comments include a hidden marker (`<!-- linearis:guard-plan-files -->`) for future automated cleanup.

Closes #51

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [x] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [ ] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- Verified YAML validity with `python3 -c "import yaml; yaml.safe_load(...)"`
- Verified `printf | gh pr comment --body-file -` produces correct markdown output
- Verified `git log main...HEAD --diff-filter=A` detection works on a clean branch
- Existing test suite passes (378 tests)

## Notes for reviewers

- Uses `git log main...HEAD --diff-filter=A` to catch plan files added at any point in branch history, even if later deleted
- Zero additional CI dependencies — no node setup, just `actions/checkout` with `fetch-depth: 0` plus shell
- Only runs on pull requests, not pushes to `main`
- The guide only suggests rebasing (`git push --force-with-lease`) — follow-up commit removal is intentionally excluded since the concern is branch history, not working tree