### PR TITLE
fix(issues): fail fast on invalid priority/estimate options

### DIFF
--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -610,6 +610,15 @@ export function setupIssuesCommands(program: Command): void {
           throw new Error("--label-mode must be either 'add' or 'overwrite'");
         }
 
+        const parsedPriority =
+          options.priority !== undefined
+            ? parsePriorityOption(options.priority)
+            : undefined;
+        const parsedEstimate =
+          options.estimate !== undefined
+            ? parseEstimateOption(options.estimate)
+            : undefined;
+
         const relationActions = parseRelationFlags(options);
 
         const ctx = createContext(command.parent!.parent!.opts());
@@ -647,14 +656,14 @@ export function setupIssuesCommands(program: Command): void {
           );
         }
 
-        if (options.priority) {
-          input.priority = parseInt(options.priority, 10);
+        if (parsedPriority !== undefined) {
+          input.priority = parsedPriority;
         }
 
         if (options.clearEstimate) {
           input.estimate = null;
-        } else if (options.estimate !== undefined) {
-          input.estimate = parseInt(options.estimate, 10);
+        } else if (parsedEstimate !== undefined) {
+          input.estimate = parsedEstimate;
         }
 
         if (options.assignee) {

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -8,14 +8,10 @@ import {
 } from "../common/identifier.js";
 import type { RawFilterFlags } from "../common/issue-filter.js";
 import {
-  handleCommand,
-  outputSuccess,
-  parseLimit,
-} from "../common/output.js";
-import {
   parseEstimateOption,
   parsePriorityOption,
 } from "../common/number-options.js";
+import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { resolveFilterOptions } from "../common/resolve-filters.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import {

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -7,7 +7,15 @@ import {
   parseIssueIdentifier,
 } from "../common/identifier.js";
 import type { RawFilterFlags } from "../common/issue-filter.js";
-import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
+import {
+  handleCommand,
+  outputSuccess,
+  parseLimit,
+} from "../common/output.js";
+import {
+  parseEstimateOption,
+  parsePriorityOption,
+} from "../common/number-options.js";
 import { resolveFilterOptions } from "../common/resolve-filters.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import {
@@ -429,6 +437,15 @@ export function setupIssuesCommands(program: Command): void {
 
         const relationActions = parseRelationFlags(options);
 
+        const parsedPriority =
+          options.priority !== undefined
+            ? parsePriorityOption(options.priority)
+            : undefined;
+        const parsedEstimate =
+          options.estimate !== undefined
+            ? parseEstimateOption(options.estimate)
+            : undefined;
+
         if (!options.team) {
           throw new Error("--team is required");
         }
@@ -447,12 +464,12 @@ export function setupIssuesCommands(program: Command): void {
           input.assigneeId = await resolveUserId(ctx.sdk, options.assignee);
         }
 
-        if (options.priority) {
-          input.priority = parseInt(options.priority, 10);
+        if (parsedPriority !== undefined) {
+          input.priority = parsedPriority;
         }
 
-        if (options.estimate !== undefined) {
-          input.estimate = parseInt(options.estimate, 10);
+        if (parsedEstimate !== undefined) {
+          input.estimate = parsedEstimate;
         }
 
         if (options.project) {

--- a/src/common/number-options.ts
+++ b/src/common/number-options.ts
@@ -1,19 +1,30 @@
 import { invalidParameterError } from "./errors.js";
 
-export function parsePriorityOption(raw: string): number {
-	const value = Number.parseInt(raw, 10);
-	if (Number.isNaN(value) || value < 1 || value > 4) {
-		throw invalidParameterError("--priority", "must be an integer between 1 and 4");
-	}
+function parseStrictNonNegativeInteger(raw: string): number | null {
+  if (!/^\d+$/.test(raw)) {
+    return null;
+  }
 
-	return value;
+  return Number.parseInt(raw, 10);
+}
+
+export function parsePriorityOption(raw: string): number {
+  const value = parseStrictNonNegativeInteger(raw);
+  if (value === null || value < 1 || value > 4) {
+    throw invalidParameterError(
+      "--priority",
+      "must be an integer between 1 and 4",
+    );
+  }
+
+  return value;
 }
 
 export function parseEstimateOption(raw: string): number {
-	const value = Number.parseInt(raw, 10);
-	if (Number.isNaN(value) || value < 0) {
-		throw invalidParameterError("--estimate", "must be a non-negative integer");
-	}
+  const value = parseStrictNonNegativeInteger(raw);
+  if (value === null) {
+    throw invalidParameterError("--estimate", "must be a non-negative integer");
+  }
 
-	return value;
+  return value;
 }

--- a/src/common/number-options.ts
+++ b/src/common/number-options.ts
@@ -1,0 +1,19 @@
+import { invalidParameterError } from "./errors.js";
+
+export function parsePriorityOption(raw: string): number {
+	const value = Number.parseInt(raw, 10);
+	if (Number.isNaN(value) || value < 1 || value > 4) {
+		throw invalidParameterError("--priority", "must be an integer between 1 and 4");
+	}
+
+	return value;
+}
+
+export function parseEstimateOption(raw: string): number {
+	const value = Number.parseInt(raw, 10);
+	if (Number.isNaN(value) || value < 0) {
+		throw invalidParameterError("--estimate", "must be a non-negative integer");
+	}
+
+	return value;
+}

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -258,7 +258,9 @@ describe("issues create numeric option validation", () => {
     ]);
 
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining("Invalid --priority: must be an integer between 1 and 4"),
+      expect.stringContaining(
+        "Invalid --priority: must be an integer between 1 and 4",
+      ),
     );
     expect(resolveTeamId).not.toHaveBeenCalled();
     expect(createIssue).not.toHaveBeenCalled();
@@ -279,7 +281,9 @@ describe("issues create numeric option validation", () => {
     ]);
 
     expect(console.error).toHaveBeenCalledWith(
-      expect.stringContaining("Invalid --estimate: must be a non-negative integer"),
+      expect.stringContaining(
+        "Invalid --estimate: must be a non-negative integer",
+      ),
     );
     expect(resolveTeamId).not.toHaveBeenCalled();
     expect(createIssue).not.toHaveBeenCalled();

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -77,6 +77,7 @@ vi.mock("../../../src/services/issue-relation-service.js", () => ({
 }));
 
 import { setupIssuesCommands } from "../../../src/commands/issues.js";
+import { resolveIssueId } from "../../../src/resolvers/issue-resolver.js";
 import { resolveTeamId } from "../../../src/resolvers/team-resolver.js";
 import { resolveUserId } from "../../../src/resolvers/user-resolver.js";
 import {
@@ -464,7 +465,7 @@ describe("issues update numeric option validation", () => {
     vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
   });
 
-  it("rejects invalid --priority before service calls", async () => {
+  it("rejects invalid --priority before resolver/service calls", async () => {
     const program = createProgram();
     await program.parseAsync([
       "node",
@@ -481,10 +482,11 @@ describe("issues update numeric option validation", () => {
         "Invalid --priority: must be an integer between 1 and 4",
       ),
     );
+    expect(resolveIssueId).not.toHaveBeenCalled();
     expect(updateIssue).not.toHaveBeenCalled();
   });
 
-  it("rejects invalid --estimate before service calls", async () => {
+  it("rejects invalid --estimate before resolver/service calls", async () => {
     const program = createProgram();
     await program.parseAsync([
       "node",
@@ -501,6 +503,7 @@ describe("issues update numeric option validation", () => {
         "Invalid --estimate: must be a non-negative integer",
       ),
     );
+    expect(resolveIssueId).not.toHaveBeenCalled();
     expect(updateIssue).not.toHaveBeenCalled();
   });
 

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -456,6 +456,76 @@ describe("issues update --estimate", () => {
   });
 });
 
+describe("issues update numeric option validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("rejects invalid --priority before service calls", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--priority",
+      "5",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid --priority: must be an integer between 1 and 4",
+      ),
+    );
+    expect(updateIssue).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid --estimate before service calls", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--estimate",
+      "-1",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid --estimate: must be a non-negative integer",
+      ),
+    );
+    expect(updateIssue).not.toHaveBeenCalled();
+  });
+
+  it("maps valid numeric update options into updateIssue input", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--priority",
+      "1",
+      "--estimate",
+      "8",
+    ]);
+
+    expect(updateIssue).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+      expect.objectContaining({ priority: 1, estimate: 8 }),
+    );
+  });
+});
+
 describe("issues update --due-date", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -77,6 +77,7 @@ vi.mock("../../../src/services/issue-relation-service.js", () => ({
 }));
 
 import { setupIssuesCommands } from "../../../src/commands/issues.js";
+import { resolveTeamId } from "../../../src/resolvers/team-resolver.js";
 import { resolveUserId } from "../../../src/resolvers/user-resolver.js";
 import {
   createIssue,
@@ -230,6 +231,79 @@ describe("issues create --estimate", () => {
     expect(createIssue).toHaveBeenCalledWith(
       expect.anything(),
       expect.not.objectContaining({ estimate: expect.anything() }),
+    );
+  });
+});
+
+describe("issues create numeric option validation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("rejects invalid --priority before resolver/service calls", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "create",
+      "Invalid priority",
+      "--team",
+      "ENG",
+      "--priority",
+      "0",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid --priority: must be an integer between 1 and 4"),
+    );
+    expect(resolveTeamId).not.toHaveBeenCalled();
+    expect(createIssue).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid --estimate before resolver/service calls", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "create",
+      "Invalid estimate",
+      "--team",
+      "ENG",
+      "--estimate",
+      "-1",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid --estimate: must be a non-negative integer"),
+    );
+    expect(resolveTeamId).not.toHaveBeenCalled();
+    expect(createIssue).not.toHaveBeenCalled();
+  });
+
+  it("maps valid numeric create options into createIssue input", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "create",
+      "Valid numbers",
+      "--team",
+      "ENG",
+      "--priority",
+      "2",
+      "--estimate",
+      "3",
+    ]);
+
+    expect(createIssue).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ priority: 2, estimate: 3 }),
     );
   });
 });

