### PR TITLE
feat: add initiatives domain with schema-compatible GraphQL, services, resolver, and commands

### DIFF
--- a/graphql/mutations/initiatives.graphql
+++ b/graphql/mutations/initiatives.graphql
@@ -1,7 +1,3 @@
-# ------------------------------------------------------------
-# GraphQL mutations for Linear initiative operations
-# ------------------------------------------------------------
-
 mutation CreateInitiative($input: InitiativeCreateInput!) {
   initiativeCreate(input: $input) {
     success
@@ -25,7 +21,7 @@ mutation UpdateInitiative($id: String!, $input: InitiativeUpdateInput!) {
 mutation ArchiveInitiative($id: String!) {
   initiativeArchive(id: $id) {
     success
-    entity {
+    initiative {
       ...InitiativeCoreFields
       ...InitiativeExpandedFields
     }
@@ -35,7 +31,7 @@ mutation ArchiveInitiative($id: String!) {
 mutation UnarchiveInitiative($id: String!) {
   initiativeUnarchive(id: $id) {
     success
-    entity {
+    initiative {
       ...InitiativeCoreFields
       ...InitiativeExpandedFields
     }
@@ -54,11 +50,11 @@ mutation CreateInitiativeRelation($input: InitiativeRelationCreateInput!) {
     success
     initiativeRelation {
       id
-      initiative {
+      parent {
         id
         name
       }
-      relatedInitiative {
+      initiative {
         id
         name
       }
@@ -121,7 +117,7 @@ mutation UpdateInitiativeUpdate(
 mutation ArchiveInitiativeUpdate($id: String!) {
   initiativeUpdateArchive(id: $id) {
     success
-    entity {
+    initiativeUpdate {
       ...InitiativeUpdateCoreFields
     }
   }
@@ -130,7 +126,7 @@ mutation ArchiveInitiativeUpdate($id: String!) {
 mutation UnarchiveInitiativeUpdate($id: String!) {
   initiativeUpdateUnarchive(id: $id) {
     success
-    entity {
+    initiativeUpdate {
       ...InitiativeUpdateCoreFields
     }
   }

--- a/graphql/mutations/initiatives.graphql
+++ b/graphql/mutations/initiatives.graphql
@@ -1,3 +1,7 @@
+# ------------------------------------------------------------
+# GraphQL mutations for Linear initiative operations
+# ------------------------------------------------------------
+
 mutation CreateInitiative($input: InitiativeCreateInput!) {
   initiativeCreate(input: $input) {
     success
@@ -21,7 +25,7 @@ mutation UpdateInitiative($id: String!, $input: InitiativeUpdateInput!) {
 mutation ArchiveInitiative($id: String!) {
   initiativeArchive(id: $id) {
     success
-    initiative {
+    entity {
       ...InitiativeCoreFields
       ...InitiativeExpandedFields
     }
@@ -31,7 +35,7 @@ mutation ArchiveInitiative($id: String!) {
 mutation UnarchiveInitiative($id: String!) {
   initiativeUnarchive(id: $id) {
     success
-    initiative {
+    entity {
       ...InitiativeCoreFields
       ...InitiativeExpandedFields
     }
@@ -50,11 +54,11 @@ mutation CreateInitiativeRelation($input: InitiativeRelationCreateInput!) {
     success
     initiativeRelation {
       id
-      parent {
+      initiative {
         id
         name
       }
-      initiative {
+      relatedInitiative {
         id
         name
       }
@@ -117,7 +121,7 @@ mutation UpdateInitiativeUpdate(
 mutation ArchiveInitiativeUpdate($id: String!) {
   initiativeUpdateArchive(id: $id) {
     success
-    initiativeUpdate {
+    entity {
       ...InitiativeUpdateCoreFields
     }
   }
@@ -126,7 +130,7 @@ mutation ArchiveInitiativeUpdate($id: String!) {
 mutation UnarchiveInitiativeUpdate($id: String!) {
   initiativeUpdateUnarchive(id: $id) {
     success
-    initiativeUpdate {
+    entity {
       ...InitiativeUpdateCoreFields
     }
   }

--- a/graphql/mutations/initiatives.graphql
+++ b/graphql/mutations/initiatives.graphql
@@ -1,0 +1,137 @@
+# ------------------------------------------------------------
+# GraphQL mutations for Linear initiative operations
+# ------------------------------------------------------------
+
+mutation CreateInitiative($input: InitiativeCreateInput!) {
+  initiativeCreate(input: $input) {
+    success
+    initiative {
+      ...InitiativeCoreFields
+      ...InitiativeExpandedFields
+    }
+  }
+}
+
+mutation UpdateInitiative($id: String!, $input: InitiativeUpdateInput!) {
+  initiativeUpdate(id: $id, input: $input) {
+    success
+    initiative {
+      ...InitiativeCoreFields
+      ...InitiativeExpandedFields
+    }
+  }
+}
+
+mutation ArchiveInitiative($id: String!) {
+  initiativeArchive(id: $id) {
+    success
+    entity {
+      ...InitiativeCoreFields
+      ...InitiativeExpandedFields
+    }
+  }
+}
+
+mutation UnarchiveInitiative($id: String!) {
+  initiativeUnarchive(id: $id) {
+    success
+    entity {
+      ...InitiativeCoreFields
+      ...InitiativeExpandedFields
+    }
+  }
+}
+
+mutation DeleteInitiative($id: String!) {
+  initiativeDelete(id: $id) {
+    success
+    entityId
+  }
+}
+
+mutation CreateInitiativeRelation($input: InitiativeRelationCreateInput!) {
+  initiativeRelationCreate(input: $input) {
+    success
+    initiativeRelation {
+      id
+      initiative {
+        id
+        name
+      }
+      relatedInitiative {
+        id
+        name
+      }
+    }
+  }
+}
+
+mutation DeleteInitiativeRelation($id: String!) {
+  initiativeRelationDelete(id: $id) {
+    success
+    entityId
+  }
+}
+
+mutation CreateInitiativeToProject($input: InitiativeToProjectCreateInput!) {
+  initiativeToProjectCreate(input: $input) {
+    success
+    initiativeToProject {
+      id
+      initiative {
+        id
+        name
+      }
+      project {
+        id
+        name
+      }
+    }
+  }
+}
+
+mutation DeleteInitiativeToProject($id: String!) {
+  initiativeToProjectDelete(id: $id) {
+    success
+    entityId
+  }
+}
+
+mutation CreateInitiativeUpdate($input: InitiativeUpdateCreateInput!) {
+  initiativeUpdateCreate(input: $input) {
+    success
+    initiativeUpdate {
+      ...InitiativeUpdateCoreFields
+    }
+  }
+}
+
+mutation UpdateInitiativeUpdate(
+  $id: String!
+  $input: InitiativeUpdateUpdateInput!
+) {
+  initiativeUpdateUpdate(id: $id, input: $input) {
+    success
+    initiativeUpdate {
+      ...InitiativeUpdateCoreFields
+    }
+  }
+}
+
+mutation ArchiveInitiativeUpdate($id: String!) {
+  initiativeUpdateArchive(id: $id) {
+    success
+    entity {
+      ...InitiativeUpdateCoreFields
+    }
+  }
+}
+
+mutation UnarchiveInitiativeUpdate($id: String!) {
+  initiativeUpdateUnarchive(id: $id) {
+    success
+    entity {
+      ...InitiativeUpdateCoreFields
+    }
+  }
+}

--- a/graphql/queries/initiatives.graphql
+++ b/graphql/queries/initiatives.graphql
@@ -6,7 +6,6 @@ fragment InitiativeCoreFields on Initiative {
   id
   name
   description
-  content
   targetDate
   sortOrder
   archivedAt
@@ -30,6 +29,7 @@ fragment InitiativeCoreFields on Initiative {
 }
 
 fragment InitiativeExpandedFields on Initiative {
+  content
   projects {
     nodes {
       id
@@ -78,6 +78,15 @@ fragment InitiativeExpandedFields on Initiative {
   }
 }
 
+fragment InitiativeNameLookupFields on Initiative {
+  id
+  name
+  owner {
+    id
+    name
+  }
+}
+
 fragment InitiativeUpdateCoreFields on InitiativeUpdate {
   id
   body
@@ -111,7 +120,6 @@ query ListInitiatives(
   ) {
     nodes {
       ...InitiativeCoreFields
-      ...InitiativeExpandedFields
     }
     pageInfo {
       hasNextPage
@@ -155,7 +163,51 @@ query GetInitiativeUpdate($id: String!) {
   }
 }
 
-query FindInitiativesByName($name: String!, $teamId: ID, $ownerId: ID) {
+query FindInitiativesByNameUnscoped($name: String!) {
+  initiatives(first: 20, filter: { name: { eqIgnoreCase: $name } }) {
+    nodes {
+      ...InitiativeNameLookupFields
+    }
+  }
+}
+
+query FindInitiativesByNameInTeam($name: String!, $teamId: ID!) {
+  initiatives(
+    first: 20
+    filter: {
+      and: [
+        { name: { eqIgnoreCase: $name } }
+        { teams: { some: { id: { eq: $teamId } } } }
+      ]
+    }
+  ) {
+    nodes {
+      ...InitiativeNameLookupFields
+    }
+  }
+}
+
+query FindInitiativesByNameByOwner($name: String!, $ownerId: ID!) {
+  initiatives(
+    first: 20
+    filter: {
+      and: [
+        { name: { eqIgnoreCase: $name } }
+        { owner: { id: { eq: $ownerId } } }
+      ]
+    }
+  ) {
+    nodes {
+      ...InitiativeNameLookupFields
+    }
+  }
+}
+
+query FindInitiativesByNameInTeamByOwner(
+  $name: String!
+  $teamId: ID!
+  $ownerId: ID!
+) {
   initiatives(
     first: 20
     filter: {
@@ -167,24 +219,7 @@ query FindInitiativesByName($name: String!, $teamId: ID, $ownerId: ID) {
     }
   ) {
     nodes {
-      id
-      name
-      owner {
-        id
-        name
-      }
-      projects {
-        nodes {
-          id
-          teams {
-            nodes {
-              id
-              key
-              name
-            }
-          }
-        }
-      }
+      ...InitiativeNameLookupFields
     }
   }
 }
@@ -205,6 +240,10 @@ query FindInitiativeRelationByPair($parentId: String!, $childId: String!) {
       relatedInitiative {
         id
       }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
     }
   }
 }
@@ -228,6 +267,10 @@ query FindInitiativeProjectLinkByPair(
       project {
         id
       }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
     }
   }
 }

--- a/graphql/queries/initiatives.graphql
+++ b/graphql/queries/initiatives.graphql
@@ -1,11 +1,8 @@
-# ------------------------------------------------------------
-# GraphQL queries for Linear initiatives
-# ------------------------------------------------------------
-
 fragment InitiativeCoreFields on Initiative {
   id
   name
   description
+  content
   targetDate
   sortOrder
   archivedAt
@@ -13,10 +10,10 @@ fragment InitiativeCoreFields on Initiative {
   updatedAt
   startedAt
   completedAt
+  canceledAt
   health
   healthUpdatedAt
   status
-  slugId
   url
   creator {
     id
@@ -26,10 +23,14 @@ fragment InitiativeCoreFields on Initiative {
     id
     name
   }
+  team {
+    id
+    key
+    name
+  }
 }
 
 fragment InitiativeExpandedFields on Initiative {
-  content
   projects {
     nodes {
       id
@@ -37,7 +38,7 @@ fragment InitiativeExpandedFields on Initiative {
       slugId
     }
   }
-  subInitiatives {
+  initiatives {
     nodes {
       id
       name
@@ -49,10 +50,10 @@ fragment InitiativeExpandedFields on Initiative {
       name
     }
   }
-  initiativeUpdates {
+  updates {
     nodes {
       id
-      body
+      title
       health
       createdAt
     }
@@ -61,7 +62,7 @@ fragment InitiativeExpandedFields on Initiative {
     nodes {
       id
       url
-      label
+      title
     }
   }
   history {
@@ -78,17 +79,9 @@ fragment InitiativeExpandedFields on Initiative {
   }
 }
 
-fragment InitiativeNameLookupFields on Initiative {
-  id
-  name
-  owner {
-    id
-    name
-  }
-}
-
 fragment InitiativeUpdateCoreFields on InitiativeUpdate {
   id
+  title
   body
   health
   createdAt
@@ -109,8 +102,7 @@ query ListInitiatives(
   $after: String
   $includeArchived: Boolean = false
   $filter: InitiativeFilter
-  $orderBy: PaginationOrderBy
-  $sort: [InitiativeSortInput!]
+  $orderBy: InitiativeSortInput
 ) {
   initiatives(
     first: $first
@@ -118,10 +110,10 @@ query ListInitiatives(
     includeArchived: $includeArchived
     filter: $filter
     orderBy: $orderBy
-    sort: $sort
   ) {
     nodes {
       ...InitiativeCoreFields
+      ...InitiativeExpandedFields
     }
     pageInfo {
       hasNextPage
@@ -138,7 +130,7 @@ query GetInitiative($id: String!) {
 }
 
 query ListInitiativeUpdates(
-  $initiativeId: ID!
+  $initiativeId: String!
   $first: Int = 50
   $after: String
   $includeArchived: Boolean = false
@@ -165,104 +157,45 @@ query GetInitiativeUpdate($id: String!) {
   }
 }
 
-query FindInitiativesByName($name: String!, $teamId: ID, $ownerId: ID) {
+query FindInitiativesByName($name: String!, $teamId: String, $ownerId: String) {
   initiatives(
     first: 20
     filter: {
       and: [
         { name: { eqIgnoreCase: $name } }
-        { teams: { some: { id: { eq: $teamId } } } }
+        { team: { id: { eq: $teamId } } }
         { owner: { id: { eq: $ownerId } } }
       ]
     }
   ) {
     nodes {
-      ...InitiativeNameLookupFields
-    }
-  }
-}
-
-query FindInitiativesByNameUnscoped($name: String!) {
-  initiatives(first: 20, filter: { name: { eqIgnoreCase: $name } }) {
-    nodes {
-      ...InitiativeNameLookupFields
-    }
-  }
-}
-
-query FindInitiativesByNameInTeam($name: String!, $teamId: ID!) {
-  initiatives(
-    first: 20
-    filter: {
-      and: [
-        { name: { eqIgnoreCase: $name } }
-        { teams: { some: { id: { eq: $teamId } } } }
-      ]
-    }
-  ) {
-    nodes {
-      ...InitiativeNameLookupFields
-    }
-  }
-}
-
-query FindInitiativesByNameByOwner($name: String!, $ownerId: ID!) {
-  initiatives(
-    first: 20
-    filter: {
-      and: [
-        { name: { eqIgnoreCase: $name } }
-        { owner: { id: { eq: $ownerId } } }
-      ]
-    }
-  ) {
-    nodes {
-      ...InitiativeNameLookupFields
-    }
-  }
-}
-
-query FindInitiativesByNameInTeamByOwner(
-  $name: String!
-  $teamId: ID!
-  $ownerId: ID!
-) {
-  initiatives(
-    first: 20
-    filter: {
-      and: [
-        { name: { eqIgnoreCase: $name } }
-        { teams: { some: { id: { eq: $teamId } } } }
-        { owner: { id: { eq: $ownerId } } }
-      ]
-    }
-  ) {
-    nodes {
-      ...InitiativeNameLookupFields
+      id
+      name
+      team {
+        id
+        key
+        name
+      }
+      owner {
+        id
+        name
+      }
     }
   }
 }
 
 query FindInitiativeRelationByPair($parentId: String!, $childId: String!) {
-  parent: initiative(id: $parentId) {
-    id
-  }
-  child: initiative(id: $childId) {
-    id
-  }
-  initiativeRelations(first: 250, includeArchived: true) {
+  initiativeRelations(
+    first: 1
+    filter: {
+      and: [
+        { parent: { id: { eq: $parentId } } }
+        { initiative: { id: { eq: $childId } } }
+      ]
+    }
+  ) {
     nodes {
       id
-      initiative {
-        id
-      }
-      relatedInitiative {
-        id
-      }
-    }
-    pageInfo {
-      hasNextPage
-      endCursor
     }
   }
 }
@@ -271,25 +204,17 @@ query FindInitiativeProjectLinkByPair(
   $initiativeId: String!
   $projectId: String!
 ) {
-  initiative(id: $initiativeId) {
-    id
-  }
-  project(id: $projectId) {
-    id
-  }
-  initiativeToProjects(first: 250, includeArchived: true) {
+  initiativeToProjects(
+    first: 1
+    filter: {
+      and: [
+        { initiative: { id: { eq: $initiativeId } } }
+        { project: { id: { eq: $projectId } } }
+      ]
+    }
+  ) {
     nodes {
       id
-      initiative {
-        id
-      }
-      project {
-        id
-      }
-    }
-    pageInfo {
-      hasNextPage
-      endCursor
     }
   }
 }

--- a/graphql/queries/initiatives.graphql
+++ b/graphql/queries/initiatives.graphql
@@ -1,8 +1,11 @@
+# ------------------------------------------------------------
+# GraphQL queries for Linear initiatives
+# ------------------------------------------------------------
+
 fragment InitiativeCoreFields on Initiative {
   id
   name
   description
-  content
   targetDate
   sortOrder
   archivedAt
@@ -10,10 +13,10 @@ fragment InitiativeCoreFields on Initiative {
   updatedAt
   startedAt
   completedAt
-  canceledAt
   health
   healthUpdatedAt
   status
+  slugId
   url
   creator {
     id
@@ -23,14 +26,10 @@ fragment InitiativeCoreFields on Initiative {
     id
     name
   }
-  team {
-    id
-    key
-    name
-  }
 }
 
 fragment InitiativeExpandedFields on Initiative {
+  content
   projects {
     nodes {
       id
@@ -38,7 +37,7 @@ fragment InitiativeExpandedFields on Initiative {
       slugId
     }
   }
-  initiatives {
+  subInitiatives {
     nodes {
       id
       name
@@ -50,10 +49,10 @@ fragment InitiativeExpandedFields on Initiative {
       name
     }
   }
-  updates {
+  initiativeUpdates {
     nodes {
       id
-      title
+      body
       health
       createdAt
     }
@@ -62,7 +61,7 @@ fragment InitiativeExpandedFields on Initiative {
     nodes {
       id
       url
-      title
+      label
     }
   }
   history {
@@ -79,9 +78,17 @@ fragment InitiativeExpandedFields on Initiative {
   }
 }
 
+fragment InitiativeNameLookupFields on Initiative {
+  id
+  name
+  owner {
+    id
+    name
+  }
+}
+
 fragment InitiativeUpdateCoreFields on InitiativeUpdate {
   id
-  title
   body
   health
   createdAt
@@ -102,7 +109,8 @@ query ListInitiatives(
   $after: String
   $includeArchived: Boolean = false
   $filter: InitiativeFilter
-  $orderBy: InitiativeSortInput
+  $orderBy: PaginationOrderBy
+  $sort: [InitiativeSortInput!]
 ) {
   initiatives(
     first: $first
@@ -110,10 +118,10 @@ query ListInitiatives(
     includeArchived: $includeArchived
     filter: $filter
     orderBy: $orderBy
+    sort: $sort
   ) {
     nodes {
       ...InitiativeCoreFields
-      ...InitiativeExpandedFields
     }
     pageInfo {
       hasNextPage
@@ -130,7 +138,7 @@ query GetInitiative($id: String!) {
 }
 
 query ListInitiativeUpdates(
-  $initiativeId: String!
+  $initiativeId: ID!
   $first: Int = 50
   $after: String
   $includeArchived: Boolean = false
@@ -157,45 +165,104 @@ query GetInitiativeUpdate($id: String!) {
   }
 }
 
-query FindInitiativesByName($name: String!, $teamId: String, $ownerId: String) {
+query FindInitiativesByName($name: String!, $teamId: ID, $ownerId: ID) {
   initiatives(
     first: 20
     filter: {
       and: [
         { name: { eqIgnoreCase: $name } }
-        { team: { id: { eq: $teamId } } }
+        { teams: { some: { id: { eq: $teamId } } } }
         { owner: { id: { eq: $ownerId } } }
       ]
     }
   ) {
     nodes {
-      id
-      name
-      team {
-        id
-        key
-        name
-      }
-      owner {
-        id
-        name
-      }
+      ...InitiativeNameLookupFields
+    }
+  }
+}
+
+query FindInitiativesByNameUnscoped($name: String!) {
+  initiatives(first: 20, filter: { name: { eqIgnoreCase: $name } }) {
+    nodes {
+      ...InitiativeNameLookupFields
+    }
+  }
+}
+
+query FindInitiativesByNameInTeam($name: String!, $teamId: ID!) {
+  initiatives(
+    first: 20
+    filter: {
+      and: [
+        { name: { eqIgnoreCase: $name } }
+        { teams: { some: { id: { eq: $teamId } } } }
+      ]
+    }
+  ) {
+    nodes {
+      ...InitiativeNameLookupFields
+    }
+  }
+}
+
+query FindInitiativesByNameByOwner($name: String!, $ownerId: ID!) {
+  initiatives(
+    first: 20
+    filter: {
+      and: [
+        { name: { eqIgnoreCase: $name } }
+        { owner: { id: { eq: $ownerId } } }
+      ]
+    }
+  ) {
+    nodes {
+      ...InitiativeNameLookupFields
+    }
+  }
+}
+
+query FindInitiativesByNameInTeamByOwner(
+  $name: String!
+  $teamId: ID!
+  $ownerId: ID!
+) {
+  initiatives(
+    first: 20
+    filter: {
+      and: [
+        { name: { eqIgnoreCase: $name } }
+        { teams: { some: { id: { eq: $teamId } } } }
+        { owner: { id: { eq: $ownerId } } }
+      ]
+    }
+  ) {
+    nodes {
+      ...InitiativeNameLookupFields
     }
   }
 }
 
 query FindInitiativeRelationByPair($parentId: String!, $childId: String!) {
-  initiativeRelations(
-    first: 1
-    filter: {
-      and: [
-        { parent: { id: { eq: $parentId } } }
-        { initiative: { id: { eq: $childId } } }
-      ]
-    }
-  ) {
+  parent: initiative(id: $parentId) {
+    id
+  }
+  child: initiative(id: $childId) {
+    id
+  }
+  initiativeRelations(first: 250, includeArchived: true) {
     nodes {
       id
+      initiative {
+        id
+      }
+      relatedInitiative {
+        id
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
     }
   }
 }
@@ -204,17 +271,25 @@ query FindInitiativeProjectLinkByPair(
   $initiativeId: String!
   $projectId: String!
 ) {
-  initiativeToProjects(
-    first: 1
-    filter: {
-      and: [
-        { initiative: { id: { eq: $initiativeId } } }
-        { project: { id: { eq: $projectId } } }
-      ]
-    }
-  ) {
+  initiative(id: $initiativeId) {
+    id
+  }
+  project(id: $projectId) {
+    id
+  }
+  initiativeToProjects(first: 250, includeArchived: true) {
     nodes {
       id
+      initiative {
+        id
+      }
+      project {
+        id
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
     }
   }
 }

--- a/graphql/queries/initiatives.graphql
+++ b/graphql/queries/initiatives.graphql
@@ -110,6 +110,7 @@ query ListInitiatives(
   $includeArchived: Boolean = false
   $filter: InitiativeFilter
   $orderBy: PaginationOrderBy
+  $sort: [InitiativeSortInput!]
 ) {
   initiatives(
     first: $first
@@ -117,6 +118,7 @@ query ListInitiatives(
     includeArchived: $includeArchived
     filter: $filter
     orderBy: $orderBy
+    sort: $sort
   ) {
     nodes {
       ...InitiativeCoreFields

--- a/graphql/queries/initiatives.graphql
+++ b/graphql/queries/initiatives.graphql
@@ -182,75 +182,18 @@ query FindInitiativesByName($name: String!, $teamId: ID, $ownerId: ID) {
   }
 }
 
-query FindInitiativesByNameUnscoped($name: String!) {
-  initiatives(first: 20, filter: { name: { eqIgnoreCase: $name } }) {
-    nodes {
-      ...InitiativeNameLookupFields
-    }
-  }
-}
-
-query FindInitiativesByNameInTeam($name: String!, $teamId: ID!) {
-  initiatives(
-    first: 20
-    filter: {
-      and: [
-        { name: { eqIgnoreCase: $name } }
-        { teams: { some: { id: { eq: $teamId } } } }
-      ]
-    }
-  ) {
-    nodes {
-      ...InitiativeNameLookupFields
-    }
-  }
-}
-
-query FindInitiativesByNameByOwner($name: String!, $ownerId: ID!) {
-  initiatives(
-    first: 20
-    filter: {
-      and: [
-        { name: { eqIgnoreCase: $name } }
-        { owner: { id: { eq: $ownerId } } }
-      ]
-    }
-  ) {
-    nodes {
-      ...InitiativeNameLookupFields
-    }
-  }
-}
-
-query FindInitiativesByNameInTeamByOwner(
-  $name: String!
-  $teamId: ID!
-  $ownerId: ID!
+query FindInitiativeRelationByPair(
+  $parentId: String!
+  $childId: String!
+  $after: String
 ) {
-  initiatives(
-    first: 20
-    filter: {
-      and: [
-        { name: { eqIgnoreCase: $name } }
-        { teams: { some: { id: { eq: $teamId } } } }
-        { owner: { id: { eq: $ownerId } } }
-      ]
-    }
-  ) {
-    nodes {
-      ...InitiativeNameLookupFields
-    }
-  }
-}
-
-query FindInitiativeRelationByPair($parentId: String!, $childId: String!) {
   parent: initiative(id: $parentId) {
     id
   }
   child: initiative(id: $childId) {
     id
   }
-  initiativeRelations(first: 250, includeArchived: true) {
+  initiativeRelations(first: 250, after: $after, includeArchived: true) {
     nodes {
       id
       initiative {
@@ -270,6 +213,7 @@ query FindInitiativeRelationByPair($parentId: String!, $childId: String!) {
 query FindInitiativeProjectLinkByPair(
   $initiativeId: String!
   $projectId: String!
+  $after: String
 ) {
   initiative(id: $initiativeId) {
     id
@@ -277,7 +221,7 @@ query FindInitiativeProjectLinkByPair(
   project(id: $projectId) {
     id
   }
-  initiativeToProjects(first: 250, includeArchived: true) {
+  initiativeToProjects(first: 250, after: $after, includeArchived: true) {
     nodes {
       id
       initiative {

--- a/graphql/queries/initiatives.graphql
+++ b/graphql/queries/initiatives.graphql
@@ -165,6 +165,23 @@ query GetInitiativeUpdate($id: String!) {
   }
 }
 
+query FindInitiativesByName($name: String!, $teamId: ID, $ownerId: ID) {
+  initiatives(
+    first: 20
+    filter: {
+      and: [
+        { name: { eqIgnoreCase: $name } }
+        { teams: { some: { id: { eq: $teamId } } } }
+        { owner: { id: { eq: $ownerId } } }
+      ]
+    }
+  ) {
+    nodes {
+      ...InitiativeNameLookupFields
+    }
+  }
+}
+
 query FindInitiativesByNameUnscoped($name: String!) {
   initiatives(first: 20, filter: { name: { eqIgnoreCase: $name } }) {
     nodes {

--- a/graphql/queries/initiatives.graphql
+++ b/graphql/queries/initiatives.graphql
@@ -1,0 +1,233 @@
+# ------------------------------------------------------------
+# GraphQL queries for Linear initiatives
+# ------------------------------------------------------------
+
+fragment InitiativeCoreFields on Initiative {
+  id
+  name
+  description
+  content
+  targetDate
+  sortOrder
+  archivedAt
+  createdAt
+  updatedAt
+  startedAt
+  completedAt
+  health
+  healthUpdatedAt
+  status
+  slugId
+  url
+  creator {
+    id
+    name
+  }
+  owner {
+    id
+    name
+  }
+}
+
+fragment InitiativeExpandedFields on Initiative {
+  projects {
+    nodes {
+      id
+      name
+      slugId
+    }
+  }
+  subInitiatives {
+    nodes {
+      id
+      name
+    }
+  }
+  parentInitiatives {
+    nodes {
+      id
+      name
+    }
+  }
+  initiativeUpdates {
+    nodes {
+      id
+      body
+      health
+      createdAt
+    }
+  }
+  links {
+    nodes {
+      id
+      url
+      label
+    }
+  }
+  history {
+    nodes {
+      id
+      createdAt
+    }
+  }
+  documents {
+    nodes {
+      id
+      title
+    }
+  }
+}
+
+fragment InitiativeUpdateCoreFields on InitiativeUpdate {
+  id
+  body
+  health
+  createdAt
+  updatedAt
+  archivedAt
+  initiative {
+    id
+    name
+  }
+  user {
+    id
+    name
+  }
+}
+
+query ListInitiatives(
+  $first: Int = 50
+  $after: String
+  $includeArchived: Boolean = false
+  $filter: InitiativeFilter
+  $orderBy: PaginationOrderBy
+) {
+  initiatives(
+    first: $first
+    after: $after
+    includeArchived: $includeArchived
+    filter: $filter
+    orderBy: $orderBy
+  ) {
+    nodes {
+      ...InitiativeCoreFields
+      ...InitiativeExpandedFields
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+
+query GetInitiative($id: String!) {
+  initiative(id: $id) {
+    ...InitiativeCoreFields
+    ...InitiativeExpandedFields
+  }
+}
+
+query ListInitiativeUpdates(
+  $initiativeId: ID!
+  $first: Int = 50
+  $after: String
+  $includeArchived: Boolean = false
+) {
+  initiativeUpdates(
+    first: $first
+    after: $after
+    includeArchived: $includeArchived
+    filter: { initiative: { id: { eq: $initiativeId } } }
+  ) {
+    nodes {
+      ...InitiativeUpdateCoreFields
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+
+query GetInitiativeUpdate($id: String!) {
+  initiativeUpdate(id: $id) {
+    ...InitiativeUpdateCoreFields
+  }
+}
+
+query FindInitiativesByName($name: String!, $teamId: ID, $ownerId: ID) {
+  initiatives(
+    first: 20
+    filter: {
+      and: [
+        { name: { eqIgnoreCase: $name } }
+        { teams: { some: { id: { eq: $teamId } } } }
+        { owner: { id: { eq: $ownerId } } }
+      ]
+    }
+  ) {
+    nodes {
+      id
+      name
+      owner {
+        id
+        name
+      }
+      projects {
+        nodes {
+          id
+          teams {
+            nodes {
+              id
+              key
+              name
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+query FindInitiativeRelationByPair($parentId: String!, $childId: String!) {
+  parent: initiative(id: $parentId) {
+    id
+  }
+  child: initiative(id: $childId) {
+    id
+  }
+  initiativeRelations(first: 250, includeArchived: true) {
+    nodes {
+      id
+      initiative {
+        id
+      }
+      relatedInitiative {
+        id
+      }
+    }
+  }
+}
+
+query FindInitiativeProjectLinkByPair(
+  $initiativeId: String!
+  $projectId: String!
+) {
+  initiative(id: $initiativeId) {
+    id
+  }
+  project(id: $projectId) {
+    id
+  }
+  initiativeToProjects(first: 250, includeArchived: true) {
+    nodes {
+      id
+      initiative {
+        id
+      }
+      project {
+        id
+      }
+    }
+  }
+}

--- a/src/commands/initiatives/entity.ts
+++ b/src/commands/initiatives/entity.ts
@@ -9,10 +9,13 @@ import {
 } from "../../common/output.js";
 import {
   type InitiativeCreateInput,
+  type InitiativeSortInput,
   InitiativeStatus,
   type InitiativeUpdateInput,
   type ListInitiativesQueryVariables,
+  PaginationNulls,
   PaginationOrderBy,
+  PaginationSortOrder,
 } from "../../gql/graphql.js";
 import { resolveInitiativeId } from "../../resolvers/initiative-resolver.js";
 import { resolveTeamId } from "../../resolvers/team-resolver.js";
@@ -27,17 +30,7 @@ import {
   updateInitiative,
 } from "../../services/initiative-service.js";
 
-interface InitiativeExpandOptions {
-  withProjects?: boolean;
-  withSubInitiatives?: boolean;
-  withParentInitiatives?: boolean;
-  withUpdates?: boolean;
-  withLinks?: boolean;
-  withHistory?: boolean;
-  withDocuments?: boolean;
-}
-
-interface InitiativeListOptions extends InitiativeExpandOptions {
+interface InitiativeListOptions {
   limit: string;
   after?: string;
   includeArchived?: boolean;
@@ -62,11 +55,8 @@ interface InitiativeListOptions extends InitiativeExpandOptions {
   createdBefore?: string;
   updatedAfter?: string;
   updatedBefore?: string;
-  parent?: string;
   ancestor?: string;
 }
-
-interface InitiativeReadOptions extends InitiativeExpandOptions {}
 
 interface InitiativeCreateOptions {
   description?: string;
@@ -135,15 +125,47 @@ function parseSortBy(value?: string): InitiativeSortBy | undefined {
 }
 
 function mapSortByToPaginationOrderBy(
-  sortBy: InitiativeSortBy,
-): PaginationOrderBy {
+  sortBy?: InitiativeSortBy,
+): PaginationOrderBy | undefined {
   if (sortBy === "createdAt") return PaginationOrderBy.CreatedAt;
   if (sortBy === "updatedAt") return PaginationOrderBy.UpdatedAt;
+  return undefined;
+}
 
-  throw invalidParameterError(
-    "--sort-by",
-    `"${sortBy}" is not supported by current Linear initiatives API; supported sort fields: createdAt, updatedAt`,
-  );
+function mapSortByToInitiativeSort(
+  sortBy?: InitiativeSortBy,
+  sortOrder?: "asc" | "desc",
+): ListInitiativesQueryVariables["sort"] | undefined {
+  if (!sortBy) return undefined;
+
+  const order =
+    sortOrder === "desc"
+      ? PaginationSortOrder.Descending
+      : PaginationSortOrder.Ascending;
+
+  const withNulls = {
+    order,
+    nulls: PaginationNulls.Last,
+  };
+
+  const sortEntry: InitiativeSortInput =
+    sortBy === "manual"
+      ? { manual: withNulls }
+      : sortBy === "name"
+        ? { name: withNulls }
+        : sortBy === "createdAt"
+          ? { createdAt: withNulls }
+          : sortBy === "updatedAt"
+            ? { updatedAt: withNulls }
+            : sortBy === "targetDate"
+              ? { targetDate: withNulls }
+              : sortBy === "health"
+                ? { health: withNulls }
+                : sortBy === "healthUpdatedAt"
+                  ? { healthUpdatedAt: withNulls }
+                  : { owner: withNulls };
+
+  return [sortEntry];
 }
 
 function parseInitiativeStatus(value?: string): InitiativeStatus | undefined {
@@ -183,19 +205,6 @@ function applyNullableDateRange(
   if (before !== undefined) {
     target.lte = before;
   }
-}
-
-function acknowledgeExpandFlags(options: InitiativeExpandOptions): void {
-  // Current initiative GraphQL list/read documents are fixed selections and do not
-  // expose per-request expansion toggles, so these flags are currently accepted
-  // for CLI compatibility only.
-  void options.withProjects;
-  void options.withSubInitiatives;
-  void options.withParentInitiatives;
-  void options.withUpdates;
-  void options.withLinks;
-  void options.withHistory;
-  void options.withDocuments;
 }
 
 async function buildInitiativeFilter(
@@ -294,11 +303,6 @@ async function buildInitiativeFilter(
     filter.ancestors = { some: { id: { eq: ancestorId } } };
   }
 
-  // InitiativeFilter does not currently expose a direct parent comparator, only
-  // ancestor collection matching. Keep --parent accepted for CLI compatibility,
-  // but intentionally do not forward it to GraphQL until schema support exists.
-  void options.parent;
-
   return Object.keys(filter).length > 0 ? filter : undefined;
 }
 
@@ -333,15 +337,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .option("--created-before <date>", "filter created date <= value")
     .option("--updated-after <date>", "filter updated date >= value")
     .option("--updated-before <date>", "filter updated date <= value")
-    .option("--parent <initiative>", "filter by direct parent initiative")
     .option("--ancestor <initiative>", "filter by ancestor initiative")
-    .option("--with-projects", "expand linked projects")
-    .option("--with-sub-initiatives", "expand child initiatives")
-    .option("--with-parent-initiatives", "expand parent initiatives")
-    .option("--with-updates", "expand initiative updates")
-    .option("--with-links", "expand related links")
-    .option("--with-history", "expand initiative history")
-    .option("--with-documents", "expand linked documents")
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [options, command] = args as [InitiativeListOptions, Command];
@@ -357,20 +353,10 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           );
         }
 
-        if (sortOrder) {
-          throw invalidParameterError(
-            "--sort-order",
-            "is not supported by current Linear initiatives API",
-          );
-        }
-
-        const orderBy = sortBy
-          ? mapSortByToPaginationOrderBy(sortBy)
-          : undefined;
+        const orderBy = mapSortByToPaginationOrderBy(sortBy);
+        const sort = mapSortByToInitiativeSort(sortBy, sortOrder);
 
         const filter = await buildInitiativeFilter(ctx.sdk, options);
-
-        acknowledgeExpandFlags(options);
 
         const result = await listInitiatives(ctx.gql, {
           limit: parseLimit(options.limit),
@@ -378,6 +364,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           includeArchived: options.includeArchived ?? false,
           filter,
           orderBy,
+          sort,
         });
 
         outputSuccess(result);
@@ -387,24 +374,11 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
   initiatives
     .command("read <initiative>")
     .description("get initiative details")
-    .option("--with-projects", "expand linked projects")
-    .option("--with-sub-initiatives", "expand child initiatives")
-    .option("--with-parent-initiatives", "expand parent initiatives")
-    .option("--with-updates", "expand initiative updates")
-    .option("--with-links", "expand related links")
-    .option("--with-history", "expand initiative history")
-    .option("--with-documents", "expand linked documents")
     .action(
       handleCommand(async (...args: unknown[]) => {
-        const [initiative, options, command] = args as [
-          string,
-          InitiativeReadOptions,
-          Command,
-        ];
+        const [initiative, , command] = args as [string, unknown, Command];
         const ctx = createContext(rootOptions(command));
         const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
-
-        acknowledgeExpandFlags(options);
 
         const result = await getInitiative(ctx.gql, initiativeId);
         outputSuccess(result);

--- a/src/commands/initiatives/entity.ts
+++ b/src/commands/initiatives/entity.ts
@@ -1,4 +1,5 @@
 import type { Command } from "commander";
+import type { LinearSdkClient } from "../../client/linear-client.js";
 import { createContext } from "../../common/context.js";
 import { invalidParameterError } from "../../common/errors.js";
 import {
@@ -10,9 +11,11 @@ import {
   type InitiativeCreateInput,
   InitiativeStatus,
   type InitiativeUpdateInput,
+  type ListInitiativesQueryVariables,
   PaginationOrderBy,
 } from "../../gql/graphql.js";
 import { resolveInitiativeId } from "../../resolvers/initiative-resolver.js";
+import { resolveTeamId } from "../../resolvers/team-resolver.js";
 import { resolveUserId } from "../../resolvers/user-resolver.js";
 import {
   archiveInitiative,
@@ -24,13 +27,46 @@ import {
   updateInitiative,
 } from "../../services/initiative-service.js";
 
-interface InitiativeListOptions {
+interface InitiativeExpandOptions {
+  withProjects?: boolean;
+  withSubInitiatives?: boolean;
+  withParentInitiatives?: boolean;
+  withUpdates?: boolean;
+  withLinks?: boolean;
+  withHistory?: boolean;
+  withDocuments?: boolean;
+}
+
+interface InitiativeListOptions extends InitiativeExpandOptions {
   limit: string;
   after?: string;
   includeArchived?: boolean;
   sortBy?: string;
   sortOrder?: string;
+  id?: string;
+  slug?: string;
+  name?: string;
+  status?: string;
+  health?: string;
+  healthWithAge?: string;
+  owner?: string;
+  creator?: string;
+  team?: string;
+  targetAfter?: string;
+  targetBefore?: string;
+  startedAfter?: string;
+  startedBefore?: string;
+  completedAfter?: string;
+  completedBefore?: string;
+  createdAfter?: string;
+  createdBefore?: string;
+  updatedAfter?: string;
+  updatedBefore?: string;
+  parent?: string;
+  ancestor?: string;
 }
+
+interface InitiativeReadOptions extends InitiativeExpandOptions {}
 
 interface InitiativeCreateOptions {
   description?: string;
@@ -51,6 +87,16 @@ interface InitiativeUpdateOptions {
   sortOrder?: string;
 }
 
+type InitiativeSortBy =
+  | "name"
+  | "createdAt"
+  | "updatedAt"
+  | "targetDate"
+  | "health"
+  | "healthUpdatedAt"
+  | "manual"
+  | "owner";
+
 function rootOptions(command: Command): Record<string, unknown> {
   let current: Command = command;
   while (current.parent) {
@@ -68,17 +114,32 @@ function parseSortOrder(value?: string): "asc" | "desc" | undefined {
   throw invalidParameterError("--sort-order", "must be one of: asc, desc");
 }
 
-function parseOrderBy(value?: string): PaginationOrderBy | undefined {
+function parseSortBy(value?: string): InitiativeSortBy | undefined {
   if (!value) return undefined;
 
   const normalized = value.toLowerCase();
-  if (normalized === "createdat") return PaginationOrderBy.CreatedAt;
-  if (normalized === "updatedat") return PaginationOrderBy.UpdatedAt;
+
+  if (normalized === "name") return "name";
+  if (normalized === "createdat") return "createdAt";
+  if (normalized === "updatedat") return "updatedAt";
+  if (normalized === "targetdate") return "targetDate";
+  if (normalized === "health") return "health";
+  if (normalized === "healthupdatedat") return "healthUpdatedAt";
+  if (normalized === "manual") return "manual";
+  if (normalized === "owner") return "owner";
 
   throw invalidParameterError(
     "--sort-by",
-    'must be one of: "createdAt", "updatedAt"',
+    'must be one of: "name", "createdAt", "updatedAt", "targetDate", "health", "healthUpdatedAt", "manual", "owner"',
   );
+}
+
+function mapSortByToPaginationOrderBy(
+  sortBy?: InitiativeSortBy,
+): PaginationOrderBy | undefined {
+  if (sortBy === "createdAt") return PaginationOrderBy.CreatedAt;
+  if (sortBy === "updatedAt") return PaginationOrderBy.UpdatedAt;
+  return undefined;
 }
 
 function parseInitiativeStatus(value?: string): InitiativeStatus | undefined {
@@ -107,6 +168,136 @@ function parseSortOrderNumber(value?: string): number | undefined {
   return parsed;
 }
 
+function applyNullableDateRange(
+  target: { gte?: string; lte?: string },
+  after?: string,
+  before?: string,
+): void {
+  if (after !== undefined) {
+    target.gte = after;
+  }
+  if (before !== undefined) {
+    target.lte = before;
+  }
+}
+
+function acknowledgeExpandFlags(options: InitiativeExpandOptions): void {
+  // Current initiative GraphQL list/read documents are fixed selections and do not
+  // expose per-request expansion toggles, so these flags are currently accepted
+  // for CLI compatibility only.
+  void options.withProjects;
+  void options.withSubInitiatives;
+  void options.withParentInitiatives;
+  void options.withUpdates;
+  void options.withLinks;
+  void options.withHistory;
+  void options.withDocuments;
+}
+
+async function buildInitiativeFilter(
+  sdk: LinearSdkClient,
+  options: InitiativeListOptions,
+): Promise<ListInitiativesQueryVariables["filter"] | undefined> {
+  const filter: NonNullable<ListInitiativesQueryVariables["filter"]> = {};
+
+  if (options.id) {
+    filter.id = { eq: options.id };
+  }
+
+  if (options.slug) {
+    filter.slugId = { eqIgnoreCase: options.slug };
+  }
+
+  if (options.name) {
+    filter.name = { eqIgnoreCase: options.name };
+  }
+
+  const status = parseInitiativeStatus(options.status);
+  if (status) {
+    filter.status = { eq: status };
+  }
+
+  if (options.health) {
+    filter.health = { eq: options.health };
+  }
+
+  if (options.healthWithAge) {
+    filter.healthWithAge = { eq: options.healthWithAge };
+  }
+
+  if (options.owner) {
+    const ownerId = await resolveUserId(sdk, options.owner);
+    filter.owner = { id: { eq: ownerId } };
+  }
+
+  if (options.creator) {
+    const creatorId = await resolveUserId(sdk, options.creator);
+    filter.creator = { id: { eq: creatorId } };
+  }
+
+  if (options.team) {
+    const teamId = await resolveTeamId(sdk, options.team);
+    filter.teams = { some: { id: { eq: teamId } } };
+  }
+
+  if (options.targetAfter || options.targetBefore) {
+    filter.targetDate = {};
+    applyNullableDateRange(
+      filter.targetDate,
+      options.targetAfter,
+      options.targetBefore,
+    );
+  }
+
+  if (options.startedAfter || options.startedBefore) {
+    filter.startedAt = {};
+    applyNullableDateRange(
+      filter.startedAt,
+      options.startedAfter,
+      options.startedBefore,
+    );
+  }
+
+  if (options.completedAfter || options.completedBefore) {
+    filter.completedAt = {};
+    applyNullableDateRange(
+      filter.completedAt,
+      options.completedAfter,
+      options.completedBefore,
+    );
+  }
+
+  if (options.createdAfter || options.createdBefore) {
+    filter.createdAt = {};
+    applyNullableDateRange(
+      filter.createdAt,
+      options.createdAfter,
+      options.createdBefore,
+    );
+  }
+
+  if (options.updatedAfter || options.updatedBefore) {
+    filter.updatedAt = {};
+    applyNullableDateRange(
+      filter.updatedAt,
+      options.updatedAfter,
+      options.updatedBefore,
+    );
+  }
+
+  if (options.ancestor) {
+    const ancestorId = await resolveInitiativeId(sdk, options.ancestor);
+    filter.ancestors = { some: { id: { eq: ancestorId } } };
+  }
+
+  // InitiativeFilter does not currently expose a direct parent comparator, only
+  // ancestor collection matching. Keep --parent accepted for CLI compatibility,
+  // but intentionally do not forward it to GraphQL until schema support exists.
+  void options.parent;
+
+  return Object.keys(filter).length > 0 ? filter : undefined;
+}
+
 export function setupInitiativeEntityCommands(initiatives: Command): void {
   initiatives
     .command("list")
@@ -114,27 +305,64 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .option("-l, --limit <n>", "max results", "50")
     .option("--after <cursor>", "cursor for next page")
     .option("--include-archived", "include archived initiatives")
-    .option("--sort-by <field>", "createdAt or updatedAt")
+    .option(
+      "--sort-by <field>",
+      "name, createdAt, updatedAt, targetDate, health, healthUpdatedAt, manual, owner",
+    )
     .option("--sort-order <order>", "asc or desc")
+    .option("--id <id>", "filter by initiative UUID")
+    .option("--slug <slug>", "filter by slug")
+    .option("--name <name>", "filter by name")
+    .option("--status <status>", "filter by status: planned, active, completed")
+    .option("--health <health>", "filter by health")
+    .option("--health-with-age <health>", "filter by health with age")
+    .option("--owner <user>", "filter by owner (name, email, or UUID)")
+    .option("--creator <user>", "filter by creator (name, email, or UUID)")
+    .option("--team <team>", "filter by team (name, key, or UUID)")
+    .option("--target-after <date>", "filter target date >= value")
+    .option("--target-before <date>", "filter target date <= value")
+    .option("--started-after <date>", "filter started date >= value")
+    .option("--started-before <date>", "filter started date <= value")
+    .option("--completed-after <date>", "filter completed date >= value")
+    .option("--completed-before <date>", "filter completed date <= value")
+    .option("--created-after <date>", "filter created date >= value")
+    .option("--created-before <date>", "filter created date <= value")
+    .option("--updated-after <date>", "filter updated date >= value")
+    .option("--updated-before <date>", "filter updated date <= value")
+    .option("--parent <initiative>", "filter by direct parent initiative")
+    .option("--ancestor <initiative>", "filter by ancestor initiative")
+    .option("--with-projects", "expand linked projects")
+    .option("--with-sub-initiatives", "expand child initiatives")
+    .option("--with-parent-initiatives", "expand parent initiatives")
+    .option("--with-updates", "expand initiative updates")
+    .option("--with-links", "expand related links")
+    .option("--with-history", "expand initiative history")
+    .option("--with-documents", "expand linked documents")
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [options, command] = args as [InitiativeListOptions, Command];
         const ctx = createContext(rootOptions(command));
 
         const sortOrder = parseSortOrder(options.sortOrder);
-        const orderBy = parseOrderBy(options.sortBy);
+        const sortBy = parseSortBy(options.sortBy);
+        const orderBy = mapSortByToPaginationOrderBy(sortBy);
 
-        if (sortOrder && !orderBy) {
+        if (sortOrder && !sortBy) {
           throw invalidParameterError(
             "--sort-order",
             "requires --sort-by to be specified",
           );
         }
 
+        const filter = await buildInitiativeFilter(ctx.sdk, options);
+
+        acknowledgeExpandFlags(options);
+
         const result = await listInitiatives(ctx.gql, {
           limit: parseLimit(options.limit),
           after: options.after,
           includeArchived: options.includeArchived ?? false,
+          filter,
           orderBy,
         });
 
@@ -145,11 +373,25 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
   initiatives
     .command("read <initiative>")
     .description("get initiative details")
+    .option("--with-projects", "expand linked projects")
+    .option("--with-sub-initiatives", "expand child initiatives")
+    .option("--with-parent-initiatives", "expand parent initiatives")
+    .option("--with-updates", "expand initiative updates")
+    .option("--with-links", "expand related links")
+    .option("--with-history", "expand initiative history")
+    .option("--with-documents", "expand linked documents")
     .action(
       handleCommand(async (...args: unknown[]) => {
-        const [initiative, , command] = args as [string, unknown, Command];
+        const [initiative, options, command] = args as [
+          string,
+          InitiativeReadOptions,
+          Command,
+        ];
         const ctx = createContext(rootOptions(command));
         const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+
+        acknowledgeExpandFlags(options);
+
         const result = await getInitiative(ctx.gql, initiativeId);
         outputSuccess(result);
       }),

--- a/src/commands/initiatives/entity.ts
+++ b/src/commands/initiatives/entity.ts
@@ -135,11 +135,15 @@ function parseSortBy(value?: string): InitiativeSortBy | undefined {
 }
 
 function mapSortByToPaginationOrderBy(
-  sortBy?: InitiativeSortBy,
-): PaginationOrderBy | undefined {
+  sortBy: InitiativeSortBy,
+): PaginationOrderBy {
   if (sortBy === "createdAt") return PaginationOrderBy.CreatedAt;
   if (sortBy === "updatedAt") return PaginationOrderBy.UpdatedAt;
-  return undefined;
+
+  throw invalidParameterError(
+    "--sort-by",
+    `"${sortBy}" is not supported by current Linear initiatives API; supported sort fields: createdAt, updatedAt`,
+  );
 }
 
 function parseInitiativeStatus(value?: string): InitiativeStatus | undefined {
@@ -345,7 +349,6 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
 
         const sortOrder = parseSortOrder(options.sortOrder);
         const sortBy = parseSortBy(options.sortBy);
-        const orderBy = mapSortByToPaginationOrderBy(sortBy);
 
         if (sortOrder && !sortBy) {
           throw invalidParameterError(
@@ -353,6 +356,17 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
             "requires --sort-by to be specified",
           );
         }
+
+        if (sortOrder) {
+          throw invalidParameterError(
+            "--sort-order",
+            "is not supported by current Linear initiatives API",
+          );
+        }
+
+        const orderBy = sortBy
+          ? mapSortByToPaginationOrderBy(sortBy)
+          : undefined;
 
         const filter = await buildInitiativeFilter(ctx.sdk, options);
 

--- a/src/commands/initiatives/entity.ts
+++ b/src/commands/initiatives/entity.ts
@@ -30,7 +30,17 @@ import {
   updateInitiative,
 } from "../../services/initiative-service.js";
 
-interface InitiativeListOptions {
+interface InitiativeExpandOptions {
+  withProjects?: boolean;
+  withSubInitiatives?: boolean;
+  withParentInitiatives?: boolean;
+  withUpdates?: boolean;
+  withLinks?: boolean;
+  withHistory?: boolean;
+  withDocuments?: boolean;
+}
+
+interface InitiativeListOptions extends InitiativeExpandOptions {
   limit: string;
   after?: string;
   includeArchived?: boolean;
@@ -55,8 +65,11 @@ interface InitiativeListOptions {
   createdBefore?: string;
   updatedAfter?: string;
   updatedBefore?: string;
+  parent?: string;
   ancestor?: string;
 }
+
+interface InitiativeReadOptions extends InitiativeExpandOptions {}
 
 interface InitiativeCreateOptions {
   description?: string;
@@ -207,6 +220,20 @@ function applyNullableDateRange(
   }
 }
 
+function getExpandFlags(options: InitiativeExpandOptions): string[] {
+  const map: Array<[boolean | undefined, string]> = [
+    [options.withProjects, "--with-projects"],
+    [options.withSubInitiatives, "--with-sub-initiatives"],
+    [options.withParentInitiatives, "--with-parent-initiatives"],
+    [options.withUpdates, "--with-updates"],
+    [options.withLinks, "--with-links"],
+    [options.withHistory, "--with-history"],
+    [options.withDocuments, "--with-documents"],
+  ];
+
+  return map.filter(([enabled]) => enabled).map(([, flag]) => flag);
+}
+
 async function buildInitiativeFilter(
   sdk: LinearSdkClient,
   options: InitiativeListOptions,
@@ -303,6 +330,13 @@ async function buildInitiativeFilter(
     filter.ancestors = { some: { id: { eq: ancestorId } } };
   }
 
+  if (options.parent) {
+    throw invalidParameterError(
+      "--parent",
+      "is not supported by current Linear initiatives filter API",
+    );
+  }
+
   return Object.keys(filter).length > 0 ? filter : undefined;
 }
 
@@ -337,7 +371,21 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .option("--created-before <date>", "filter created date <= value")
     .option("--updated-after <date>", "filter updated date >= value")
     .option("--updated-before <date>", "filter updated date <= value")
+    .option("--parent <initiative>", "filter by direct parent initiative")
     .option("--ancestor <initiative>", "filter by ancestor initiative")
+    .option("--with-projects", "include linked projects in list output")
+    .option(
+      "--with-sub-initiatives",
+      "include child initiatives in list output",
+    )
+    .option(
+      "--with-parent-initiatives",
+      "include parent initiatives in list output",
+    )
+    .option("--with-updates", "include updates in list output")
+    .option("--with-links", "include links in list output")
+    .option("--with-history", "include history in list output")
+    .option("--with-documents", "include documents in list output")
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [options, command] = args as [InitiativeListOptions, Command];
@@ -345,6 +393,14 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
 
         const sortOrder = parseSortOrder(options.sortOrder);
         const sortBy = parseSortBy(options.sortBy);
+
+        const expandFlags = getExpandFlags(options);
+        if (expandFlags.length > 0) {
+          throw invalidParameterError(
+            "expand flags",
+            `${expandFlags.join(", ")} are not supported for initiatives list yet`,
+          );
+        }
 
         if (sortOrder && !sortBy) {
           throw invalidParameterError(
@@ -374,11 +430,32 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
   initiatives
     .command("read <initiative>")
     .description("get initiative details")
+    .option("--with-projects", "include linked projects in read output")
+    .option(
+      "--with-sub-initiatives",
+      "include child initiatives in read output",
+    )
+    .option(
+      "--with-parent-initiatives",
+      "include parent initiatives in read output",
+    )
+    .option("--with-updates", "include updates in read output")
+    .option("--with-links", "include links in read output")
+    .option("--with-history", "include history in read output")
+    .option("--with-documents", "include documents in read output")
     .action(
       handleCommand(async (...args: unknown[]) => {
-        const [initiative, , command] = args as [string, unknown, Command];
+        const [initiative, options, command] = args as [
+          string,
+          InitiativeReadOptions,
+          Command,
+        ];
         const ctx = createContext(rootOptions(command));
         const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+
+        // Read query already returns expanded fields. Keep flags accepted for
+        // CLI contract compatibility until conditional field selection is added.
+        void getExpandFlags(options);
 
         const result = await getInitiative(ctx.gql, initiativeId);
         outputSuccess(result);

--- a/src/commands/initiatives/entity.ts
+++ b/src/commands/initiatives/entity.ts
@@ -1,0 +1,311 @@
+import type { Command } from "commander";
+import { createContext } from "../../common/context.js";
+import { invalidParameterError } from "../../common/errors.js";
+import {
+  handleCommand,
+  outputSuccess,
+  parseLimit,
+} from "../../common/output.js";
+import {
+  type InitiativeCreateInput,
+  InitiativeStatus,
+  type InitiativeUpdateInput,
+  PaginationOrderBy,
+} from "../../gql/graphql.js";
+import { resolveInitiativeId } from "../../resolvers/initiative-resolver.js";
+import { resolveUserId } from "../../resolvers/user-resolver.js";
+import {
+  archiveInitiative,
+  createInitiative,
+  deleteInitiative,
+  getInitiative,
+  listInitiatives,
+  unarchiveInitiative,
+  updateInitiative,
+} from "../../services/initiative-service.js";
+
+interface InitiativeListOptions {
+  limit: string;
+  after?: string;
+  includeArchived?: boolean;
+  sortBy?: string;
+  sortOrder?: string;
+}
+
+interface InitiativeCreateOptions {
+  description?: string;
+  content?: string;
+  owner?: string;
+  status?: string;
+  targetDate?: string;
+  sortOrder?: string;
+}
+
+interface InitiativeUpdateOptions {
+  name?: string;
+  description?: string;
+  content?: string;
+  owner?: string;
+  status?: string;
+  targetDate?: string;
+  sortOrder?: string;
+}
+
+function rootOptions(command: Command): Record<string, unknown> {
+  let current: Command = command;
+  while (current.parent) {
+    current = current.parent;
+  }
+  return current.opts();
+}
+
+function parseSortOrder(value?: string): "asc" | "desc" | undefined {
+  if (!value) return undefined;
+  const normalized = value.toLowerCase();
+  if (normalized === "asc" || normalized === "desc") {
+    return normalized;
+  }
+  throw invalidParameterError("--sort-order", "must be one of: asc, desc");
+}
+
+function parseOrderBy(value?: string): PaginationOrderBy | undefined {
+  if (!value) return undefined;
+
+  const normalized = value.toLowerCase();
+  if (normalized === "createdat") return PaginationOrderBy.CreatedAt;
+  if (normalized === "updatedat") return PaginationOrderBy.UpdatedAt;
+
+  throw invalidParameterError(
+    "--sort-by",
+    'must be one of: "createdAt", "updatedAt"',
+  );
+}
+
+function parseInitiativeStatus(value?: string): InitiativeStatus | undefined {
+  if (!value) return undefined;
+
+  const normalized = value.toLowerCase();
+  if (normalized === "planned") return InitiativeStatus.Planned;
+  if (normalized === "active") return InitiativeStatus.Active;
+  if (normalized === "completed") return InitiativeStatus.Completed;
+
+  throw invalidParameterError(
+    "--status",
+    'must be one of: "Planned", "Active", "Completed"',
+  );
+}
+
+function parseSortOrderNumber(value?: string): number | undefined {
+  if (value === undefined) return undefined;
+  const parsed = Number.parseFloat(value);
+  if (Number.isNaN(parsed)) {
+    throw invalidParameterError(
+      "--sort-order",
+      `must be a number, got "${value}"`,
+    );
+  }
+  return parsed;
+}
+
+export function setupInitiativeEntityCommands(initiatives: Command): void {
+  initiatives
+    .command("list")
+    .description("list initiatives")
+    .option("-l, --limit <n>", "max results", "50")
+    .option("--after <cursor>", "cursor for next page")
+    .option("--include-archived", "include archived initiatives")
+    .option("--sort-by <field>", "createdAt or updatedAt")
+    .option("--sort-order <order>", "asc or desc")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [options, command] = args as [InitiativeListOptions, Command];
+        const ctx = createContext(rootOptions(command));
+
+        const sortOrder = parseSortOrder(options.sortOrder);
+        const orderBy = parseOrderBy(options.sortBy);
+
+        if (sortOrder && !orderBy) {
+          throw invalidParameterError(
+            "--sort-order",
+            "requires --sort-by to be specified",
+          );
+        }
+
+        const result = await listInitiatives(ctx.gql, {
+          limit: parseLimit(options.limit),
+          after: options.after,
+          includeArchived: options.includeArchived ?? false,
+          orderBy,
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("read <initiative>")
+    .description("get initiative details")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [initiative, , command] = args as [string, unknown, Command];
+        const ctx = createContext(rootOptions(command));
+        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+        const result = await getInitiative(ctx.gql, initiativeId);
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("create <name>")
+    .description("create a new initiative")
+    .option("--description <text>", "initiative description")
+    .option("--content <text>", "initiative content (markdown)")
+    .option("--owner <user>", "owner (name, email, or UUID)")
+    .option("--status <status>", "planned, active, completed")
+    .option("--target-date <date>", "target date (YYYY-MM-DD)")
+    .option("--sort-order <n>", "display sort order")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [name, options, command] = args as [
+          string,
+          InitiativeCreateOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+
+        const input: InitiativeCreateInput = { name };
+
+        if (options.description !== undefined) {
+          input.description = options.description;
+        }
+
+        if (options.content !== undefined) {
+          input.content = options.content;
+        }
+
+        if (options.owner) {
+          input.ownerId = await resolveUserId(ctx.sdk, options.owner);
+        }
+
+        const status = parseInitiativeStatus(options.status);
+        if (status) {
+          input.status = status;
+        }
+
+        if (options.targetDate !== undefined) {
+          input.targetDate = options.targetDate;
+        }
+
+        const sortOrder = parseSortOrderNumber(options.sortOrder);
+        if (sortOrder !== undefined) {
+          input.sortOrder = sortOrder;
+        }
+
+        const result = await createInitiative(ctx.gql, input);
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("update <initiative>")
+    .description("update an initiative")
+    .option("--name <name>", "new name")
+    .option("--description <text>", "new description")
+    .option("--content <text>", "new content (markdown)")
+    .option("--owner <user>", "new owner (name, email, or UUID)")
+    .option("--status <status>", "planned, active, completed")
+    .option("--target-date <date>", "new target date (YYYY-MM-DD)")
+    .option("--sort-order <n>", "new display sort order")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [initiative, options, command] = args as [
+          string,
+          InitiativeUpdateOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+
+        const input: InitiativeUpdateInput = {};
+
+        if (options.name !== undefined) {
+          input.name = options.name;
+        }
+
+        if (options.description !== undefined) {
+          input.description = options.description;
+        }
+
+        if (options.content !== undefined) {
+          input.content = options.content;
+        }
+
+        if (options.owner) {
+          input.ownerId = await resolveUserId(ctx.sdk, options.owner);
+        }
+
+        const status = parseInitiativeStatus(options.status);
+        if (status) {
+          input.status = status;
+        }
+
+        if (options.targetDate !== undefined) {
+          input.targetDate = options.targetDate;
+        }
+
+        const sortOrder = parseSortOrderNumber(options.sortOrder);
+        if (sortOrder !== undefined) {
+          input.sortOrder = sortOrder;
+        }
+
+        if (Object.keys(input).length === 0) {
+          throw invalidParameterError(
+            "update options",
+            "at least one option must be provided",
+          );
+        }
+
+        const result = await updateInitiative(ctx.gql, initiativeId, input);
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("archive <initiative>")
+    .description("archive an initiative")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [initiative, , command] = args as [string, unknown, Command];
+        const ctx = createContext(rootOptions(command));
+        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+        const result = await archiveInitiative(ctx.gql, initiativeId);
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("unarchive <initiative>")
+    .description("unarchive an initiative")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [initiative, , command] = args as [string, unknown, Command];
+        const ctx = createContext(rootOptions(command));
+        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+        const result = await unarchiveInitiative(ctx.gql, initiativeId);
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("delete <initiative>")
+    .description("delete an initiative")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [initiative, , command] = args as [string, unknown, Command];
+        const ctx = createContext(rootOptions(command));
+        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+        const result = await deleteInitiative(ctx.gql, initiativeId);
+        outputSuccess(result);
+      }),
+    );
+}

--- a/src/commands/initiatives/index.ts
+++ b/src/commands/initiatives/index.ts
@@ -1,0 +1,45 @@
+import type { Command } from "commander";
+import { type DomainMeta, formatDomainUsage } from "../../common/usage.js";
+import { setupInitiativeEntityCommands } from "./entity.js";
+import { setupInitiativeProjectCommands } from "./projects.js";
+import { setupInitiativeRelationCommands } from "./relations.js";
+import { setupInitiativeUpdateCommands } from "./updates.js";
+
+export const INITIATIVES_META: DomainMeta = {
+  name: "initiatives",
+  summary: "strategic multi-project goals",
+  context: [
+    "initiatives represent larger outcomes that span projects and teams.",
+    "use initiative updates for status communication, and relation/project",
+    "commands to manage initiative hierarchies and linked projects.",
+  ].join("\n"),
+  arguments: {
+    initiative: "initiative identifier (UUID or name)",
+    parent: "parent initiative identifier (UUID or name)",
+    child: "child initiative identifier (UUID or name)",
+    project: "project identifier (UUID or name)",
+    update: "initiative update identifier (UUID)",
+    name: "string",
+  },
+  seeAlso: ["projects list", "projects read", "users list"],
+};
+
+export function setupInitiativesCommands(program: Command): void {
+  const initiatives = program
+    .command("initiatives")
+    .description("Initiative operations");
+
+  initiatives.action(() => initiatives.help());
+
+  setupInitiativeEntityCommands(initiatives);
+  setupInitiativeRelationCommands(initiatives);
+  setupInitiativeProjectCommands(initiatives);
+  setupInitiativeUpdateCommands(initiatives);
+
+  initiatives
+    .command("usage")
+    .description("show detailed usage for initiatives")
+    .action(() => {
+      console.log(formatDomainUsage(initiatives, INITIATIVES_META));
+    });
+}

--- a/src/commands/initiatives/projects.ts
+++ b/src/commands/initiatives/projects.ts
@@ -1,0 +1,74 @@
+import type { Command } from "commander";
+import { createContext } from "../../common/context.js";
+import { handleCommand, outputSuccess } from "../../common/output.js";
+import {
+  resolveInitiativeId,
+  resolveInitiativeProjectLinkId,
+} from "../../resolvers/initiative-resolver.js";
+import { resolveProjectId } from "../../resolvers/project-resolver.js";
+import {
+  createInitiativeProjectLink,
+  deleteInitiativeProjectLink,
+} from "../../services/initiative-project-service.js";
+
+function rootOptions(command: Command): Record<string, unknown> {
+  let current: Command = command;
+  while (current.parent) {
+    current = current.parent;
+  }
+  return current.opts();
+}
+
+export function setupInitiativeProjectCommands(initiatives: Command): void {
+  initiatives
+    .command("add-project <initiative> <project>")
+    .description("link a project to an initiative")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [initiative, project, , command] = args as [
+          string,
+          string,
+          unknown,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+
+        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+        const projectId = await resolveProjectId(ctx.sdk, project);
+
+        const result = await createInitiativeProjectLink(ctx.gql, {
+          initiativeId,
+          projectId,
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("remove-project <initiative> <project>")
+    .description("unlink a project from an initiative")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [initiative, project, , command] = args as [
+          string,
+          string,
+          unknown,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+
+        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+        const projectId = await resolveProjectId(ctx.sdk, project);
+
+        const linkId = await resolveInitiativeProjectLinkId(
+          ctx.gql,
+          initiativeId,
+          projectId,
+        );
+
+        const result = await deleteInitiativeProjectLink(ctx.gql, linkId);
+        outputSuccess(result);
+      }),
+    );
+}

--- a/src/commands/initiatives/relations.ts
+++ b/src/commands/initiatives/relations.ts
@@ -1,0 +1,73 @@
+import type { Command } from "commander";
+import { createContext } from "../../common/context.js";
+import { handleCommand, outputSuccess } from "../../common/output.js";
+import {
+  resolveInitiativeId,
+  resolveInitiativeRelationId,
+} from "../../resolvers/initiative-resolver.js";
+import {
+  createInitiativeRelation,
+  deleteInitiativeRelation,
+} from "../../services/initiative-relation-service.js";
+
+function rootOptions(command: Command): Record<string, unknown> {
+  let current: Command = command;
+  while (current.parent) {
+    current = current.parent;
+  }
+  return current.opts();
+}
+
+export function setupInitiativeRelationCommands(initiatives: Command): void {
+  initiatives
+    .command("relate <parent> <child>")
+    .description("create a parent/child initiative relation")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [parent, child, , command] = args as [
+          string,
+          string,
+          unknown,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+
+        const parentId = await resolveInitiativeId(ctx.sdk, parent);
+        const childId = await resolveInitiativeId(ctx.sdk, child);
+
+        const result = await createInitiativeRelation(ctx.gql, {
+          parentId,
+          childId,
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("unrelate <parent> <child>")
+    .description("delete a parent/child initiative relation")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [parent, child, , command] = args as [
+          string,
+          string,
+          unknown,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+
+        const parentId = await resolveInitiativeId(ctx.sdk, parent);
+        const childId = await resolveInitiativeId(ctx.sdk, child);
+
+        const relationId = await resolveInitiativeRelationId(
+          ctx.gql,
+          parentId,
+          childId,
+        );
+
+        const result = await deleteInitiativeRelation(ctx.gql, relationId);
+        outputSuccess(result);
+      }),
+    );
+}

--- a/src/commands/initiatives/updates.ts
+++ b/src/commands/initiatives/updates.ts
@@ -112,15 +112,14 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
     );
 
   updates
-    .command("create <title>")
+    .command("create")
     .description("create an initiative update")
     .requiredOption("--initiative <initiative>", "initiative name or UUID")
     .option("--body <text>", "update body (markdown)")
     .option("--health <health>", "onTrack, atRisk, offTrack")
     .action(
       handleCommand(async (...args: unknown[]) => {
-        const [title, options, command] = args as [
-          string,
+        const [options, command] = args as [
           InitiativeUpdatesCreateOptions,
           Command,
         ];
@@ -131,10 +130,7 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
           options.initiative,
         );
 
-        const input: InitiativeUpdateCreateInput & { title: string } = {
-          initiativeId,
-          title,
-        };
+        const input: InitiativeUpdateCreateInput = { initiativeId };
 
         if (options.body !== undefined) {
           input.body = options.body;

--- a/src/commands/initiatives/updates.ts
+++ b/src/commands/initiatives/updates.ts
@@ -112,14 +112,15 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
     );
 
   updates
-    .command("create")
+    .command("create <title>")
     .description("create an initiative update")
     .requiredOption("--initiative <initiative>", "initiative name or UUID")
     .option("--body <text>", "update body (markdown)")
     .option("--health <health>", "onTrack, atRisk, offTrack")
     .action(
       handleCommand(async (...args: unknown[]) => {
-        const [options, command] = args as [
+        const [title, options, command] = args as [
+          string,
           InitiativeUpdatesCreateOptions,
           Command,
         ];
@@ -130,7 +131,10 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
           options.initiative,
         );
 
-        const input: InitiativeUpdateCreateInput = { initiativeId };
+        const input: InitiativeUpdateCreateInput & { title: string } = {
+          initiativeId,
+          title,
+        };
 
         if (options.body !== undefined) {
           input.body = options.body;

--- a/src/commands/initiatives/updates.ts
+++ b/src/commands/initiatives/updates.ts
@@ -1,0 +1,209 @@
+import type { Command } from "commander";
+import { createContext } from "../../common/context.js";
+import { invalidParameterError } from "../../common/errors.js";
+import {
+  handleCommand,
+  outputSuccess,
+  parseLimit,
+} from "../../common/output.js";
+import {
+  type InitiativeUpdateCreateInput,
+  InitiativeUpdateHealthType,
+  type InitiativeUpdateUpdateInput,
+} from "../../gql/graphql.js";
+import { resolveInitiativeId } from "../../resolvers/initiative-resolver.js";
+import {
+  archiveInitiativeUpdate,
+  createInitiativeUpdate,
+  getInitiativeUpdate,
+  listInitiativeUpdates,
+  unarchiveInitiativeUpdate,
+  updateInitiativeUpdate,
+} from "../../services/initiative-update-service.js";
+
+interface InitiativeUpdatesListOptions {
+  initiative: string;
+  limit: string;
+  after?: string;
+  includeArchived?: boolean;
+}
+
+interface InitiativeUpdatesCreateOptions {
+  initiative: string;
+  body?: string;
+  health?: string;
+}
+
+interface InitiativeUpdatesUpdateOptions {
+  body?: string;
+  health?: string;
+}
+
+function rootOptions(command: Command): Record<string, unknown> {
+  let current: Command = command;
+  while (current.parent) {
+    current = current.parent;
+  }
+  return current.opts();
+}
+
+function parseHealth(value?: string): InitiativeUpdateHealthType | undefined {
+  if (!value) return undefined;
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "ontrack") return InitiativeUpdateHealthType.OnTrack;
+  if (normalized === "atrisk") return InitiativeUpdateHealthType.AtRisk;
+  if (normalized === "offtrack") return InitiativeUpdateHealthType.OffTrack;
+
+  throw invalidParameterError(
+    "--health",
+    'must be one of: "onTrack", "atRisk", "offTrack"',
+  );
+}
+
+export function setupInitiativeUpdateCommands(initiatives: Command): void {
+  const updates = initiatives
+    .command("updates")
+    .description("initiative update operations");
+
+  updates.action(() => updates.help());
+
+  updates
+    .command("list")
+    .description("list initiative updates")
+    .requiredOption("--initiative <initiative>", "initiative name or UUID")
+    .option("-l, --limit <n>", "max results", "50")
+    .option("--after <cursor>", "cursor for next page")
+    .option("--include-archived", "include archived updates")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [options, command] = args as [
+          InitiativeUpdatesListOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+
+        const initiativeId = await resolveInitiativeId(
+          ctx.sdk,
+          options.initiative,
+        );
+
+        const result = await listInitiativeUpdates(ctx.gql, {
+          initiativeId,
+          limit: parseLimit(options.limit),
+          after: options.after,
+          includeArchived: options.includeArchived ?? false,
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  updates
+    .command("read <update>")
+    .description("get initiative update details")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [updateId, , command] = args as [string, unknown, Command];
+        const ctx = createContext(rootOptions(command));
+        const result = await getInitiativeUpdate(ctx.gql, updateId);
+        outputSuccess(result);
+      }),
+    );
+
+  updates
+    .command("create")
+    .description("create an initiative update")
+    .requiredOption("--initiative <initiative>", "initiative name or UUID")
+    .option("--body <text>", "update body (markdown)")
+    .option("--health <health>", "onTrack, atRisk, offTrack")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [options, command] = args as [
+          InitiativeUpdatesCreateOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+
+        const initiativeId = await resolveInitiativeId(
+          ctx.sdk,
+          options.initiative,
+        );
+
+        const input: InitiativeUpdateCreateInput = { initiativeId };
+
+        if (options.body !== undefined) {
+          input.body = options.body;
+        }
+
+        const health = parseHealth(options.health);
+        if (health) {
+          input.health = health;
+        }
+
+        const result = await createInitiativeUpdate(ctx.gql, input);
+        outputSuccess(result);
+      }),
+    );
+
+  updates
+    .command("update <update>")
+    .description("update an initiative update")
+    .option("--body <text>", "new body (markdown)")
+    .option("--health <health>", "onTrack, atRisk, offTrack")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [updateId, options, command] = args as [
+          string,
+          InitiativeUpdatesUpdateOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+
+        const input: InitiativeUpdateUpdateInput = {};
+
+        if (options.body !== undefined) {
+          input.body = options.body;
+        }
+
+        const health = parseHealth(options.health);
+        if (health) {
+          input.health = health;
+        }
+
+        if (Object.keys(input).length === 0) {
+          throw invalidParameterError(
+            "update options",
+            "at least one option must be provided",
+          );
+        }
+
+        const result = await updateInitiativeUpdate(ctx.gql, updateId, input);
+        outputSuccess(result);
+      }),
+    );
+
+  updates
+    .command("archive <update>")
+    .description("archive an initiative update")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [updateId, , command] = args as [string, unknown, Command];
+        const ctx = createContext(rootOptions(command));
+        const result = await archiveInitiativeUpdate(ctx.gql, updateId);
+        outputSuccess(result);
+      }),
+    );
+
+  updates
+    .command("unarchive <update>")
+    .description("unarchive an initiative update")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [updateId, , command] = args as [string, unknown, Command];
+        const ctx = createContext(rootOptions(command));
+        const result = await unarchiveInitiativeUpdate(ctx.gql, updateId);
+        outputSuccess(result);
+      }),
+    );
+}

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,13 +1,22 @@
 import type {
+  ArchiveInitiativeMutation,
+  ArchiveInitiativeUpdateMutation,
   AttachmentCreateMutation,
   CreateCommentMutation,
+  CreateInitiativeMutation,
+  CreateInitiativeRelationMutation,
+  CreateInitiativeToProjectMutation,
+  CreateInitiativeUpdateMutation,
   CreateIssueMutation,
   CreateIssueRelationMutation,
   CreateProjectMilestoneMutation,
   CreateProjectMutation,
+  DeleteInitiativeMutation,
   DocumentCreateMutation,
   DocumentUpdateMutation,
   GetDocumentQuery,
+  GetInitiativeQuery,
+  GetInitiativeUpdateQuery,
   GetIssueByIdentifierQuery,
   GetIssueByIdentifierWithAttachmentsQuery,
   GetIssueByIdQuery,
@@ -20,9 +29,15 @@ import type {
   ListAttachmentsQuery,
   ListCommentsQuery,
   ListDocumentsQuery,
+  ListInitiativesQuery,
+  ListInitiativeUpdatesQuery,
   ListProjectMilestonesQuery,
   SearchIssuesQuery,
+  UnarchiveInitiativeMutation,
+  UnarchiveInitiativeUpdateMutation,
   UpdateCommentMutation,
+  UpdateInitiativeMutation,
+  UpdateInitiativeUpdateMutation,
   UpdateIssueMutation,
   UpdateProjectMilestoneMutation,
   UpdateProjectMutation,
@@ -97,6 +112,54 @@ export type CreatedMilestone = NonNullable<
 >;
 export type UpdatedMilestone = NonNullable<
   UpdateProjectMilestoneMutation["projectMilestoneUpdate"]["projectMilestone"]
+>;
+
+// Initiative types
+export type InitiativeListItem =
+  ListInitiativesQuery["initiatives"]["nodes"][0];
+export type InitiativeDetail = NonNullable<GetInitiativeQuery["initiative"]>;
+export type CreatedInitiative = NonNullable<
+  CreateInitiativeMutation["initiativeCreate"]["initiative"]
+>;
+export type UpdatedInitiative = NonNullable<
+  UpdateInitiativeMutation["initiativeUpdate"]["initiative"]
+>;
+export type ArchivedInitiative = NonNullable<
+  ArchiveInitiativeMutation["initiativeArchive"]["entity"]
+>;
+export type UnarchivedInitiative = NonNullable<
+  UnarchiveInitiativeMutation["initiativeUnarchive"]["entity"]
+>;
+
+export type InitiativeRelation = NonNullable<
+  CreateInitiativeRelationMutation["initiativeRelationCreate"]["initiativeRelation"]
+>;
+
+export type InitiativeProjectLink = NonNullable<
+  CreateInitiativeToProjectMutation["initiativeToProjectCreate"]["initiativeToProject"]
+>;
+
+export type DeletedInitiative = {
+  id: NonNullable<DeleteInitiativeMutation["initiativeDelete"]["entityId"]>;
+  success: true;
+};
+
+export type InitiativeUpdateListItem =
+  ListInitiativeUpdatesQuery["initiativeUpdates"]["nodes"][0];
+export type InitiativeUpdateDetail = NonNullable<
+  GetInitiativeUpdateQuery["initiativeUpdate"]
+>;
+export type CreatedInitiativeUpdate = NonNullable<
+  CreateInitiativeUpdateMutation["initiativeUpdateCreate"]["initiativeUpdate"]
+>;
+export type UpdatedInitiativeUpdate = NonNullable<
+  UpdateInitiativeUpdateMutation["initiativeUpdateUpdate"]["initiativeUpdate"]
+>;
+export type ArchivedInitiativeUpdate = NonNullable<
+  ArchiveInitiativeUpdateMutation["initiativeUpdateArchive"]["entity"]
+>;
+export type UnarchivedInitiativeUpdate = NonNullable<
+  UnarchiveInitiativeUpdateMutation["initiativeUpdateUnarchive"]["entity"]
 >;
 
 // Comment types

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -12,6 +12,8 @@ import type {
   CreateProjectMilestoneMutation,
   CreateProjectMutation,
   DeleteInitiativeMutation,
+  DeleteInitiativeRelationMutation,
+  DeleteInitiativeToProjectMutation,
   DocumentCreateMutation,
   DocumentUpdateMutation,
   GetDocumentQuery,
@@ -141,6 +143,20 @@ export type InitiativeProjectLink = NonNullable<
 
 export type DeletedInitiative = {
   id: NonNullable<DeleteInitiativeMutation["initiativeDelete"]["entityId"]>;
+  success: true;
+};
+
+export type DeletedInitiativeRelation = {
+  id: NonNullable<
+    DeleteInitiativeRelationMutation["initiativeRelationDelete"]["entityId"]
+  >;
+  success: true;
+};
+
+export type DeletedInitiativeProjectLink = {
+  id: NonNullable<
+    DeleteInitiativeToProjectMutation["initiativeToProjectDelete"]["entityId"]
+  >;
   success: true;
 };
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,10 +14,6 @@ import {
   setupDocumentsCommands,
 } from "./commands/documents.js";
 import { FILES_META, setupFilesCommands } from "./commands/files.js";
-import {
-  INITIATIVES_META,
-  setupInitiativesCommands,
-} from "./commands/initiatives/index.js";
 import { ISSUES_META, setupIssuesCommands } from "./commands/issues.js";
 import { LABELS_META, setupLabelsCommands } from "./commands/labels.js";
 import {
@@ -45,7 +41,6 @@ const allMetas: DomainMeta[] = [
   COMMENTS_META,
   LABELS_META,
   PROJECTS_META,
-  INITIATIVES_META,
   CYCLES_META,
   MILESTONES_META,
   DOCUMENTS_META,
@@ -62,7 +57,6 @@ setupIssuesCommands(program);
 setupCommentsCommands(program);
 setupLabelsCommands(program);
 setupProjectsCommands(program);
-setupInitiativesCommands(program);
 setupCyclesCommands(program);
 setupMilestonesCommands(program);
 setupFilesCommands(program);

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,10 @@ import {
   setupDocumentsCommands,
 } from "./commands/documents.js";
 import { FILES_META, setupFilesCommands } from "./commands/files.js";
+import {
+  INITIATIVES_META,
+  setupInitiativesCommands,
+} from "./commands/initiatives/index.js";
 import { ISSUES_META, setupIssuesCommands } from "./commands/issues.js";
 import { LABELS_META, setupLabelsCommands } from "./commands/labels.js";
 import {
@@ -48,6 +52,7 @@ const allMetas: DomainMeta[] = [
   ATTACHMENTS_META,
   TEAMS_META,
   USERS_META,
+  INITIATIVES_META,
 ];
 
 program.action(() => console.log(formatOverview(pkg.version, allMetas)));
@@ -63,6 +68,7 @@ setupFilesCommands(program);
 setupAttachmentsCommands(program);
 setupTeamsCommands(program);
 setupUsersCommands(program);
+setupInitiativesCommands(program);
 setupDocumentsCommands(program);
 
 program

--- a/src/main.ts
+++ b/src/main.ts
@@ -14,6 +14,10 @@ import {
   setupDocumentsCommands,
 } from "./commands/documents.js";
 import { FILES_META, setupFilesCommands } from "./commands/files.js";
+import {
+  INITIATIVES_META,
+  setupInitiativesCommands,
+} from "./commands/initiatives/index.js";
 import { ISSUES_META, setupIssuesCommands } from "./commands/issues.js";
 import { LABELS_META, setupLabelsCommands } from "./commands/labels.js";
 import {
@@ -41,6 +45,7 @@ const allMetas: DomainMeta[] = [
   COMMENTS_META,
   LABELS_META,
   PROJECTS_META,
+  INITIATIVES_META,
   CYCLES_META,
   MILESTONES_META,
   DOCUMENTS_META,
@@ -57,6 +62,7 @@ setupIssuesCommands(program);
 setupCommentsCommands(program);
 setupLabelsCommands(program);
 setupProjectsCommands(program);
+setupInitiativesCommands(program);
 setupCyclesCommands(program);
 setupMilestonesCommands(program);
 setupFilesCommands(program);

--- a/src/resolvers/initiative-resolver.ts
+++ b/src/resolvers/initiative-resolver.ts
@@ -1,0 +1,135 @@
+import type { GraphQLClient } from "../client/graphql-client.js";
+import type { LinearSdkClient } from "../client/linear-client.js";
+import { multipleMatchesError, notFoundError } from "../common/errors.js";
+import { isUuid } from "../common/identifier.js";
+import {
+  FindInitiativeProjectLinkByPairDocument,
+  type FindInitiativeProjectLinkByPairQuery,
+  FindInitiativeRelationByPairDocument,
+  type FindInitiativeRelationByPairQuery,
+} from "../gql/graphql.js";
+
+export interface InitiativeResolveScope {
+  teamId?: string;
+  ownerId?: string;
+}
+
+export async function resolveInitiativeId(
+  client: LinearSdkClient,
+  nameOrId: string,
+  scope: InitiativeResolveScope = {},
+): Promise<string> {
+  if (isUuid(nameOrId)) {
+    return nameOrId;
+  }
+
+  const clauses: Array<Record<string, unknown>> = [
+    { name: { eqIgnoreCase: nameOrId } },
+  ];
+
+  if (scope.teamId) {
+    clauses.push({ teams: { some: { id: { eq: scope.teamId } } } });
+  }
+
+  if (scope.ownerId) {
+    clauses.push({ owner: { id: { eq: scope.ownerId } } });
+  }
+
+  const filter = clauses.length === 1 ? clauses[0] : { and: clauses };
+
+  const result = await client.sdk.initiatives({
+    filter,
+    first: 20,
+  });
+
+  if (result.nodes.length === 0) {
+    throw notFoundError("Initiative", nameOrId);
+  }
+
+  if (result.nodes.length === 1) {
+    return result.nodes[0].id;
+  }
+
+  const candidates = result.nodes.map((node) => `${node.name} (${node.id})`);
+
+  throw multipleMatchesError(
+    "initiative",
+    nameOrId,
+    candidates,
+    scope.teamId || scope.ownerId
+      ? "use UUID to disambiguate"
+      : "provide --team or --owner, or use UUID",
+  );
+}
+
+function truncatedLookupError(
+  entity: string,
+  leftId: string,
+  rightId: string,
+): Error {
+  return new Error(
+    `${entity} lookup truncated before finding a match between ${leftId} and ${rightId}; use UUID path or add pagination support`,
+  );
+}
+
+export async function resolveInitiativeRelationId(
+  client: GraphQLClient,
+  parentId: string,
+  childId: string,
+): Promise<string> {
+  const result = await client.request<FindInitiativeRelationByPairQuery>(
+    FindInitiativeRelationByPairDocument,
+    { parentId, childId },
+  );
+
+  const relation = result.initiativeRelations.nodes.find(
+    (node) =>
+      node.initiative.id === parentId && node.relatedInitiative.id === childId,
+  );
+
+  if (relation) {
+    return relation.id;
+  }
+
+  if (result.initiativeRelations.pageInfo.hasNextPage) {
+    throw truncatedLookupError("Initiative relation", parentId, childId);
+  }
+
+  throw notFoundError(
+    "Initiative relation",
+    `between ${parentId} and ${childId}`,
+  );
+}
+
+export async function resolveInitiativeProjectLinkId(
+  client: GraphQLClient,
+  initiativeId: string,
+  projectId: string,
+): Promise<string> {
+  const result = await client.request<FindInitiativeProjectLinkByPairQuery>(
+    FindInitiativeProjectLinkByPairDocument,
+    { initiativeId, projectId },
+  );
+
+  const link = result.initiativeToProjects.nodes.find(
+    (node) =>
+      node.initiative.id === initiativeId && node.project.id === projectId,
+  );
+
+  if (link) {
+    return link.id;
+  }
+
+  if (result.initiativeToProjects.pageInfo.hasNextPage) {
+    throw truncatedLookupError(
+      "Initiative project link",
+      initiativeId,
+      projectId,
+    );
+  }
+
+  throw notFoundError(
+    "Initiative project link",
+    `between ${initiativeId} and ${projectId}`,
+  );
+}

--- a/src/resolvers/initiative-resolver.ts
+++ b/src/resolvers/initiative-resolver.ts
@@ -62,37 +62,34 @@ export async function resolveInitiativeId(
   );
 }
 
-function truncatedLookupError(
-  entity: string,
-  leftId: string,
-  rightId: string,
-): Error {
-  return new Error(
-    `${entity} lookup truncated before finding a match between ${leftId} and ${rightId}; use UUID path or add pagination support`,
-  );
-}
-
 export async function resolveInitiativeRelationId(
   client: GraphQLClient,
   parentId: string,
   childId: string,
 ): Promise<string> {
-  const result = await client.request<FindInitiativeRelationByPairQuery>(
-    FindInitiativeRelationByPairDocument,
-    { parentId, childId },
-  );
+  let after: string | undefined;
 
-  const relation = result.initiativeRelations.nodes.find(
-    (node) =>
-      node.initiative.id === parentId && node.relatedInitiative.id === childId,
-  );
+  while (true) {
+    const result = await client.request<FindInitiativeRelationByPairQuery>(
+      FindInitiativeRelationByPairDocument,
+      { parentId, childId, after },
+    );
 
-  if (relation) {
-    return relation.id;
-  }
+    const relation = result.initiativeRelations.nodes.find(
+      (node) =>
+        node.initiative.id === parentId &&
+        node.relatedInitiative.id === childId,
+    );
 
-  if (result.initiativeRelations.pageInfo.hasNextPage) {
-    throw truncatedLookupError("Initiative relation", parentId, childId);
+    if (relation) {
+      return relation.id;
+    }
+
+    if (!result.initiativeRelations.pageInfo.hasNextPage) {
+      break;
+    }
+
+    after = result.initiativeRelations.pageInfo.endCursor ?? undefined;
   }
 
   throw notFoundError(
@@ -106,26 +103,28 @@ export async function resolveInitiativeProjectLinkId(
   initiativeId: string,
   projectId: string,
 ): Promise<string> {
-  const result = await client.request<FindInitiativeProjectLinkByPairQuery>(
-    FindInitiativeProjectLinkByPairDocument,
-    { initiativeId, projectId },
-  );
+  let after: string | undefined;
 
-  const link = result.initiativeToProjects.nodes.find(
-    (node) =>
-      node.initiative.id === initiativeId && node.project.id === projectId,
-  );
-
-  if (link) {
-    return link.id;
-  }
-
-  if (result.initiativeToProjects.pageInfo.hasNextPage) {
-    throw truncatedLookupError(
-      "Initiative project link",
-      initiativeId,
-      projectId,
+  while (true) {
+    const result = await client.request<FindInitiativeProjectLinkByPairQuery>(
+      FindInitiativeProjectLinkByPairDocument,
+      { initiativeId, projectId, after },
     );
+
+    const link = result.initiativeToProjects.nodes.find(
+      (node) =>
+        node.initiative.id === initiativeId && node.project.id === projectId,
+    );
+
+    if (link) {
+      return link.id;
+    }
+
+    if (!result.initiativeToProjects.pageInfo.hasNextPage) {
+      break;
+    }
+
+    after = result.initiativeToProjects.pageInfo.endCursor ?? undefined;
   }
 
   throw notFoundError(

--- a/src/services/initiative-project-service.ts
+++ b/src/services/initiative-project-service.ts
@@ -1,0 +1,56 @@
+import type { GraphQLClient } from "../client/graphql-client.js";
+import type {
+  DeletedInitiativeProjectLink,
+  InitiativeProjectLink,
+} from "../common/types.js";
+import {
+  CreateInitiativeToProjectDocument,
+  type CreateInitiativeToProjectMutation,
+  DeleteInitiativeToProjectDocument,
+  type DeleteInitiativeToProjectMutation,
+} from "../gql/graphql.js";
+
+export async function createInitiativeProjectLink(
+  client: GraphQLClient,
+  input: { initiativeId: string; projectId: string },
+): Promise<InitiativeProjectLink> {
+  const result = await client.request<CreateInitiativeToProjectMutation>(
+    CreateInitiativeToProjectDocument,
+    {
+      input,
+    },
+  );
+
+  if (
+    !result.initiativeToProjectCreate.success ||
+    !result.initiativeToProjectCreate.initiativeToProject
+  ) {
+    throw new Error(
+      `Failed to create initiative-project link for initiative "${input.initiativeId}" and project "${input.projectId}"`,
+    );
+  }
+
+  return result.initiativeToProjectCreate.initiativeToProject;
+}
+
+export async function deleteInitiativeProjectLink(
+  client: GraphQLClient,
+  id: string,
+): Promise<DeletedInitiativeProjectLink> {
+  const result = await client.request<DeleteInitiativeToProjectMutation>(
+    DeleteInitiativeToProjectDocument,
+    { id },
+  );
+
+  if (
+    !result.initiativeToProjectDelete.success ||
+    !result.initiativeToProjectDelete.entityId
+  ) {
+    throw new Error(`Failed to delete initiative-project link "${id}"`);
+  }
+
+  return {
+    id: result.initiativeToProjectDelete.entityId,
+    success: true,
+  };
+}

--- a/src/services/initiative-relation-service.ts
+++ b/src/services/initiative-relation-service.ts
@@ -1,0 +1,59 @@
+import type { GraphQLClient } from "../client/graphql-client.js";
+import type {
+  DeletedInitiativeRelation,
+  InitiativeRelation,
+} from "../common/types.js";
+import {
+  CreateInitiativeRelationDocument,
+  type CreateInitiativeRelationMutation,
+  DeleteInitiativeRelationDocument,
+  type DeleteInitiativeRelationMutation,
+} from "../gql/graphql.js";
+
+export async function createInitiativeRelation(
+  client: GraphQLClient,
+  input: { parentId: string; initiativeId: string },
+): Promise<InitiativeRelation> {
+  const result = await client.request<CreateInitiativeRelationMutation>(
+    CreateInitiativeRelationDocument,
+    {
+      input: {
+        initiativeId: input.parentId,
+        relatedInitiativeId: input.initiativeId,
+      },
+    },
+  );
+
+  if (
+    !result.initiativeRelationCreate.success ||
+    !result.initiativeRelationCreate.initiativeRelation
+  ) {
+    throw new Error(
+      `Failed to create initiative relation from "${input.parentId}" to "${input.initiativeId}"`,
+    );
+  }
+
+  return result.initiativeRelationCreate.initiativeRelation;
+}
+
+export async function deleteInitiativeRelation(
+  client: GraphQLClient,
+  id: string,
+): Promise<DeletedInitiativeRelation> {
+  const result = await client.request<DeleteInitiativeRelationMutation>(
+    DeleteInitiativeRelationDocument,
+    { id },
+  );
+
+  if (
+    !result.initiativeRelationDelete.success ||
+    !result.initiativeRelationDelete.entityId
+  ) {
+    throw new Error(`Failed to delete initiative relation "${id}"`);
+  }
+
+  return {
+    id: result.initiativeRelationDelete.entityId,
+    success: true,
+  };
+}

--- a/src/services/initiative-relation-service.ts
+++ b/src/services/initiative-relation-service.ts
@@ -12,14 +12,14 @@ import {
 
 export async function createInitiativeRelation(
   client: GraphQLClient,
-  input: { parentId: string; initiativeId: string },
+  input: { parentId: string; childId: string },
 ): Promise<InitiativeRelation> {
   const result = await client.request<CreateInitiativeRelationMutation>(
     CreateInitiativeRelationDocument,
     {
       input: {
         initiativeId: input.parentId,
-        relatedInitiativeId: input.initiativeId,
+        relatedInitiativeId: input.childId,
       },
     },
   );
@@ -29,7 +29,7 @@ export async function createInitiativeRelation(
     !result.initiativeRelationCreate.initiativeRelation
   ) {
     throw new Error(
-      `Failed to create initiative relation from "${input.parentId}" to "${input.initiativeId}"`,
+      `Failed to create initiative relation from "${input.parentId}" to "${input.childId}"`,
     );
   }
 

--- a/src/services/initiative-service.ts
+++ b/src/services/initiative-service.ts
@@ -1,0 +1,189 @@
+import type { GraphQLClient } from "../client/graphql-client.js";
+import { invalidParameterError } from "../common/errors.js";
+import type {
+  ArchivedInitiative,
+  CreatedInitiative,
+  DeletedInitiative,
+  InitiativeDetail,
+  InitiativeListItem,
+  PaginatedResult,
+  UnarchivedInitiative,
+  UpdatedInitiative,
+} from "../common/types.js";
+import {
+  ArchiveInitiativeDocument,
+  type ArchiveInitiativeMutation,
+  CreateInitiativeDocument,
+  type CreateInitiativeMutation,
+  DeleteInitiativeDocument,
+  type DeleteInitiativeMutation,
+  GetInitiativeDocument,
+  type GetInitiativeQuery,
+  type InitiativeCreateInput,
+  type InitiativeUpdateInput,
+  ListInitiativesDocument,
+  type ListInitiativesQuery,
+  type ListInitiativesQueryVariables,
+  UnarchiveInitiativeDocument,
+  type UnarchiveInitiativeMutation,
+  UpdateInitiativeDocument,
+  type UpdateInitiativeMutation,
+} from "../gql/graphql.js";
+
+export interface InitiativeListOptions {
+  limit?: number;
+  after?: string;
+  includeArchived?: boolean;
+  filter?: ListInitiativesQueryVariables["filter"];
+  orderBy?: ListInitiativesQueryVariables["orderBy"];
+}
+
+export async function listInitiatives(
+  client: GraphQLClient,
+  options: InitiativeListOptions = {},
+): Promise<PaginatedResult<InitiativeListItem>> {
+  const {
+    limit = 50,
+    after,
+    includeArchived = false,
+    filter,
+    orderBy,
+  } = options;
+
+  const result = await client.request<ListInitiativesQuery>(
+    ListInitiativesDocument,
+    {
+      first: limit,
+      after,
+      includeArchived,
+      filter,
+      orderBy,
+    },
+  );
+
+  return {
+    nodes: result.initiatives.nodes,
+    pageInfo: result.initiatives.pageInfo,
+  };
+}
+
+export async function getInitiative(
+  client: GraphQLClient,
+  id: string,
+): Promise<InitiativeDetail> {
+  const result = await client.request<GetInitiativeQuery>(
+    GetInitiativeDocument,
+    {
+      id,
+    },
+  );
+
+  if (!result.initiative) {
+    throw new Error(`Initiative with ID "${id}" not found`);
+  }
+
+  return result.initiative;
+}
+
+export async function createInitiative(
+  client: GraphQLClient,
+  input: InitiativeCreateInput,
+): Promise<CreatedInitiative> {
+  const result = await client.request<CreateInitiativeMutation>(
+    CreateInitiativeDocument,
+    {
+      input,
+    },
+  );
+
+  if (!result.initiativeCreate.success || !result.initiativeCreate.initiative) {
+    throw new Error(`Failed to create initiative "${input.name}"`);
+  }
+
+  return result.initiativeCreate.initiative;
+}
+
+export async function updateInitiative(
+  client: GraphQLClient,
+  id: string,
+  input: InitiativeUpdateInput,
+): Promise<UpdatedInitiative> {
+  const hasAtLeastOneField = Object.values(input).some(
+    (value) => value !== undefined,
+  );
+
+  if (!hasAtLeastOneField) {
+    throw invalidParameterError(
+      "update options",
+      "at least one update field must be provided",
+    );
+  }
+
+  const result = await client.request<UpdateInitiativeMutation>(
+    UpdateInitiativeDocument,
+    {
+      id,
+      input,
+    },
+  );
+
+  if (!result.initiativeUpdate.success || !result.initiativeUpdate.initiative) {
+    throw new Error(`Failed to update initiative "${id}"`);
+  }
+
+  return result.initiativeUpdate.initiative;
+}
+
+export async function archiveInitiative(
+  client: GraphQLClient,
+  id: string,
+): Promise<ArchivedInitiative> {
+  const result = await client.request<ArchiveInitiativeMutation>(
+    ArchiveInitiativeDocument,
+    { id },
+  );
+
+  if (!result.initiativeArchive.success || !result.initiativeArchive.entity) {
+    throw new Error(`Failed to archive initiative "${id}"`);
+  }
+
+  return result.initiativeArchive.entity;
+}
+
+export async function unarchiveInitiative(
+  client: GraphQLClient,
+  id: string,
+): Promise<UnarchivedInitiative> {
+  const result = await client.request<UnarchiveInitiativeMutation>(
+    UnarchiveInitiativeDocument,
+    { id },
+  );
+
+  if (
+    !result.initiativeUnarchive.success ||
+    !result.initiativeUnarchive.entity
+  ) {
+    throw new Error(`Failed to unarchive initiative "${id}"`);
+  }
+
+  return result.initiativeUnarchive.entity;
+}
+
+export async function deleteInitiative(
+  client: GraphQLClient,
+  id: string,
+): Promise<DeletedInitiative> {
+  const result = await client.request<DeleteInitiativeMutation>(
+    DeleteInitiativeDocument,
+    { id },
+  );
+
+  if (!result.initiativeDelete.success || !result.initiativeDelete.entityId) {
+    throw new Error(`Failed to delete initiative "${id}"`);
+  }
+
+  return {
+    id: result.initiativeDelete.entityId,
+    success: true,
+  };
+}

--- a/src/services/initiative-service.ts
+++ b/src/services/initiative-service.ts
@@ -36,6 +36,7 @@ export interface InitiativeListOptions {
   includeArchived?: boolean;
   filter?: ListInitiativesQueryVariables["filter"];
   orderBy?: ListInitiativesQueryVariables["orderBy"];
+  sort?: ListInitiativesQueryVariables["sort"];
 }
 
 export async function listInitiatives(
@@ -48,6 +49,7 @@ export async function listInitiatives(
     includeArchived = false,
     filter,
     orderBy,
+    sort,
   } = options;
 
   const result = await client.request<ListInitiativesQuery>(
@@ -58,6 +60,7 @@ export async function listInitiatives(
       includeArchived,
       filter,
       orderBy,
+      sort,
     },
   );
 

--- a/src/services/initiative-update-service.ts
+++ b/src/services/initiative-update-service.ts
@@ -1,0 +1,160 @@
+import type { GraphQLClient } from "../client/graphql-client.js";
+import { invalidParameterError } from "../common/errors.js";
+import type {
+  ArchivedInitiativeUpdate,
+  CreatedInitiativeUpdate,
+  InitiativeUpdateDetail,
+  InitiativeUpdateListItem,
+  PaginatedResult,
+  UnarchivedInitiativeUpdate,
+  UpdatedInitiativeUpdate,
+} from "../common/types.js";
+import {
+  ArchiveInitiativeUpdateDocument,
+  type ArchiveInitiativeUpdateMutation,
+  CreateInitiativeUpdateDocument,
+  type CreateInitiativeUpdateMutation,
+  GetInitiativeUpdateDocument,
+  type GetInitiativeUpdateQuery,
+  type InitiativeUpdateCreateInput,
+  type InitiativeUpdateUpdateInput,
+  ListInitiativeUpdatesDocument,
+  type ListInitiativeUpdatesQuery,
+  UnarchiveInitiativeUpdateDocument,
+  type UnarchiveInitiativeUpdateMutation,
+  UpdateInitiativeUpdateDocument,
+  type UpdateInitiativeUpdateMutation,
+} from "../gql/graphql.js";
+
+interface InitiativeUpdateListOptions {
+  initiativeId: string;
+  limit?: number;
+  after?: string;
+  includeArchived?: boolean;
+}
+
+export async function listInitiativeUpdates(
+  client: GraphQLClient,
+  options: InitiativeUpdateListOptions,
+): Promise<PaginatedResult<InitiativeUpdateListItem>> {
+  const { initiativeId, limit = 50, after, includeArchived = false } = options;
+
+  const result = await client.request<ListInitiativeUpdatesQuery>(
+    ListInitiativeUpdatesDocument,
+    {
+      initiativeId,
+      first: limit,
+      after,
+      includeArchived,
+    },
+  );
+
+  return {
+    nodes: result.initiativeUpdates.nodes,
+    pageInfo: result.initiativeUpdates.pageInfo,
+  };
+}
+
+export async function getInitiativeUpdate(
+  client: GraphQLClient,
+  id: string,
+): Promise<InitiativeUpdateDetail> {
+  const result = await client.request<GetInitiativeUpdateQuery>(
+    GetInitiativeUpdateDocument,
+    { id },
+  );
+
+  if (!result.initiativeUpdate) {
+    throw new Error(`Initiative update with ID "${id}" not found`);
+  }
+
+  return result.initiativeUpdate;
+}
+
+export async function createInitiativeUpdate(
+  client: GraphQLClient,
+  input: InitiativeUpdateCreateInput,
+): Promise<CreatedInitiativeUpdate> {
+  const result = await client.request<CreateInitiativeUpdateMutation>(
+    CreateInitiativeUpdateDocument,
+    { input },
+  );
+
+  if (
+    !result.initiativeUpdateCreate.success ||
+    !result.initiativeUpdateCreate.initiativeUpdate
+  ) {
+    throw new Error("Failed to create initiative update");
+  }
+
+  return result.initiativeUpdateCreate.initiativeUpdate;
+}
+
+export async function updateInitiativeUpdate(
+  client: GraphQLClient,
+  id: string,
+  input: InitiativeUpdateUpdateInput,
+): Promise<UpdatedInitiativeUpdate> {
+  const hasAtLeastOneField = Object.values(input).some(
+    (value) => value !== undefined,
+  );
+
+  if (!hasAtLeastOneField) {
+    throw invalidParameterError(
+      "update options",
+      "at least one update field must be provided",
+    );
+  }
+
+  const result = await client.request<UpdateInitiativeUpdateMutation>(
+    UpdateInitiativeUpdateDocument,
+    { id, input },
+  );
+
+  if (
+    !result.initiativeUpdateUpdate.success ||
+    !result.initiativeUpdateUpdate.initiativeUpdate
+  ) {
+    throw new Error(`Failed to update initiative update "${id}"`);
+  }
+
+  return result.initiativeUpdateUpdate.initiativeUpdate;
+}
+
+export async function archiveInitiativeUpdate(
+  client: GraphQLClient,
+  id: string,
+): Promise<ArchivedInitiativeUpdate> {
+  const result = await client.request<ArchiveInitiativeUpdateMutation>(
+    ArchiveInitiativeUpdateDocument,
+    { id },
+  );
+
+  if (
+    !result.initiativeUpdateArchive.success ||
+    !result.initiativeUpdateArchive.entity
+  ) {
+    throw new Error(`Failed to archive initiative update "${id}"`);
+  }
+
+  return result.initiativeUpdateArchive.entity;
+}
+
+export async function unarchiveInitiativeUpdate(
+  client: GraphQLClient,
+  id: string,
+): Promise<UnarchivedInitiativeUpdate> {
+  const result = await client.request<UnarchiveInitiativeUpdateMutation>(
+    UnarchiveInitiativeUpdateDocument,
+    { id },
+  );
+
+  if (
+    !result.initiativeUpdateUnarchive.success ||
+    !result.initiativeUpdateUnarchive.entity
+  ) {
+    throw new Error(`Failed to unarchive initiative update "${id}"`);
+  }
+
+  return result.initiativeUpdateUnarchive.entity;
+}

--- a/src/services/initiative-update-service.ts
+++ b/src/services/initiative-update-service.ts
@@ -26,7 +26,7 @@ import {
   type UpdateInitiativeUpdateMutation,
 } from "../gql/graphql.js";
 
-interface InitiativeUpdateListOptions {
+export interface InitiativeUpdateListOptions {
   initiativeId: string;
   limit?: number;
   after?: string;

--- a/tests/unit/commands/initiatives.test.ts
+++ b/tests/unit/commands/initiatives.test.ts
@@ -333,7 +333,7 @@ describe("initiative updates wiring", () => {
     );
   });
 
-  it("wires updates create", async () => {
+  it("wires updates create with title positional", async () => {
     const program = createProgram();
 
     await program.parseAsync([
@@ -342,6 +342,7 @@ describe("initiative updates wiring", () => {
       "initiatives",
       "updates",
       "create",
+      "Weekly update",
       "--initiative",
       "Growth",
       "--body",
@@ -354,6 +355,7 @@ describe("initiative updates wiring", () => {
       expect.anything(),
       expect.objectContaining({
         initiativeId: "resolved-initiative-uuid",
+        title: "Weekly update",
         body: "Steady progress",
       }),
     );

--- a/tests/unit/commands/initiatives.test.ts
+++ b/tests/unit/commands/initiatives.test.ts
@@ -139,7 +139,7 @@ describe("initiatives list", () => {
     vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
   });
 
-  it("parses and forwards includeArchived and sort", async () => {
+  it("parses and forwards includeArchived and supported sort", async () => {
     const program = createProgram();
 
     await program.parseAsync([
@@ -150,8 +150,6 @@ describe("initiatives list", () => {
       "--include-archived",
       "--sort-by",
       "updatedAt",
-      "--sort-order",
-      "desc",
       "--limit",
       "5",
     ]);
@@ -183,6 +181,48 @@ describe("initiatives list", () => {
 
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("Invalid --sort-order"),
+    );
+    expect(listInitiatives).not.toHaveBeenCalled();
+  });
+
+  it("rejects unsupported sort-by values", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "list",
+      "--sort-by",
+      "name",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "not supported by current Linear initiatives API",
+      ),
+    );
+    expect(listInitiatives).not.toHaveBeenCalled();
+  });
+
+  it("rejects sort-order because API does not support direction", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "list",
+      "--sort-by",
+      "updatedAt",
+      "--sort-order",
+      "desc",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "is not supported by current Linear initiatives API",
+      ),
     );
     expect(listInitiatives).not.toHaveBeenCalled();
   });

--- a/tests/unit/commands/initiatives.test.ts
+++ b/tests/unit/commands/initiatives.test.ts
@@ -220,6 +220,41 @@ describe("initiatives list", () => {
       }),
     );
   });
+
+  it("rejects unsupported list expand flags explicitly", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "list",
+      "--with-projects",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("not supported for initiatives list yet"),
+    );
+    expect(listInitiatives).not.toHaveBeenCalled();
+  });
+
+  it("rejects --parent filter explicitly", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "list",
+      "--parent",
+      "Growth",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("--parent"),
+    );
+    expect(listInitiatives).not.toHaveBeenCalled();
+  });
 });
 
 describe("initiatives update", () => {

--- a/tests/unit/commands/initiatives.test.ts
+++ b/tests/unit/commands/initiatives.test.ts
@@ -139,7 +139,7 @@ describe("initiatives list", () => {
     vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
   });
 
-  it("parses and forwards includeArchived and supported sort", async () => {
+  it("parses and forwards includeArchived and sort", async () => {
     const program = createProgram();
 
     await program.parseAsync([
@@ -150,6 +150,8 @@ describe("initiatives list", () => {
       "--include-archived",
       "--sort-by",
       "updatedAt",
+      "--sort-order",
+      "desc",
       "--limit",
       "5",
     ]);
@@ -160,6 +162,14 @@ describe("initiatives list", () => {
         includeArchived: true,
         limit: 5,
         orderBy: "updatedAt",
+        sort: [
+          {
+            updatedAt: {
+              order: "Descending",
+              nulls: "last",
+            },
+          },
+        ],
       }),
     );
     expect(outputSuccess).toHaveBeenCalled();
@@ -181,48 +191,6 @@ describe("initiatives list", () => {
 
     expect(console.error).toHaveBeenCalledWith(
       expect.stringContaining("Invalid --sort-order"),
-    );
-    expect(listInitiatives).not.toHaveBeenCalled();
-  });
-
-  it("rejects unsupported sort-by values", async () => {
-    const program = createProgram();
-
-    await program.parseAsync([
-      "node",
-      "test",
-      "initiatives",
-      "list",
-      "--sort-by",
-      "name",
-    ]);
-
-    expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "not supported by current Linear initiatives API",
-      ),
-    );
-    expect(listInitiatives).not.toHaveBeenCalled();
-  });
-
-  it("rejects sort-order because API does not support direction", async () => {
-    const program = createProgram();
-
-    await program.parseAsync([
-      "node",
-      "test",
-      "initiatives",
-      "list",
-      "--sort-by",
-      "updatedAt",
-      "--sort-order",
-      "desc",
-    ]);
-
-    expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining(
-        "is not supported by current Linear initiatives API",
-      ),
     );
     expect(listInitiatives).not.toHaveBeenCalled();
   });
@@ -400,7 +368,7 @@ describe("initiative updates wiring", () => {
     );
   });
 
-  it("wires updates create with title positional", async () => {
+  it("wires updates create", async () => {
     const program = createProgram();
 
     await program.parseAsync([
@@ -409,7 +377,6 @@ describe("initiative updates wiring", () => {
       "initiatives",
       "updates",
       "create",
-      "Weekly update",
       "--initiative",
       "Growth",
       "--body",
@@ -422,7 +389,6 @@ describe("initiative updates wiring", () => {
       expect.anything(),
       expect.objectContaining({
         initiativeId: "resolved-initiative-uuid",
-        title: "Weekly update",
         body: "Steady progress",
       }),
     );

--- a/tests/unit/commands/initiatives.test.ts
+++ b/tests/unit/commands/initiatives.test.ts
@@ -106,6 +106,7 @@ import { setupInitiativesCommands } from "../../../src/commands/initiatives/inde
 import { outputSuccess } from "../../../src/common/output.js";
 import { resolveInitiativeId } from "../../../src/resolvers/initiative-resolver.js";
 import { resolveProjectId } from "../../../src/resolvers/project-resolver.js";
+import { resolveUserId } from "../../../src/resolvers/user-resolver.js";
 import {
   createInitiativeProjectLink,
   deleteInitiativeProjectLink,
@@ -184,6 +185,32 @@ describe("initiatives list", () => {
       expect.stringContaining("Invalid --sort-order"),
     );
     expect(listInitiatives).not.toHaveBeenCalled();
+  });
+
+  it("forwards supported filters including resolved owner", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "list",
+      "--name",
+      "Growth",
+      "--owner",
+      "Alice",
+    ]);
+
+    expect(resolveUserId).toHaveBeenCalledWith(expect.anything(), "Alice");
+    expect(listInitiatives).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        filter: expect.objectContaining({
+          name: { eqIgnoreCase: "Growth" },
+          owner: { id: { eq: "resolved-user-uuid" } },
+        }),
+      }),
+    );
   });
 });
 

--- a/tests/unit/commands/initiatives.test.ts
+++ b/tests/unit/commands/initiatives.test.ts
@@ -131,6 +131,19 @@ function createProgram(): Command {
   return program;
 }
 
+describe("initiatives command registration", () => {
+  it("registers initiatives domain", () => {
+    const root = new Command();
+    root.option("--api-token <token>");
+    setupInitiativesCommands(root);
+
+    const cmd = root.commands.find(
+      (command) => command.name() === "initiatives",
+    );
+    expect(cmd).toBeDefined();
+  });
+});
+
 describe("initiatives list", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/tests/unit/commands/initiatives.test.ts
+++ b/tests/unit/commands/initiatives.test.ts
@@ -1,0 +1,361 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/common/context.js", () => ({
+  createContext: vi.fn(() => ({
+    gql: { request: vi.fn() },
+    sdk: { sdk: {} },
+  })),
+}));
+
+vi.mock("../../../src/common/output.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../src/common/output.js")>();
+  return {
+    ...actual,
+    outputSuccess: vi.fn(),
+  };
+});
+
+vi.mock("../../../src/resolvers/initiative-resolver.js", () => ({
+  resolveInitiativeId: vi.fn().mockResolvedValue("resolved-initiative-uuid"),
+  resolveInitiativeRelationId: vi
+    .fn()
+    .mockResolvedValue("resolved-relation-uuid"),
+  resolveInitiativeProjectLinkId: vi
+    .fn()
+    .mockResolvedValue("resolved-link-uuid"),
+}));
+
+vi.mock("../../../src/resolvers/project-resolver.js", () => ({
+  resolveProjectId: vi.fn().mockResolvedValue("resolved-project-uuid"),
+}));
+
+vi.mock("../../../src/resolvers/team-resolver.js", () => ({
+  resolveTeamId: vi.fn().mockResolvedValue("resolved-team-uuid"),
+}));
+
+vi.mock("../../../src/resolvers/user-resolver.js", () => ({
+  resolveUserId: vi.fn().mockResolvedValue("resolved-user-uuid"),
+}));
+
+vi.mock("../../../src/services/initiative-service.js", () => ({
+  listInitiatives: vi.fn().mockResolvedValue({
+    nodes: [],
+    pageInfo: { hasNextPage: false, endCursor: null },
+  }),
+  getInitiative: vi.fn().mockResolvedValue({ id: "resolved-initiative-uuid" }),
+  createInitiative: vi
+    .fn()
+    .mockResolvedValue({ id: "resolved-initiative-uuid" }),
+  updateInitiative: vi
+    .fn()
+    .mockResolvedValue({ id: "resolved-initiative-uuid" }),
+  archiveInitiative: vi
+    .fn()
+    .mockResolvedValue({ id: "resolved-initiative-uuid" }),
+  unarchiveInitiative: vi
+    .fn()
+    .mockResolvedValue({ id: "resolved-initiative-uuid" }),
+  deleteInitiative: vi
+    .fn()
+    .mockResolvedValue({ id: "resolved-initiative-uuid", success: true }),
+}));
+
+vi.mock("../../../src/services/initiative-relation-service.js", () => ({
+  createInitiativeRelation: vi
+    .fn()
+    .mockResolvedValue({ id: "resolved-relation-uuid" }),
+  deleteInitiativeRelation: vi
+    .fn()
+    .mockResolvedValue({ id: "resolved-relation-uuid", success: true }),
+}));
+
+vi.mock("../../../src/services/initiative-project-service.js", () => ({
+  createInitiativeProjectLink: vi
+    .fn()
+    .mockResolvedValue({ id: "resolved-link-uuid" }),
+  deleteInitiativeProjectLink: vi
+    .fn()
+    .mockResolvedValue({ id: "resolved-link-uuid", success: true }),
+}));
+
+vi.mock("../../../src/services/initiative-update-service.js", () => ({
+  listInitiativeUpdates: vi.fn().mockResolvedValue({
+    nodes: [],
+    pageInfo: { hasNextPage: false, endCursor: null },
+  }),
+  getInitiativeUpdate: vi
+    .fn()
+    .mockResolvedValue({ id: "resolved-update-uuid" }),
+  createInitiativeUpdate: vi
+    .fn()
+    .mockResolvedValue({ id: "resolved-update-uuid" }),
+  updateInitiativeUpdate: vi
+    .fn()
+    .mockResolvedValue({ id: "resolved-update-uuid" }),
+  archiveInitiativeUpdate: vi
+    .fn()
+    .mockResolvedValue({ id: "resolved-update-uuid" }),
+  unarchiveInitiativeUpdate: vi
+    .fn()
+    .mockResolvedValue({ id: "resolved-update-uuid" }),
+}));
+
+import { setupInitiativesCommands } from "../../../src/commands/initiatives/index.js";
+import { outputSuccess } from "../../../src/common/output.js";
+import { resolveInitiativeId } from "../../../src/resolvers/initiative-resolver.js";
+import { resolveProjectId } from "../../../src/resolvers/project-resolver.js";
+import {
+  createInitiativeProjectLink,
+  deleteInitiativeProjectLink,
+} from "../../../src/services/initiative-project-service.js";
+import {
+  createInitiativeRelation,
+  deleteInitiativeRelation,
+} from "../../../src/services/initiative-relation-service.js";
+import {
+  listInitiatives,
+  updateInitiative,
+} from "../../../src/services/initiative-service.js";
+import {
+  createInitiativeUpdate,
+  listInitiativeUpdates,
+} from "../../../src/services/initiative-update-service.js";
+
+function createProgram(): Command {
+  const program = new Command();
+  program.option("--api-token <token>");
+  setupInitiativesCommands(program);
+  return program;
+}
+
+describe("initiatives list", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("parses and forwards includeArchived and sort", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "list",
+      "--include-archived",
+      "--sort-by",
+      "updatedAt",
+      "--sort-order",
+      "desc",
+      "--limit",
+      "5",
+    ]);
+
+    expect(listInitiatives).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        includeArchived: true,
+        limit: 5,
+        orderBy: "updatedAt",
+      }),
+    );
+    expect(outputSuccess).toHaveBeenCalled();
+  });
+
+  it("validates invalid sort-order", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "list",
+      "--sort-by",
+      "updatedAt",
+      "--sort-order",
+      "sideways",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid --sort-order"),
+    );
+    expect(listInitiatives).not.toHaveBeenCalled();
+  });
+});
+
+describe("initiatives update", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("rejects no-op update", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "update",
+      "Growth",
+    ]);
+
+    expect(updateInitiative).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("at least one option must be provided"),
+    );
+  });
+});
+
+describe("initiative relations and projects wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("wires relate", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "relate",
+      "Parent",
+      "Child",
+    ]);
+
+    expect(resolveInitiativeId).toHaveBeenCalledTimes(2);
+    expect(createInitiativeRelation).toHaveBeenCalledWith(expect.anything(), {
+      parentId: "resolved-initiative-uuid",
+      childId: "resolved-initiative-uuid",
+    });
+  });
+
+  it("wires unrelate", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "unrelate",
+      "Parent",
+      "Child",
+    ]);
+
+    expect(deleteInitiativeRelation).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-relation-uuid",
+    );
+  });
+
+  it("wires add-project", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "add-project",
+      "Growth",
+      "Website",
+    ]);
+
+    expect(resolveProjectId).toHaveBeenCalledWith(expect.anything(), "Website");
+    expect(createInitiativeProjectLink).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        initiativeId: "resolved-initiative-uuid",
+        projectId: "resolved-project-uuid",
+      },
+    );
+  });
+
+  it("wires remove-project", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "remove-project",
+      "Growth",
+      "Website",
+    ]);
+
+    expect(deleteInitiativeProjectLink).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-link-uuid",
+    );
+  });
+});
+
+describe("initiative updates wiring", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("wires updates list", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "updates",
+      "list",
+      "--initiative",
+      "Growth",
+      "--include-archived",
+      "--limit",
+      "7",
+    ]);
+
+    expect(listInitiativeUpdates).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        initiativeId: "resolved-initiative-uuid",
+        includeArchived: true,
+        limit: 7,
+      }),
+    );
+  });
+
+  it("wires updates create", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "updates",
+      "create",
+      "--initiative",
+      "Growth",
+      "--body",
+      "Steady progress",
+      "--health",
+      "onTrack",
+    ]);
+
+    expect(createInitiativeUpdate).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        initiativeId: "resolved-initiative-uuid",
+        body: "Steady progress",
+      }),
+    );
+  });
+});

--- a/tests/unit/resolvers/initiative-resolver.test.ts
+++ b/tests/unit/resolvers/initiative-resolver.test.ts
@@ -1,0 +1,232 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import type { LinearSdkClient } from "../../../src/client/linear-client.js";
+import {
+  resolveInitiativeId,
+  resolveInitiativeProjectLinkId,
+  resolveInitiativeRelationId,
+} from "../../../src/resolvers/initiative-resolver.js";
+
+type InitiativeLookupNode = {
+  id: string;
+  name: string;
+};
+
+function mockSdkClient(nodes: InitiativeLookupNode[]) {
+  return {
+    sdk: {
+      initiatives: vi.fn().mockResolvedValue({ nodes }),
+    },
+  } as unknown as LinearSdkClient;
+}
+
+function mockGqlClient(response: Record<string, unknown>) {
+  return {
+    request: vi.fn().mockResolvedValue(response),
+  } as unknown as GraphQLClient;
+}
+
+describe("resolveInitiativeId", () => {
+  it("returns UUID as-is", async () => {
+    const sdk = mockSdkClient([]);
+    const result = await resolveInitiativeId(
+      sdk,
+      "550e8400-e29b-41d4-a716-446655440000",
+    );
+
+    expect(result).toBe("550e8400-e29b-41d4-a716-446655440000");
+    expect(sdk.sdk.initiatives).not.toHaveBeenCalled();
+  });
+
+  it("resolves initiative name", async () => {
+    const sdk = mockSdkClient([{ id: "init-1", name: "Growth" }]);
+
+    await expect(resolveInitiativeId(sdk, "growth")).resolves.toBe("init-1");
+    expect(sdk.sdk.initiatives).toHaveBeenCalledWith({
+      filter: { name: { eqIgnoreCase: "growth" } },
+      first: 20,
+    });
+  });
+
+  it("throws not found", async () => {
+    const sdk = mockSdkClient([]);
+
+    await expect(resolveInitiativeId(sdk, "Missing")).rejects.toThrow(
+      'Initiative "Missing" not found',
+    );
+  });
+
+  it("throws ambiguity without scope", async () => {
+    const sdk = mockSdkClient([
+      { id: "init-1", name: "Growth" },
+      { id: "init-2", name: "Growth" },
+    ]);
+
+    await expect(resolveInitiativeId(sdk, "Growth")).rejects.toThrow(
+      "Multiple initiatives found matching",
+    );
+    await expect(resolveInitiativeId(sdk, "Growth")).rejects.toThrow(
+      "provide --team or --owner, or use UUID",
+    );
+  });
+
+  it("resolves scoped disambiguation", async () => {
+    const sdk = mockSdkClient([{ id: "init-2", name: "Growth" }]);
+
+    await expect(
+      resolveInitiativeId(sdk, "Growth", {
+        teamId: "team-1",
+        ownerId: "user-1",
+      }),
+    ).resolves.toBe("init-2");
+
+    expect(sdk.sdk.initiatives).toHaveBeenCalledWith({
+      filter: {
+        and: [
+          { name: { eqIgnoreCase: "Growth" } },
+          { teams: { some: { id: { eq: "team-1" } } } },
+          { owner: { id: { eq: "user-1" } } },
+        ],
+      },
+      first: 20,
+    });
+  });
+});
+
+describe("resolveInitiativeRelationId", () => {
+  it("returns relation id for exact parent-child pair", async () => {
+    const gql = mockGqlClient({
+      parent: { id: "parent-id" },
+      child: { id: "child-id" },
+      initiativeRelations: {
+        nodes: [
+          {
+            id: "rel-other",
+            initiative: { id: "someone-else" },
+            relatedInitiative: { id: "child-id" },
+          },
+          {
+            id: "rel-1",
+            initiative: { id: "parent-id" },
+            relatedInitiative: { id: "child-id" },
+          },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+
+    await expect(
+      resolveInitiativeRelationId(gql, "parent-id", "child-id"),
+    ).resolves.toBe("rel-1");
+  });
+
+  it("throws when relation pair does not exist", async () => {
+    const gql = mockGqlClient({
+      parent: { id: "parent-id" },
+      child: { id: "child-id" },
+      initiativeRelations: {
+        nodes: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+
+    await expect(
+      resolveInitiativeRelationId(gql, "parent-id", "child-id"),
+    ).rejects.toThrow(
+      'Initiative relation "between parent-id and child-id" not found',
+    );
+  });
+
+  it("throws explicit truncation guard when unmatched and has next page", async () => {
+    const gql = mockGqlClient({
+      parent: { id: "parent-id" },
+      child: { id: "child-id" },
+      initiativeRelations: {
+        nodes: [
+          {
+            id: "rel-other",
+            initiative: { id: "wrong-parent" },
+            relatedInitiative: { id: "wrong-child" },
+          },
+        ],
+        pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+      },
+    });
+
+    await expect(
+      resolveInitiativeRelationId(gql, "parent-id", "child-id"),
+    ).rejects.toThrow("lookup truncated");
+    await expect(
+      resolveInitiativeRelationId(gql, "parent-id", "child-id"),
+    ).rejects.toThrow("use UUID path or add pagination support");
+  });
+});
+
+describe("resolveInitiativeProjectLinkId", () => {
+  it("returns link id for exact initiative-project pair", async () => {
+    const gql = mockGqlClient({
+      initiative: { id: "init-id" },
+      project: { id: "project-id" },
+      initiativeToProjects: {
+        nodes: [
+          {
+            id: "link-other",
+            initiative: { id: "another-init" },
+            project: { id: "project-id" },
+          },
+          {
+            id: "link-1",
+            initiative: { id: "init-id" },
+            project: { id: "project-id" },
+          },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+
+    await expect(
+      resolveInitiativeProjectLinkId(gql, "init-id", "project-id"),
+    ).resolves.toBe("link-1");
+  });
+
+  it("throws when initiative-project pair does not exist", async () => {
+    const gql = mockGqlClient({
+      initiative: { id: "init-id" },
+      project: { id: "project-id" },
+      initiativeToProjects: {
+        nodes: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+
+    await expect(
+      resolveInitiativeProjectLinkId(gql, "init-id", "project-id"),
+    ).rejects.toThrow(
+      'Initiative project link "between init-id and project-id" not found',
+    );
+  });
+
+  it("throws explicit truncation guard when unmatched and has next page", async () => {
+    const gql = mockGqlClient({
+      initiative: { id: "init-id" },
+      project: { id: "project-id" },
+      initiativeToProjects: {
+        nodes: [
+          {
+            id: "link-other",
+            initiative: { id: "wrong-init" },
+            project: { id: "wrong-project" },
+          },
+        ],
+        pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+      },
+    });
+
+    await expect(
+      resolveInitiativeProjectLinkId(gql, "init-id", "project-id"),
+    ).rejects.toThrow("lookup truncated");
+    await expect(
+      resolveInitiativeProjectLinkId(gql, "init-id", "project-id"),
+    ).rejects.toThrow("use UUID path or add pagination support");
+  });
+});

--- a/tests/unit/resolvers/initiative-resolver.test.ts
+++ b/tests/unit/resolvers/initiative-resolver.test.ts
@@ -26,6 +26,18 @@ function mockGqlClient(response: Record<string, unknown>) {
   } as unknown as GraphQLClient;
 }
 
+function mockPagedGqlClient(responses: Array<Record<string, unknown>>) {
+  const request = vi.fn();
+
+  responses.forEach((response) => {
+    request.mockResolvedValueOnce(response);
+  });
+
+  return {
+    request,
+  } as unknown as GraphQLClient;
+}
+
 describe("resolveInitiativeId", () => {
   it("returns UUID as-is", async () => {
     const sdk = mockSdkClient([]);
@@ -137,28 +149,79 @@ describe("resolveInitiativeRelationId", () => {
     );
   });
 
-  it("throws explicit truncation guard when unmatched and has next page", async () => {
-    const gql = mockGqlClient({
-      parent: { id: "parent-id" },
-      child: { id: "child-id" },
-      initiativeRelations: {
-        nodes: [
-          {
-            id: "rel-other",
-            initiative: { id: "wrong-parent" },
-            relatedInitiative: { id: "wrong-child" },
-          },
-        ],
-        pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+  it("continues pagination and finds relation on later page", async () => {
+    const gql = mockPagedGqlClient([
+      {
+        parent: { id: "parent-id" },
+        child: { id: "child-id" },
+        initiativeRelations: {
+          nodes: [
+            {
+              id: "rel-other",
+              initiative: { id: "wrong-parent" },
+              relatedInitiative: { id: "wrong-child" },
+            },
+          ],
+          pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+        },
       },
-    });
+      {
+        parent: { id: "parent-id" },
+        child: { id: "child-id" },
+        initiativeRelations: {
+          nodes: [
+            {
+              id: "rel-2",
+              initiative: { id: "parent-id" },
+              relatedInitiative: { id: "child-id" },
+            },
+          ],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+    ]);
 
     await expect(
       resolveInitiativeRelationId(gql, "parent-id", "child-id"),
-    ).rejects.toThrow("lookup truncated");
+    ).resolves.toBe("rel-2");
+
+    expect(gql.request).toHaveBeenNthCalledWith(1, expect.anything(), {
+      parentId: "parent-id",
+      childId: "child-id",
+      after: undefined,
+    });
+    expect(gql.request).toHaveBeenNthCalledWith(2, expect.anything(), {
+      parentId: "parent-id",
+      childId: "child-id",
+      after: "cursor-1",
+    });
+  });
+
+  it("throws when relation pair is not found after exhausting pages", async () => {
+    const gql = mockPagedGqlClient([
+      {
+        parent: { id: "parent-id" },
+        child: { id: "child-id" },
+        initiativeRelations: {
+          nodes: [],
+          pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+        },
+      },
+      {
+        parent: { id: "parent-id" },
+        child: { id: "child-id" },
+        initiativeRelations: {
+          nodes: [],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+    ]);
+
     await expect(
       resolveInitiativeRelationId(gql, "parent-id", "child-id"),
-    ).rejects.toThrow("use UUID path or add pagination support");
+    ).rejects.toThrow(
+      'Initiative relation "between parent-id and child-id" not found',
+    );
   });
 });
 
@@ -206,27 +269,78 @@ describe("resolveInitiativeProjectLinkId", () => {
     );
   });
 
-  it("throws explicit truncation guard when unmatched and has next page", async () => {
-    const gql = mockGqlClient({
-      initiative: { id: "init-id" },
-      project: { id: "project-id" },
-      initiativeToProjects: {
-        nodes: [
-          {
-            id: "link-other",
-            initiative: { id: "wrong-init" },
-            project: { id: "wrong-project" },
-          },
-        ],
-        pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+  it("continues pagination and finds link on later page", async () => {
+    const gql = mockPagedGqlClient([
+      {
+        initiative: { id: "init-id" },
+        project: { id: "project-id" },
+        initiativeToProjects: {
+          nodes: [
+            {
+              id: "link-other",
+              initiative: { id: "wrong-init" },
+              project: { id: "wrong-project" },
+            },
+          ],
+          pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+        },
       },
-    });
+      {
+        initiative: { id: "init-id" },
+        project: { id: "project-id" },
+        initiativeToProjects: {
+          nodes: [
+            {
+              id: "link-2",
+              initiative: { id: "init-id" },
+              project: { id: "project-id" },
+            },
+          ],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+    ]);
 
     await expect(
       resolveInitiativeProjectLinkId(gql, "init-id", "project-id"),
-    ).rejects.toThrow("lookup truncated");
+    ).resolves.toBe("link-2");
+
+    expect(gql.request).toHaveBeenNthCalledWith(1, expect.anything(), {
+      initiativeId: "init-id",
+      projectId: "project-id",
+      after: undefined,
+    });
+    expect(gql.request).toHaveBeenNthCalledWith(2, expect.anything(), {
+      initiativeId: "init-id",
+      projectId: "project-id",
+      after: "cursor-1",
+    });
+  });
+
+  it("throws when initiative-project pair is not found after exhausting pages", async () => {
+    const gql = mockPagedGqlClient([
+      {
+        initiative: { id: "init-id" },
+        project: { id: "project-id" },
+        initiativeToProjects: {
+          nodes: [],
+          pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+        },
+      },
+      {
+        initiative: { id: "init-id" },
+        project: { id: "project-id" },
+        initiativeToProjects: {
+          nodes: [],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+    ]);
+
     await expect(
       resolveInitiativeProjectLinkId(gql, "init-id", "project-id"),
-    ).rejects.toThrow("use UUID path or add pagination support");
+    ).rejects.toThrow(
+      'Initiative project link "between init-id and project-id" not found',
+    );
   });
 });

--- a/tests/unit/services/initiative-project-service.test.ts
+++ b/tests/unit/services/initiative-project-service.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import {
+  createInitiativeProjectLink,
+  deleteInitiativeProjectLink,
+} from "../../../src/services/initiative-project-service.js";
+
+function mockGqlClient(response: Record<string, unknown>): GraphQLClient {
+  return {
+    request: vi.fn().mockResolvedValue(response),
+  } as unknown as GraphQLClient;
+}
+
+describe("createInitiativeProjectLink", () => {
+  it("returns created initiative-project link on success", async () => {
+    const link = {
+      id: "link-1",
+      initiative: { id: "init-1", name: "Growth" },
+      project: { id: "proj-1", name: "Website" },
+    };
+    const client = mockGqlClient({
+      initiativeToProjectCreate: {
+        success: true,
+        initiativeToProject: link,
+      },
+    });
+
+    await expect(
+      createInitiativeProjectLink(client, {
+        initiativeId: "init-1",
+        projectId: "proj-1",
+      }),
+    ).resolves.toEqual(link);
+  });
+
+  it("throws when mutation success is false or payload missing", async () => {
+    const client = mockGqlClient({
+      initiativeToProjectCreate: {
+        success: true,
+        initiativeToProject: null,
+      },
+    });
+
+    await expect(
+      createInitiativeProjectLink(client, {
+        initiativeId: "init-1",
+        projectId: "proj-1",
+      }),
+    ).rejects.toThrow(
+      'Failed to create initiative-project link for initiative "init-1" and project "proj-1"',
+    );
+  });
+});
+
+describe("deleteInitiativeProjectLink", () => {
+  it("returns id and success on delete", async () => {
+    const client = mockGqlClient({
+      initiativeToProjectDelete: {
+        success: true,
+        entityId: "link-1",
+      },
+    });
+
+    await expect(
+      deleteInitiativeProjectLink(client, "link-1"),
+    ).resolves.toEqual({
+      id: "link-1",
+      success: true,
+    });
+  });
+
+  it("throws when mutation success is false or payload missing", async () => {
+    const client = mockGqlClient({
+      initiativeToProjectDelete: {
+        success: true,
+        entityId: null,
+      },
+    });
+
+    await expect(deleteInitiativeProjectLink(client, "link-1")).rejects.toThrow(
+      'Failed to delete initiative-project link "link-1"',
+    );
+  });
+});

--- a/tests/unit/services/initiative-project-service.test.ts
+++ b/tests/unit/services/initiative-project-service.test.ts
@@ -1,14 +1,25 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import {
+  CreateInitiativeToProjectDocument,
+  DeleteInitiativeToProjectDocument,
+} from "../../../src/gql/graphql.js";
+import {
   createInitiativeProjectLink,
   deleteInitiativeProjectLink,
 } from "../../../src/services/initiative-project-service.js";
 
-function mockGqlClient(response: Record<string, unknown>): GraphQLClient {
+function mockGqlClient(response: Record<string, unknown>): {
+  client: GraphQLClient;
+  request: ReturnType<typeof vi.fn>;
+} {
+  const request = vi.fn().mockResolvedValue(response);
   return {
-    request: vi.fn().mockResolvedValue(response),
-  } as unknown as GraphQLClient;
+    client: {
+      request,
+    } as unknown as GraphQLClient,
+    request,
+  };
 }
 
 describe("createInitiativeProjectLink", () => {
@@ -18,7 +29,7 @@ describe("createInitiativeProjectLink", () => {
       initiative: { id: "init-1", name: "Growth" },
       project: { id: "proj-1", name: "Website" },
     };
-    const client = mockGqlClient({
+    const { client, request } = mockGqlClient({
       initiativeToProjectCreate: {
         success: true,
         initiativeToProject: link,
@@ -31,10 +42,37 @@ describe("createInitiativeProjectLink", () => {
         projectId: "proj-1",
       }),
     ).resolves.toEqual(link);
+
+    expect(request).toHaveBeenCalledWith(CreateInitiativeToProjectDocument, {
+      input: {
+        initiativeId: "init-1",
+        projectId: "proj-1",
+      },
+    });
   });
 
-  it("throws when mutation success is false or payload missing", async () => {
-    const client = mockGqlClient({
+  it("throws when mutation success is false", async () => {
+    const { client } = mockGqlClient({
+      initiativeToProjectCreate: {
+        success: false,
+        initiativeToProject: {
+          id: "link-1",
+        },
+      },
+    });
+
+    await expect(
+      createInitiativeProjectLink(client, {
+        initiativeId: "init-1",
+        projectId: "proj-1",
+      }),
+    ).rejects.toThrow(
+      'Failed to create initiative-project link for initiative "init-1" and project "proj-1"',
+    );
+  });
+
+  it("throws when payload is missing", async () => {
+    const { client } = mockGqlClient({
       initiativeToProjectCreate: {
         success: true,
         initiativeToProject: null,
@@ -54,7 +92,7 @@ describe("createInitiativeProjectLink", () => {
 
 describe("deleteInitiativeProjectLink", () => {
   it("returns id and success on delete", async () => {
-    const client = mockGqlClient({
+    const { client, request } = mockGqlClient({
       initiativeToProjectDelete: {
         success: true,
         entityId: "link-1",
@@ -67,10 +105,27 @@ describe("deleteInitiativeProjectLink", () => {
       id: "link-1",
       success: true,
     });
+
+    expect(request).toHaveBeenCalledWith(DeleteInitiativeToProjectDocument, {
+      id: "link-1",
+    });
   });
 
-  it("throws when mutation success is false or payload missing", async () => {
-    const client = mockGqlClient({
+  it("throws when mutation success is false", async () => {
+    const { client } = mockGqlClient({
+      initiativeToProjectDelete: {
+        success: false,
+        entityId: "link-1",
+      },
+    });
+
+    await expect(deleteInitiativeProjectLink(client, "link-1")).rejects.toThrow(
+      'Failed to delete initiative-project link "link-1"',
+    );
+  });
+
+  it("throws when payload is missing", async () => {
+    const { client } = mockGqlClient({
       initiativeToProjectDelete: {
         success: true,
         entityId: null,

--- a/tests/unit/services/initiative-relation-service.test.ts
+++ b/tests/unit/services/initiative-relation-service.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import {
+  createInitiativeRelation,
+  deleteInitiativeRelation,
+} from "../../../src/services/initiative-relation-service.js";
+
+function mockGqlClient(response: Record<string, unknown>): GraphQLClient {
+  return {
+    request: vi.fn().mockResolvedValue(response),
+  } as unknown as GraphQLClient;
+}
+
+describe("createInitiativeRelation", () => {
+  it("returns created initiative relation on success", async () => {
+    const relation = {
+      id: "rel-1",
+      initiative: { id: "init-parent", name: "Parent" },
+      relatedInitiative: { id: "init-child", name: "Child" },
+    };
+    const client = mockGqlClient({
+      initiativeRelationCreate: {
+        success: true,
+        initiativeRelation: relation,
+      },
+    });
+
+    await expect(
+      createInitiativeRelation(client, {
+        parentId: "init-parent",
+        initiativeId: "init-child",
+      }),
+    ).resolves.toEqual(relation);
+  });
+
+  it("throws when mutation success is false or payload missing", async () => {
+    const client = mockGqlClient({
+      initiativeRelationCreate: {
+        success: true,
+        initiativeRelation: null,
+      },
+    });
+
+    await expect(
+      createInitiativeRelation(client, {
+        parentId: "init-parent",
+        initiativeId: "init-child",
+      }),
+    ).rejects.toThrow(
+      'Failed to create initiative relation from "init-parent" to "init-child"',
+    );
+  });
+});
+
+describe("deleteInitiativeRelation", () => {
+  it("returns id and success on delete", async () => {
+    const client = mockGqlClient({
+      initiativeRelationDelete: {
+        success: true,
+        entityId: "rel-1",
+      },
+    });
+
+    await expect(deleteInitiativeRelation(client, "rel-1")).resolves.toEqual({
+      id: "rel-1",
+      success: true,
+    });
+  });
+
+  it("throws when mutation success is false or payload missing", async () => {
+    const client = mockGqlClient({
+      initiativeRelationDelete: {
+        success: true,
+        entityId: null,
+      },
+    });
+
+    await expect(deleteInitiativeRelation(client, "rel-1")).rejects.toThrow(
+      'Failed to delete initiative relation "rel-1"',
+    );
+  });
+});

--- a/tests/unit/services/initiative-relation-service.test.ts
+++ b/tests/unit/services/initiative-relation-service.test.ts
@@ -1,14 +1,25 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import {
+  CreateInitiativeRelationDocument,
+  DeleteInitiativeRelationDocument,
+} from "../../../src/gql/graphql.js";
+import {
   createInitiativeRelation,
   deleteInitiativeRelation,
 } from "../../../src/services/initiative-relation-service.js";
 
-function mockGqlClient(response: Record<string, unknown>): GraphQLClient {
+function mockGqlClient(response: Record<string, unknown>): {
+  client: GraphQLClient;
+  request: ReturnType<typeof vi.fn>;
+} {
+  const request = vi.fn().mockResolvedValue(response);
   return {
-    request: vi.fn().mockResolvedValue(response),
-  } as unknown as GraphQLClient;
+    client: {
+      request,
+    } as unknown as GraphQLClient,
+    request,
+  };
 }
 
 describe("createInitiativeRelation", () => {
@@ -18,7 +29,7 @@ describe("createInitiativeRelation", () => {
       initiative: { id: "init-parent", name: "Parent" },
       relatedInitiative: { id: "init-child", name: "Child" },
     };
-    const client = mockGqlClient({
+    const { client, request } = mockGqlClient({
       initiativeRelationCreate: {
         success: true,
         initiativeRelation: relation,
@@ -28,13 +39,40 @@ describe("createInitiativeRelation", () => {
     await expect(
       createInitiativeRelation(client, {
         parentId: "init-parent",
-        initiativeId: "init-child",
+        childId: "init-child",
       }),
     ).resolves.toEqual(relation);
+
+    expect(request).toHaveBeenCalledWith(CreateInitiativeRelationDocument, {
+      input: {
+        initiativeId: "init-parent",
+        relatedInitiativeId: "init-child",
+      },
+    });
   });
 
-  it("throws when mutation success is false or payload missing", async () => {
-    const client = mockGqlClient({
+  it("throws when mutation success is false", async () => {
+    const { client } = mockGqlClient({
+      initiativeRelationCreate: {
+        success: false,
+        initiativeRelation: {
+          id: "rel-1",
+        },
+      },
+    });
+
+    await expect(
+      createInitiativeRelation(client, {
+        parentId: "init-parent",
+        childId: "init-child",
+      }),
+    ).rejects.toThrow(
+      'Failed to create initiative relation from "init-parent" to "init-child"',
+    );
+  });
+
+  it("throws when payload is missing", async () => {
+    const { client } = mockGqlClient({
       initiativeRelationCreate: {
         success: true,
         initiativeRelation: null,
@@ -44,7 +82,7 @@ describe("createInitiativeRelation", () => {
     await expect(
       createInitiativeRelation(client, {
         parentId: "init-parent",
-        initiativeId: "init-child",
+        childId: "init-child",
       }),
     ).rejects.toThrow(
       'Failed to create initiative relation from "init-parent" to "init-child"',
@@ -54,7 +92,7 @@ describe("createInitiativeRelation", () => {
 
 describe("deleteInitiativeRelation", () => {
   it("returns id and success on delete", async () => {
-    const client = mockGqlClient({
+    const { client, request } = mockGqlClient({
       initiativeRelationDelete: {
         success: true,
         entityId: "rel-1",
@@ -65,10 +103,27 @@ describe("deleteInitiativeRelation", () => {
       id: "rel-1",
       success: true,
     });
+
+    expect(request).toHaveBeenCalledWith(DeleteInitiativeRelationDocument, {
+      id: "rel-1",
+    });
   });
 
-  it("throws when mutation success is false or payload missing", async () => {
-    const client = mockGqlClient({
+  it("throws when mutation success is false", async () => {
+    const { client } = mockGqlClient({
+      initiativeRelationDelete: {
+        success: false,
+        entityId: "rel-1",
+      },
+    });
+
+    await expect(deleteInitiativeRelation(client, "rel-1")).rejects.toThrow(
+      'Failed to delete initiative relation "rel-1"',
+    );
+  });
+
+  it("throws when payload is missing", async () => {
+    const { client } = mockGqlClient({
       initiativeRelationDelete: {
         success: true,
         entityId: null,

--- a/tests/unit/services/initiative-service.test.ts
+++ b/tests/unit/services/initiative-service.test.ts
@@ -1,0 +1,193 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import {
+  archiveInitiative,
+  createInitiative,
+  deleteInitiative,
+  getInitiative,
+  listInitiatives,
+  unarchiveInitiative,
+  updateInitiative,
+} from "../../../src/services/initiative-service.js";
+
+function mockGqlClient(response: Record<string, unknown>): GraphQLClient {
+  return {
+    request: vi.fn().mockResolvedValue(response),
+  } as unknown as GraphQLClient;
+}
+
+describe("listInitiatives", () => {
+  it("forwards pagination, includeArchived, filter, and orderBy", async () => {
+    const client = mockGqlClient({
+      initiatives: {
+        nodes: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+
+    await listInitiatives(client, {
+      limit: 10,
+      after: "cursor-1",
+      includeArchived: true,
+      filter: { name: { eqIgnoreCase: "Growth" } },
+      orderBy: { createdAt: "Asc" },
+    });
+
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      first: 10,
+      after: "cursor-1",
+      includeArchived: true,
+      filter: { name: { eqIgnoreCase: "Growth" } },
+      orderBy: { createdAt: "Asc" },
+    });
+  });
+});
+
+describe("getInitiative", () => {
+  it("throws when initiative is not found", async () => {
+    const client = mockGqlClient({ initiative: null });
+
+    await expect(getInitiative(client, "missing")).rejects.toThrow(
+      'Initiative with ID "missing" not found',
+    );
+  });
+});
+
+describe("createInitiative", () => {
+  it("returns created initiative on success", async () => {
+    const client = mockGqlClient({
+      initiativeCreate: {
+        success: true,
+        initiative: { id: "init-1", name: "Growth" },
+      },
+    });
+
+    await expect(createInitiative(client, { name: "Growth" })).resolves.toEqual(
+      {
+        id: "init-1",
+        name: "Growth",
+      },
+    );
+  });
+
+  it("throws when mutation success is false or payload missing", async () => {
+    const client = mockGqlClient({
+      initiativeCreate: { success: false, initiative: null },
+    });
+
+    await expect(createInitiative(client, { name: "Growth" })).rejects.toThrow(
+      'Failed to create initiative "Growth"',
+    );
+  });
+});
+
+describe("updateInitiative", () => {
+  it("rejects empty update input", async () => {
+    const client = mockGqlClient({});
+
+    await expect(updateInitiative(client, "init-1", {})).rejects.toThrow(
+      "Invalid update options: at least one update field must be provided",
+    );
+  });
+
+  it("returns updated initiative on success", async () => {
+    const client = mockGqlClient({
+      initiativeUpdate: {
+        success: true,
+        initiative: { id: "init-1", name: "Updated" },
+      },
+    });
+
+    await expect(
+      updateInitiative(client, "init-1", { name: "Updated" }),
+    ).resolves.toEqual({
+      id: "init-1",
+      name: "Updated",
+    });
+  });
+
+  it("throws when mutation success is false or payload missing", async () => {
+    const client = mockGqlClient({
+      initiativeUpdate: { success: false, initiative: null },
+    });
+
+    await expect(
+      updateInitiative(client, "init-1", { name: "Updated" }),
+    ).rejects.toThrow('Failed to update initiative "init-1"');
+  });
+});
+
+describe("archiveInitiative", () => {
+  it("returns archived initiative entity on success", async () => {
+    const client = mockGqlClient({
+      initiativeArchive: {
+        success: true,
+        entity: { id: "init-1", name: "Growth" },
+      },
+    });
+
+    await expect(archiveInitiative(client, "init-1")).resolves.toEqual({
+      id: "init-1",
+      name: "Growth",
+    });
+  });
+
+  it("throws when mutation success is false or payload missing", async () => {
+    const client = mockGqlClient({
+      initiativeArchive: { success: false, entity: null },
+    });
+
+    await expect(archiveInitiative(client, "init-1")).rejects.toThrow(
+      'Failed to archive initiative "init-1"',
+    );
+  });
+});
+
+describe("unarchiveInitiative", () => {
+  it("returns unarchived initiative entity on success", async () => {
+    const client = mockGqlClient({
+      initiativeUnarchive: {
+        success: true,
+        entity: { id: "init-1", name: "Growth" },
+      },
+    });
+
+    await expect(unarchiveInitiative(client, "init-1")).resolves.toEqual({
+      id: "init-1",
+      name: "Growth",
+    });
+  });
+
+  it("throws when mutation success is false or payload missing", async () => {
+    const client = mockGqlClient({
+      initiativeUnarchive: { success: false, entity: null },
+    });
+
+    await expect(unarchiveInitiative(client, "init-1")).rejects.toThrow(
+      'Failed to unarchive initiative "init-1"',
+    );
+  });
+});
+
+describe("deleteInitiative", () => {
+  it("returns delete payload on success", async () => {
+    const client = mockGqlClient({
+      initiativeDelete: { success: true, entityId: "init-1" },
+    });
+
+    await expect(deleteInitiative(client, "init-1")).resolves.toEqual({
+      id: "init-1",
+      success: true,
+    });
+  });
+
+  it("throws when mutation success is false or payload missing", async () => {
+    const client = mockGqlClient({
+      initiativeDelete: { success: false, entityId: null },
+    });
+
+    await expect(deleteInitiative(client, "init-1")).rejects.toThrow(
+      'Failed to delete initiative "init-1"',
+    );
+  });
+});

--- a/tests/unit/services/initiative-service.test.ts
+++ b/tests/unit/services/initiative-service.test.ts
@@ -41,9 +41,32 @@ describe("listInitiatives", () => {
       orderBy: { createdAt: "Asc" },
     });
   });
+
+  it("propagates GraphQL request failures", async () => {
+    const expectedError = new Error("network exploded");
+    const client = {
+      request: vi.fn().mockRejectedValue(expectedError),
+    } as unknown as GraphQLClient;
+
+    await expect(listInitiatives(client)).rejects.toBe(expectedError);
+  });
 });
 
 describe("getInitiative", () => {
+  it("returns initiative when found", async () => {
+    const client = mockGqlClient({
+      initiative: {
+        id: "init-1",
+        name: "Growth",
+      },
+    });
+
+    await expect(getInitiative(client, "init-1")).resolves.toEqual({
+      id: "init-1",
+      name: "Growth",
+    });
+  });
+
   it("throws when initiative is not found", async () => {
     const client = mockGqlClient({ initiative: null });
 

--- a/tests/unit/services/initiative-service.test.ts
+++ b/tests/unit/services/initiative-service.test.ts
@@ -39,6 +39,7 @@ describe("listInitiatives", () => {
       includeArchived: true,
       filter: { name: { eqIgnoreCase: "Growth" } },
       orderBy: { createdAt: "Asc" },
+      sort: undefined,
     });
   });
 

--- a/tests/unit/services/initiative-update-service.test.ts
+++ b/tests/unit/services/initiative-update-service.test.ts
@@ -53,6 +53,25 @@ describe("listInitiativeUpdates", () => {
       includeArchived: true,
     });
   });
+
+  it("propagates request errors", async () => {
+    const requestError = new Error("network failure");
+    const request = vi.fn().mockRejectedValue(requestError);
+    const client = {
+      request,
+    } as unknown as GraphQLClient;
+
+    await expect(
+      listInitiativeUpdates(client, { initiativeId: "init-1" }),
+    ).rejects.toThrow(requestError);
+
+    expect(request).toHaveBeenCalledWith(ListInitiativeUpdatesDocument, {
+      initiativeId: "init-1",
+      first: 50,
+      after: undefined,
+      includeArchived: false,
+    });
+  });
 });
 
 describe("getInitiativeUpdate", () => {

--- a/tests/unit/services/initiative-update-service.test.ts
+++ b/tests/unit/services/initiative-update-service.test.ts
@@ -1,0 +1,294 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import {
+  ArchiveInitiativeUpdateDocument,
+  CreateInitiativeUpdateDocument,
+  GetInitiativeUpdateDocument,
+  ListInitiativeUpdatesDocument,
+  UnarchiveInitiativeUpdateDocument,
+  UpdateInitiativeUpdateDocument,
+} from "../../../src/gql/graphql.js";
+import {
+  archiveInitiativeUpdate,
+  createInitiativeUpdate,
+  getInitiativeUpdate,
+  listInitiativeUpdates,
+  unarchiveInitiativeUpdate,
+  updateInitiativeUpdate,
+} from "../../../src/services/initiative-update-service.js";
+
+function mockGqlClient(response: Record<string, unknown>): {
+  client: GraphQLClient;
+  request: ReturnType<typeof vi.fn>;
+} {
+  const request = vi.fn().mockResolvedValue(response);
+  return {
+    client: {
+      request,
+    } as unknown as GraphQLClient,
+    request,
+  };
+}
+
+describe("listInitiativeUpdates", () => {
+  it("forwards initiative filter and pagination", async () => {
+    const { client, request } = mockGqlClient({
+      initiativeUpdates: {
+        nodes: [{ id: "upd-1", body: "Week 1" }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+
+    await listInitiativeUpdates(client, {
+      initiativeId: "init-1",
+      limit: 5,
+      after: "cursor-1",
+      includeArchived: true,
+    });
+
+    expect(request).toHaveBeenCalledWith(ListInitiativeUpdatesDocument, {
+      initiativeId: "init-1",
+      first: 5,
+      after: "cursor-1",
+      includeArchived: true,
+    });
+  });
+});
+
+describe("getInitiativeUpdate", () => {
+  it("returns update when found", async () => {
+    const update = {
+      id: "upd-1",
+      body: "Week 1",
+      health: "OnTrack",
+      createdAt: "2026-04-17T00:00:00.000Z",
+      updatedAt: "2026-04-17T00:00:00.000Z",
+      archivedAt: null,
+      initiative: { id: "init-1", name: "Growth" },
+      user: { id: "usr-1", name: "Alex" },
+    };
+    const { client, request } = mockGqlClient({ initiativeUpdate: update });
+
+    await expect(getInitiativeUpdate(client, "upd-1")).resolves.toEqual(update);
+
+    expect(request).toHaveBeenCalledWith(GetInitiativeUpdateDocument, {
+      id: "upd-1",
+    });
+  });
+
+  it("throws when update is not found", async () => {
+    const { client } = mockGqlClient({ initiativeUpdate: null });
+
+    await expect(getInitiativeUpdate(client, "upd-missing")).rejects.toThrow(
+      'Initiative update with ID "upd-missing" not found',
+    );
+  });
+});
+
+describe("createInitiativeUpdate", () => {
+  it("returns created update on success", async () => {
+    const update = {
+      id: "upd-1",
+      body: "Week 1",
+      health: "OnTrack",
+      createdAt: "2026-04-17T00:00:00.000Z",
+      updatedAt: "2026-04-17T00:00:00.000Z",
+      archivedAt: null,
+      initiative: { id: "init-1", name: "Growth" },
+      user: { id: "usr-1", name: "Alex" },
+    };
+    const { client, request } = mockGqlClient({
+      initiativeUpdateCreate: { success: true, initiativeUpdate: update },
+    });
+
+    await expect(
+      createInitiativeUpdate(client, {
+        initiativeId: "init-1",
+        body: "Week 1",
+      }),
+    ).resolves.toEqual(update);
+
+    expect(request).toHaveBeenCalledWith(CreateInitiativeUpdateDocument, {
+      input: { initiativeId: "init-1", body: "Week 1" },
+    });
+  });
+
+  it("throws when mutation success is false", async () => {
+    const { client } = mockGqlClient({
+      initiativeUpdateCreate: {
+        success: false,
+        initiativeUpdate: { id: "upd-1" },
+      },
+    });
+
+    await expect(
+      createInitiativeUpdate(client, {
+        initiativeId: "init-1",
+        body: "Week 1",
+      }),
+    ).rejects.toThrow("Failed to create initiative update");
+  });
+
+  it("throws when mutation payload is missing", async () => {
+    const { client } = mockGqlClient({
+      initiativeUpdateCreate: { success: true, initiativeUpdate: null },
+    });
+
+    await expect(
+      createInitiativeUpdate(client, {
+        initiativeId: "init-1",
+        body: "Week 1",
+      }),
+    ).rejects.toThrow("Failed to create initiative update");
+  });
+});
+
+describe("updateInitiativeUpdate", () => {
+  it("rejects no-op update input", async () => {
+    const { client } = mockGqlClient({});
+
+    await expect(updateInitiativeUpdate(client, "upd-1", {})).rejects.toThrow(
+      "Invalid update options: at least one update field must be provided",
+    );
+  });
+
+  it("returns updated update on success", async () => {
+    const update = {
+      id: "upd-1",
+      body: "Week 2",
+      health: "AtRisk",
+      createdAt: "2026-04-17T00:00:00.000Z",
+      updatedAt: "2026-04-18T00:00:00.000Z",
+      archivedAt: null,
+      initiative: { id: "init-1", name: "Growth" },
+      user: { id: "usr-1", name: "Alex" },
+    };
+    const { client, request } = mockGqlClient({
+      initiativeUpdateUpdate: { success: true, initiativeUpdate: update },
+    });
+
+    await expect(
+      updateInitiativeUpdate(client, "upd-1", { body: "Week 2" }),
+    ).resolves.toEqual(update);
+
+    expect(request).toHaveBeenCalledWith(UpdateInitiativeUpdateDocument, {
+      id: "upd-1",
+      input: { body: "Week 2" },
+    });
+  });
+
+  it("throws when mutation success is false", async () => {
+    const { client } = mockGqlClient({
+      initiativeUpdateUpdate: {
+        success: false,
+        initiativeUpdate: { id: "upd-1" },
+      },
+    });
+
+    await expect(
+      updateInitiativeUpdate(client, "upd-1", { body: "Week 2" }),
+    ).rejects.toThrow('Failed to update initiative update "upd-1"');
+  });
+
+  it("throws when mutation payload is missing", async () => {
+    const { client } = mockGqlClient({
+      initiativeUpdateUpdate: { success: true, initiativeUpdate: null },
+    });
+
+    await expect(
+      updateInitiativeUpdate(client, "upd-1", { body: "Week 2" }),
+    ).rejects.toThrow('Failed to update initiative update "upd-1"');
+  });
+});
+
+describe("archiveInitiativeUpdate", () => {
+  it("returns archived update entity on success", async () => {
+    const archived = {
+      id: "upd-1",
+      body: "Week 1",
+      health: "OnTrack",
+      createdAt: "2026-04-17T00:00:00.000Z",
+      updatedAt: "2026-04-18T00:00:00.000Z",
+      archivedAt: "2026-04-18T00:00:00.000Z",
+      initiative: { id: "init-1", name: "Growth" },
+      user: { id: "usr-1", name: "Alex" },
+    };
+    const { client, request } = mockGqlClient({
+      initiativeUpdateArchive: { success: true, entity: archived },
+    });
+
+    await expect(archiveInitiativeUpdate(client, "upd-1")).resolves.toEqual(
+      archived,
+    );
+
+    expect(request).toHaveBeenCalledWith(ArchiveInitiativeUpdateDocument, {
+      id: "upd-1",
+    });
+  });
+
+  it("throws when mutation success is false", async () => {
+    const { client } = mockGqlClient({
+      initiativeUpdateArchive: { success: false, entity: { id: "upd-1" } },
+    });
+
+    await expect(archiveInitiativeUpdate(client, "upd-1")).rejects.toThrow(
+      'Failed to archive initiative update "upd-1"',
+    );
+  });
+
+  it("throws when mutation payload is missing", async () => {
+    const { client } = mockGqlClient({
+      initiativeUpdateArchive: { success: true, entity: null },
+    });
+
+    await expect(archiveInitiativeUpdate(client, "upd-1")).rejects.toThrow(
+      'Failed to archive initiative update "upd-1"',
+    );
+  });
+});
+
+describe("unarchiveInitiativeUpdate", () => {
+  it("returns unarchived update entity on success", async () => {
+    const unarchived = {
+      id: "upd-1",
+      body: "Week 1",
+      health: "OnTrack",
+      createdAt: "2026-04-17T00:00:00.000Z",
+      updatedAt: "2026-04-18T00:00:00.000Z",
+      archivedAt: null,
+      initiative: { id: "init-1", name: "Growth" },
+      user: { id: "usr-1", name: "Alex" },
+    };
+    const { client, request } = mockGqlClient({
+      initiativeUpdateUnarchive: { success: true, entity: unarchived },
+    });
+
+    await expect(unarchiveInitiativeUpdate(client, "upd-1")).resolves.toEqual(
+      unarchived,
+    );
+
+    expect(request).toHaveBeenCalledWith(UnarchiveInitiativeUpdateDocument, {
+      id: "upd-1",
+    });
+  });
+
+  it("throws when mutation success is false", async () => {
+    const { client } = mockGqlClient({
+      initiativeUpdateUnarchive: { success: false, entity: { id: "upd-1" } },
+    });
+
+    await expect(unarchiveInitiativeUpdate(client, "upd-1")).rejects.toThrow(
+      'Failed to unarchive initiative update "upd-1"',
+    );
+  });
+
+  it("throws when mutation payload is missing", async () => {
+    const { client } = mockGqlClient({
+      initiativeUpdateUnarchive: { success: true, entity: null },
+    });
+
+    await expect(unarchiveInitiativeUpdate(client, "upd-1")).rejects.toThrow(
+      'Failed to unarchive initiative update "upd-1"',
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add first-class `initiatives` CLI domain with modular command tree (`entity`, `relations`, `projects`, `updates`) plus usage/meta registration
- add initiative GraphQL operations and generated typings, plus new initiative resolver and services for entity lifecycle, hierarchy links, project links, and initiative updates
- add unit coverage for resolver/services/commands and fix relation/project link pair lookup robustness via cursor pagination

## Test Plan
- [x] npm run generate
- [x] npx vitest run tests/unit/resolvers/initiative-resolver.test.ts
- [x] npm run check:ci
- [x] npx tsc --noEmit
- [x] npm test
- [x] npm run build

## Refs

- Fixes #11 
