### PR TITLE
fix(issues): validate --priority and --estimate input before API call

### DIFF
--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import type { CommandContext } from "../common/context.js";
 import { createContext } from "../common/context.js";
+import { invalidParameterError } from "../common/errors.js";
 import {
   isUuid,
   parseDueDate,
@@ -90,6 +91,23 @@ interface UpdateOptions {
   relatesTo?: string;
   duplicateOf?: string;
   removeRelation?: string;
+}
+
+function parseIntegerOption(
+  value: string,
+  flag: string,
+  min: number,
+  max: number,
+): number {
+  const n = parseInt(value, 10);
+  if (Number.isNaN(n) || !Number.isInteger(n) || n < min || n > max) {
+    const range =
+      max === Infinity
+        ? `must be ${min === 0 ? "a non-negative" : `at least ${min}`} integer`
+        : `must be an integer between ${min} and ${max}`;
+    throw invalidParameterError(flag, range);
+  }
+  return n;
 }
 
 export const ISSUES_META: DomainMeta = {
@@ -448,11 +466,21 @@ export function setupIssuesCommands(program: Command): void {
         }
 
         if (options.priority) {
-          input.priority = parseInt(options.priority, 10);
+          input.priority = parseIntegerOption(
+            options.priority,
+            "--priority",
+            1,
+            4,
+          );
         }
 
         if (options.estimate !== undefined) {
-          input.estimate = parseInt(options.estimate, 10);
+          input.estimate = parseIntegerOption(
+            options.estimate,
+            "--estimate",
+            0,
+            Infinity,
+          );
         }
 
         if (options.project) {
@@ -635,13 +663,23 @@ export function setupIssuesCommands(program: Command): void {
         }
 
         if (options.priority) {
-          input.priority = parseInt(options.priority, 10);
+          input.priority = parseIntegerOption(
+            options.priority,
+            "--priority",
+            1,
+            4,
+          );
         }
 
         if (options.clearEstimate) {
           input.estimate = null;
         } else if (options.estimate !== undefined) {
-          input.estimate = parseInt(options.estimate, 10);
+          input.estimate = parseIntegerOption(
+            options.estimate,
+            "--estimate",
+            0,
+            Infinity,
+          );
         }
 
         if (options.assignee) {

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -167,6 +167,124 @@ describe("issues create --assignee", () => {
   });
 });
 
+describe("issues create --priority validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("rejects non-numeric --priority", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "create",
+      "Bug",
+      "--team",
+      "ENG",
+      "--priority",
+      "abc",
+    ]);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid --priority: must be an integer between 1 and 4",
+      ),
+    );
+  });
+
+  it("rejects --priority out of range (0)", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "create",
+      "Bug",
+      "--team",
+      "ENG",
+      "--priority",
+      "0",
+    ]);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid --priority: must be an integer between 1 and 4",
+      ),
+    );
+  });
+
+  it("rejects --priority out of range (5)", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "create",
+      "Bug",
+      "--team",
+      "ENG",
+      "--priority",
+      "5",
+    ]);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid --priority: must be an integer between 1 and 4",
+      ),
+    );
+  });
+});
+
+describe("issues create --estimate validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("rejects non-numeric --estimate", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "create",
+      "Bug",
+      "--team",
+      "ENG",
+      "--estimate",
+      "abc",
+    ]);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid --estimate: must be a non-negative integer",
+      ),
+    );
+  });
+
+  it("rejects negative --estimate", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "create",
+      "Bug",
+      "--team",
+      "ENG",
+      "--estimate",
+      "-1",
+    ]);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid --estimate: must be a non-negative integer",
+      ),
+    );
+  });
+});
+
 describe("issues create --estimate", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -296,6 +414,96 @@ describe("issues create --due-date", () => {
 
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("Invalid due date format"),
+    );
+  });
+});
+
+describe("issues update --priority validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("rejects non-numeric --priority", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--priority",
+      "abc",
+    ]);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid --priority: must be an integer between 1 and 4",
+      ),
+    );
+  });
+
+  it("rejects --priority out of range (0)", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--priority",
+      "0",
+    ]);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid --priority: must be an integer between 1 and 4",
+      ),
+    );
+  });
+});
+
+describe("issues update --estimate validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("rejects non-numeric --estimate", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--estimate",
+      "abc",
+    ]);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid --estimate: must be a non-negative integer",
+      ),
+    );
+  });
+
+  it("rejects negative --estimate", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--estimate",
+      "-1",
+    ]);
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid --estimate: must be a non-negative integer",
+      ),
     );
   });
 });


### PR DESCRIPTION
## What does this PR do?

Adds client-side validation for `--priority` and `--estimate` flags on `issues create` and `issues update`. Previously, passing non-numeric values (e.g. `--priority abc`) silently sent `NaN` to the Linear API. Now these are caught immediately with a clear error message before any API call is made.

The validation follows the existing pattern from `cycles.ts` — using `parseInt` + `Number.isNaN()` + `invalidParameterError()`.

A private `parseIntegerOption` helper was added to `issues.ts` to avoid repeating the validation logic four times.

Closes #96

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Added 9 new test cases in `tests/unit/commands/issues.test.ts` covering:

- `issues create --priority` with `"abc"`, `"0"`, `"5"` — all rejected
- `issues create --estimate` with `"abc"`, `"-1"` — both rejected
- `issues update --priority` with `"abc"`, `"0"` — both rejected
- `issues update --estimate` with `"abc"`, `"-1"` — both rejected

All 387 tests pass (378 existing + 9 new).

## Notes for reviewers

The `parseIntegerOption` helper is file-private in `issues.ts`. This keeps the change scoped — `cycles.ts` could adopt it separately if desired. The `Infinity` upper bound for estimates is intentional since team estimation scales vary widely (fibonacci, exponential, etc.).