--- a/tests/unit/common/number-options.test.ts
+++ b/tests/unit/common/number-options.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from "vitest";
+import {
+	parseEstimateOption,
+	parsePriorityOption,
+} from "../../../src/common/number-options.js";
+
+describe("parsePriorityOption", () => {
+	it("parses valid priorities", () => {
+		expect(parsePriorityOption("1")).toBe(1);
+		expect(parsePriorityOption("4")).toBe(4);
+	});
+
+	it("throws for non-numeric priority", () => {
+		expect(() => parsePriorityOption("abc")).toThrow(
+			"Invalid --priority: must be an integer between 1 and 4",
+		);
+	});
+
+	it("throws for out-of-range priority", () => {
+		expect(() => parsePriorityOption("0")).toThrow(
+			"Invalid --priority: must be an integer between 1 and 4",
+		);
+		expect(() => parsePriorityOption("5")).toThrow(
+			"Invalid --priority: must be an integer between 1 and 4",
+		);
+	});
+});
+
+describe("parseEstimateOption", () => {
+	it("parses valid estimates", () => {
+		expect(parseEstimateOption("0")).toBe(0);
+		expect(parseEstimateOption("3")).toBe(3);
+	});
+
+	it("throws for non-numeric estimate", () => {
+		expect(() => parseEstimateOption("abc")).toThrow(
+			"Invalid --estimate: must be a non-negative integer",
+		);
+	});
+
+	it("throws for negative estimate", () => {
+		expect(() => parseEstimateOption("-1")).toThrow(
+			"Invalid --estimate: must be a non-negative integer",
+		);
+	});
+});

--- a/tests/unit/common/number-options.test.ts
+++ b/tests/unit/common/number-options.test.ts
@@ -1,46 +1,64 @@
 import { describe, expect, it } from "vitest";
 import {
-	parseEstimateOption,
-	parsePriorityOption,
+  parseEstimateOption,
+  parsePriorityOption,
 } from "../../../src/common/number-options.js";
 
 describe("parsePriorityOption", () => {
-	it("parses valid priorities", () => {
-		expect(parsePriorityOption("1")).toBe(1);
-		expect(parsePriorityOption("4")).toBe(4);
-	});
+  it("parses valid priorities", () => {
+    expect(parsePriorityOption("1")).toBe(1);
+    expect(parsePriorityOption("4")).toBe(4);
+  });
 
-	it("throws for non-numeric priority", () => {
-		expect(() => parsePriorityOption("abc")).toThrow(
-			"Invalid --priority: must be an integer between 1 and 4",
-		);
-	});
+  it("throws for non-numeric priority", () => {
+    expect(() => parsePriorityOption("abc")).toThrow(
+      "Invalid --priority: must be an integer between 1 and 4",
+    );
+  });
 
-	it("throws for out-of-range priority", () => {
-		expect(() => parsePriorityOption("0")).toThrow(
-			"Invalid --priority: must be an integer between 1 and 4",
-		);
-		expect(() => parsePriorityOption("5")).toThrow(
-			"Invalid --priority: must be an integer between 1 and 4",
-		);
-	});
+  it("throws for out-of-range priority", () => {
+    expect(() => parsePriorityOption("0")).toThrow(
+      "Invalid --priority: must be an integer between 1 and 4",
+    );
+    expect(() => parsePriorityOption("5")).toThrow(
+      "Invalid --priority: must be an integer between 1 and 4",
+    );
+  });
+
+  it("throws for malformed priority values", () => {
+    expect(() => parsePriorityOption("1abc")).toThrow(
+      "Invalid --priority: must be an integer between 1 and 4",
+    );
+    expect(() => parsePriorityOption("1.5")).toThrow(
+      "Invalid --priority: must be an integer between 1 and 4",
+    );
+  });
 });
 
 describe("parseEstimateOption", () => {
-	it("parses valid estimates", () => {
-		expect(parseEstimateOption("0")).toBe(0);
-		expect(parseEstimateOption("3")).toBe(3);
-	});
+  it("parses valid estimates", () => {
+    expect(parseEstimateOption("0")).toBe(0);
+    expect(parseEstimateOption("3")).toBe(3);
+  });
 
-	it("throws for non-numeric estimate", () => {
-		expect(() => parseEstimateOption("abc")).toThrow(
-			"Invalid --estimate: must be a non-negative integer",
-		);
-	});
+  it("throws for non-numeric estimate", () => {
+    expect(() => parseEstimateOption("abc")).toThrow(
+      "Invalid --estimate: must be a non-negative integer",
+    );
+  });
 
-	it("throws for negative estimate", () => {
-		expect(() => parseEstimateOption("-1")).toThrow(
-			"Invalid --estimate: must be a non-negative integer",
-		);
-	});
+  it("throws for negative estimate", () => {
+    expect(() => parseEstimateOption("-1")).toThrow(
+      "Invalid --estimate: must be a non-negative integer",
+    );
+  });
+
+  it("throws for malformed estimate values", () => {
+    expect(() => parseEstimateOption("3days")).toThrow(
+      "Invalid --estimate: must be a non-negative integer",
+    );
+    expect(() => parseEstimateOption("2.0")).toThrow(
+      "Invalid --estimate: must be a non-negative integer",
+    );
+  });
 });


### PR DESCRIPTION
## Summary
- add shared numeric option parsers in `src/common/number-options.ts` for `--priority` and `--estimate`
- validate numeric options early in `issues create` and `issues update` before resolver/service/API calls
- add unit + command tests for invalid/valid mappings, including fail-fast assertions before resolver calls

## Test Plan
- [x] npm run check:ci
- [x] npx tsc --noEmit
- [x] npm test
- [x] npm run build
