### PR TITLE
feat(issues): add archive, unarchive, and delete lifecycle commands

### DIFF
--- a/graphql/mutations/issues.graphql
+++ b/graphql/mutations/issues.graphql
@@ -32,3 +32,30 @@ mutation UpdateIssue($id: String!, $input: IssueUpdateInput!) {
     }
   }
 }
+
+mutation ArchiveIssue($id: String!) {
+  issueArchive(id: $id) {
+    success
+    entity {
+      ...CompleteIssueWithCommentsFields
+    }
+  }
+}
+
+mutation UnarchiveIssue($id: String!) {
+  issueUnarchive(id: $id) {
+    success
+    entity {
+      ...CompleteIssueWithCommentsFields
+    }
+  }
+}
+
+mutation DeleteIssue($id: String!) {
+  issueDelete(id: $id) {
+    success
+    entity {
+      id
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "clean": "rm -rf dist/",
     "start": "tsx src/main.ts",
     "test": "vitest run",
+    "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -23,11 +23,14 @@ import {
   findIssueRelation,
 } from "../services/issue-relation-service.js";
 import {
+  archiveIssue,
   createIssue,
+  deleteIssue,
   getIssue,
   getIssueByIdentifier,
   listIssues,
   searchIssues,
+  unarchiveIssue,
   updateIssue,
 } from "../services/issue-service.js";
 
@@ -92,7 +95,13 @@ export const ISSUES_META: DomainMeta = {
     issue: "issue identifier (UUID or ABC-123)",
     title: "string",
   },
-  seeAlso: ["comments create <issue>", "documents list --issue <issue>"],
+  seeAlso: [
+    "comments create <issue>",
+    "documents list --issue <issue>",
+    "issues archive <issue>",
+    "issues unarchive <issue>",
+    "issues delete <issue>",
+  ],
 };
 
 interface RelationFlags {
@@ -510,6 +519,45 @@ export function setupIssuesCommands(program: Command): void {
           await applyRelation(ctx, resolvedIssueId, relationTargetId, options);
         }
 
+        outputSuccess(result);
+      }),
+    );
+
+  issues
+    .command("archive <issue>")
+    .description("archive an issue")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [issue, , command] = args as [string, unknown, Command];
+        const ctx = createContext(command.parent!.parent!.opts());
+        const issueId = await resolveIssueId(ctx.sdk, issue);
+        const result = await archiveIssue(ctx.gql, issueId);
+        outputSuccess(result);
+      }),
+    );
+
+  issues
+    .command("unarchive <issue>")
+    .description("unarchive an issue")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [issue, , command] = args as [string, unknown, Command];
+        const ctx = createContext(command.parent!.parent!.opts());
+        const issueId = await resolveIssueId(ctx.sdk, issue);
+        const result = await unarchiveIssue(ctx.gql, issueId);
+        outputSuccess(result);
+      }),
+    );
+
+  issues
+    .command("delete <issue>")
+    .description("delete an issue")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [issue, , command] = args as [string, unknown, Command];
+        const ctx = createContext(command.parent!.parent!.opts());
+        const issueId = await resolveIssueId(ctx.sdk, issue);
+        const result = await deleteIssue(ctx.gql, issueId);
         outputSuccess(result);
       }),
     );

--- a/src/services/issue-service.ts
+++ b/src/services/issue-service.ts
@@ -10,8 +10,12 @@ import type {
   UpdatedIssue,
 } from "../common/types.js";
 import {
+  ArchiveIssueDocument,
+  type ArchiveIssueMutation,
   CreateIssueDocument,
   type CreateIssueMutation,
+  DeleteIssueDocument,
+  type DeleteIssueMutation,
   GetIssueByIdDocument,
   GetIssueByIdentifierDocument,
   type GetIssueByIdentifierQuery,
@@ -22,6 +26,8 @@ import {
   type IssueUpdateInput,
   SearchIssuesDocument,
   type SearchIssuesQuery,
+  UnarchiveIssueDocument,
+  type UnarchiveIssueMutation,
   UpdateIssueDocument,
   type UpdateIssueMutation,
 } from "../gql/graphql.js";
@@ -116,4 +122,57 @@ export async function updateIssue(
     throw new Error("Failed to update issue");
   }
   return result.issueUpdate.issue;
+}
+
+export async function archiveIssue(
+  client: GraphQLClient,
+  id: string,
+): Promise<IssueDetail> {
+  const result = await client.request<ArchiveIssueMutation>(
+    ArchiveIssueDocument,
+    { id },
+  );
+
+  if (!result.issueArchive.success || !result.issueArchive.entity) {
+    throw new Error(`Failed to archive issue "${id}"`);
+  }
+
+  return result.issueArchive.entity;
+}
+
+export async function unarchiveIssue(
+  client: GraphQLClient,
+  id: string,
+): Promise<IssueDetail> {
+  const result = await client.request<UnarchiveIssueMutation>(
+    UnarchiveIssueDocument,
+    { id },
+  );
+
+  if (!result.issueUnarchive.success || !result.issueUnarchive.entity) {
+    throw new Error(`Failed to unarchive issue "${id}"`);
+  }
+
+  return result.issueUnarchive.entity;
+}
+
+export async function deleteIssue(
+  client: GraphQLClient,
+  id: string,
+): Promise<{ id: string; success: true }> {
+  const result = await client.request<DeleteIssueMutation>(
+    DeleteIssueDocument,
+    {
+      id,
+    },
+  );
+
+  if (!result.issueDelete.success || !result.issueDelete.entity?.id) {
+    throw new Error(`Failed to delete issue "${id}"`);
+  }
+
+  return {
+    id: result.issueDelete.entity.id,
+    success: true,
+  };
 }

--- a/tests/integration/cycles-cli.test.ts
+++ b/tests/integration/cycles-cli.test.ts
@@ -52,16 +52,16 @@ describe("Cycles CLI Commands", () => {
       expect(stderr).not.toContain("complexity");
 
       // Should return valid JSON
-      const cycles = JSON.parse(stdout);
-      expect(Array.isArray(cycles)).toBe(true);
+      const response = JSON.parse(stdout);
+      expect(Array.isArray(response.nodes)).toBe(true);
     });
 
     it.skipIf(!hasApiToken)("should return valid cycle structure", async () => {
       const { stdout } = await execAsync(`node ${CLI_PATH} cycles list`);
-      const cycles = JSON.parse(stdout);
+      const response = JSON.parse(stdout);
 
-      if (cycles.length > 0) {
-        const cycle = cycles[0];
+      if (response.nodes.length > 0) {
+        const cycle = response.nodes[0];
 
         // Verify cycle has expected fields
         expect(cycle).toHaveProperty("id");
@@ -80,19 +80,19 @@ describe("Cycles CLI Commands", () => {
       const { stdout: teamsOutput } = await execAsync(
         `node ${CLI_PATH} teams list`,
       );
-      const teams = JSON.parse(teamsOutput);
+      const teamsResponse = JSON.parse(teamsOutput);
 
-      if (teams.length > 0) {
-        const teamKey = teams[0].key;
+      if (teamsResponse.nodes.length > 0) {
+        const teamKey = teamsResponse.nodes[0].key;
 
         // Now test active filter
         const { stdout } = await execAsync(
           `node ${CLI_PATH} cycles list --active --team ${teamKey}`,
         );
-        const activeCycles = JSON.parse(stdout);
+        const activeCyclesResponse = JSON.parse(stdout);
 
         // All returned cycles should be active
-        activeCycles.forEach((cycle: { isActive: boolean }) => {
+        activeCyclesResponse.nodes.forEach((cycle: { isActive: boolean }) => {
           expect(cycle.isActive).toBe(true);
         });
       }
@@ -100,15 +100,16 @@ describe("Cycles CLI Commands", () => {
 
     it.skipIf(!hasApiToken)(
       "should work with --window flag",
+      { timeout: 30000 },
       async () => {
         // First, get a team key from teams list
         const { stdout: teamsOutput } = await execAsync(
           `node ${CLI_PATH} teams list`,
         );
-        const teams = JSON.parse(teamsOutput);
+        const teamsResponse = JSON.parse(teamsOutput);
 
-        if (teams.length > 0) {
-          const teamKey = teams[0].key;
+        if (teamsResponse.nodes.length > 0) {
+          const teamKey = teamsResponse.nodes[0].key;
 
           // Test window (may fail if no active cycle, which is ok)
           try {
@@ -119,8 +120,8 @@ describe("Cycles CLI Commands", () => {
             // Should not have complexity errors
             expect(stderr).not.toContain("query too complex");
 
-            const cycles = JSON.parse(stdout);
-            expect(Array.isArray(cycles)).toBe(true);
+            const response = JSON.parse(stdout);
+            expect(Array.isArray(response.nodes)).toBe(true);
           } catch (error: unknown) {
             // It's ok if there's no active cycle
             const execError = error as { stderr?: string };
@@ -130,7 +131,6 @@ describe("Cycles CLI Commands", () => {
           }
         }
       },
-      { timeout: 30000 },
     );
 
     it("should require --team when using --window", async () => {
@@ -151,10 +151,10 @@ describe("Cycles CLI Commands", () => {
       const { stdout: listOutput } = await execAsync(
         `node ${CLI_PATH} cycles list`,
       );
-      const cycles = JSON.parse(listOutput);
+      const cyclesResponse = JSON.parse(listOutput);
 
-      if (cycles.length > 0) {
-        const cycleId = cycles[0].id;
+      if (cyclesResponse.nodes.length > 0) {
+        const cycleId = cyclesResponse.nodes[0].id;
 
         const { stdout, stderr } = await execAsync(
           `node ${CLI_PATH} cycles read ${cycleId}`,
@@ -179,23 +179,25 @@ describe("Cycles CLI Commands", () => {
       const { stdout: teamsOutput } = await execAsync(
         `node ${CLI_PATH} teams list`,
       );
-      const teams = JSON.parse(teamsOutput);
+      const teamsResponse = JSON.parse(teamsOutput);
 
-      if (teams.length === 0) {
+      if (teamsResponse.nodes.length === 0) {
         console.log("Skipping: No teams found in workspace");
         return;
       }
 
-      const teamKey = teams[0].key;
+      const teamKey = teamsResponse.nodes[0].key;
 
       // Get cycles for this team
       const { stdout: listOutput } = await execAsync(
         `node ${CLI_PATH} cycles list --team ${teamKey}`,
       );
-      const cycles = JSON.parse(listOutput);
+      const cyclesResponse = JSON.parse(listOutput);
 
       // Find a cycle that has a name
-      const cycleWithName = cycles.find((c: { name?: string }) => c.name);
+      const cycleWithName = cyclesResponse.nodes.find(
+        (c: { name?: string }) => c.name,
+      );
 
       if (cycleWithName) {
         const cycleName = cycleWithName.name;
@@ -232,10 +234,10 @@ describe("Cycles CLI Commands", () => {
         const { stdout: teamsOutput } = await execAsync(
           `node ${CLI_PATH} teams list`,
         );
-        const teams = JSON.parse(teamsOutput);
+        const teamsResponse = JSON.parse(teamsOutput);
 
-        if (teams.length > 0) {
-          const teamKey = teams[0].key;
+        if (teamsResponse.nodes.length > 0) {
+          const teamKey = teamsResponse.nodes[0].key;
 
           try {
             await execAsync(
@@ -260,10 +262,10 @@ describe("Cycles CLI Commands", () => {
         const { stdout: teamsOutput } = await execAsync(
           `node ${CLI_PATH} teams list`,
         );
-        const teams = JSON.parse(teamsOutput);
+        const teamsResponse = JSON.parse(teamsOutput);
 
-        if (teams.length > 0) {
-          const teamKey = teams[0].key;
+        if (teamsResponse.nodes.length > 0) {
+          const teamKey = teamsResponse.nodes[0].key;
 
           try {
             await execAsync(

--- a/tests/integration/documents-cli.test.ts
+++ b/tests/integration/documents-cli.test.ts
@@ -49,20 +49,20 @@ describe("Documents CLI Commands", () => {
       // Should not have errors
       expect(stderr).not.toContain("error");
 
-      // Should return valid JSON array
-      const documents = JSON.parse(stdout);
-      expect(Array.isArray(documents)).toBe(true);
+      // Should return valid JSON
+      const response = JSON.parse(stdout);
+      expect(Array.isArray(response.nodes)).toBe(true);
     });
 
     it.skipIf(!hasApiToken)(
       "should return valid document structure when documents exist",
       async () => {
         const { stdout } = await execAsync(`node ${CLI_PATH} documents list`);
-        const documents = JSON.parse(stdout);
+        const response = JSON.parse(stdout);
 
         // If there are documents, verify structure
-        if (documents.length > 0) {
-          const doc = documents[0];
+        if (response.nodes.length > 0) {
+          const doc = response.nodes[0];
           expect(doc).toHaveProperty("id");
           expect(doc).toHaveProperty("title");
           expect(doc).toHaveProperty("slugId");
@@ -136,9 +136,9 @@ describe("Documents CLI Commands", () => {
         const { stdout: teamsOutput } = await execAsync(
           `node ${CLI_PATH} teams list`,
         );
-        const teams = JSON.parse(teamsOutput);
-        expect(teams.length).toBeGreaterThan(0);
-        const teamKey = teams[0].key;
+        const teamsResponse = JSON.parse(teamsOutput);
+        expect(teamsResponse.nodes.length).toBeGreaterThan(0);
+        const teamKey = teamsResponse.nodes[0].key;
 
         // CREATE
         const { stdout: createOutput } = await execAsync(

--- a/tests/integration/issues-cli.test.ts
+++ b/tests/integration/issues-cli.test.ts
@@ -1,62 +1,95 @@
-/**
- * Integration tests for issues CLI commands
- *
- * These tests require LINEAR_API_TOKEN to be set in environment.
- * If not set, tests will be skipped.
- *
- * NOTE: These tests document expected behavior but are skipped by default
- * to avoid creating test data in production Linear workspaces.
- */
-
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
-import { describe, it } from "vitest";
+import { beforeAll, describe, expect, it } from "vitest";
 
-const _execAsync = promisify(exec);
-const _CLI_PATH = "dist/main.js";
+const execAsync = promisify(exec);
+const CLI_PATH = "./dist/main.js";
 const hasApiToken = !!process.env.LINEAR_API_TOKEN;
 
-if (!hasApiToken) {
-  console.warn(
-    "\n⚠️  LINEAR_API_TOKEN not set - skipping issues integration tests\n" +
-      "   To run these tests, set LINEAR_API_TOKEN in your environment\n",
-  );
+interface CliResult {
+  stdout: string;
+  stderr: string;
 }
 
-describe("Issues CLI - Milestone Resolution", () => {
-  it.skip("should resolve milestone name to issue's current project when updating", async () => {
-    // This test documents the expected behavior for ZCO-1578
-    // When a user updates an issue with --project-milestone "name",
-    // the system should:
-    // 1. First check if --project is provided, use that project's milestone
-    // 2. If no --project, check the issue's current project for the milestone
-    // 3. Only fall back to global search if not found in either
+async function runCli(command: string): Promise<CliResult> {
+  const { stdout, stderr } = await execAsync(`node ${CLI_PATH} ${command}`);
+  return { stdout, stderr };
+}
 
-    // Example scenario:
-    // - Project A has milestone "2025.11.2"
-    // - Project B has milestone "2025.11.2"
-    // - Issue ZCO-1569 is in Project A
-    // - Command: issues update ZCO-1569 --project-milestone "2025.11.2"
-    // - Expected: Uses milestone from Project A (not Project B)
+function parseJson<T>(value: string): T {
+  return JSON.parse(value) as T;
+}
 
-    if (!hasApiToken) return;
-
-    // This would require:
-    // 1. Finding or creating two projects with same milestone name
-    // 2. Creating an issue in one project
-    // 3. Attempting to set milestone by name
-    // 4. Verifying correct project's milestone was used
-
-    // Skipped to avoid creating test data in production workspace
+describe("Issues CLI lifecycle", () => {
+  beforeAll(() => {
+    if (!hasApiToken) {
+      console.warn(
+        "\n⚠️  LINEAR_API_TOKEN not set - skipping issues lifecycle integration tests\n",
+      );
+    }
   });
 
-  it.skip("should use specified project's milestone when --project is provided", async () => {
-    // This test documents that explicit --project should take precedence
-    // Command: issues update ZCO-1569 --project "Project B" --project-milestone "2025.11.2"
-    // Expected: Uses milestone from Project B (even if issue is in Project A)
+  it("shows lifecycle subcommands in issues help", async () => {
+    const { stdout } = await runCli("issues --help");
 
-    if (!hasApiToken) return;
-
-    // Skipped to avoid creating test data in production workspace
+    expect(stdout).toContain("archive");
+    expect(stdout).toContain("unarchive");
+    expect(stdout).toContain("delete");
   });
+
+  it.skipIf(!hasApiToken)(
+    "creates temporary issue and runs archive/unarchive/delete lifecycle",
+    { timeout: 90000 },
+    async () => {
+      const teamsResult = await runCli("teams list --limit 1");
+      const teams = parseJson<{ nodes: Array<{ key: string }> }>(
+        teamsResult.stdout,
+      );
+
+      expect(teams.nodes.length).toBeGreaterThan(0);
+      const teamKey = teams.nodes[0].key;
+
+      const title = `issue-lifecycle-e2e-${Date.now()}`;
+      const createdResult = await runCli(
+        `issues create "${title}" --team ${teamKey}`,
+      );
+      const createdIssue = parseJson<{ id: string; identifier: string }>(
+        createdResult.stdout,
+      );
+
+      expect(createdIssue.id).toBeTruthy();
+      expect(createdIssue.identifier).toMatch(
+        new RegExp(`^${teamKey}-\\d+$`, "i"),
+      );
+
+      const archivedResult = await runCli(
+        `issues archive ${createdIssue.identifier}`,
+      );
+      const archivedIssue = parseJson<{
+        id: string;
+        archivedAt?: string | null;
+      }>(archivedResult.stdout);
+
+      expect(archivedIssue.id).toBe(createdIssue.id);
+
+      const unarchivedResult = await runCli(
+        `issues unarchive ${createdIssue.id}`,
+      );
+      const unarchivedIssue = parseJson<{
+        id: string;
+        archivedAt?: string | null;
+      }>(unarchivedResult.stdout);
+
+      expect(unarchivedIssue.id).toBe(createdIssue.id);
+
+      const deletedResult = await runCli(
+        `issues delete ${createdIssue.identifier}`,
+      );
+      const deletedPayload = parseJson<{ id: string; success: boolean }>(
+        deletedResult.stdout,
+      );
+
+      expect(deletedPayload).toEqual({ id: createdIssue.id, success: true });
+    },
+  );
 });

--- a/tests/integration/milestones-cli.test.ts
+++ b/tests/integration/milestones-cli.test.ts
@@ -80,6 +80,7 @@ describe("Milestones CLI Commands", () => {
 
     it.skipIf(!hasApiToken)(
       "should list milestones when project exists",
+      { timeout: 30000 },
       async () => {
         try {
           // First get a project
@@ -111,7 +112,6 @@ describe("Milestones CLI Commands", () => {
           }
         }
       },
-      { timeout: 30000 },
     );
   });
 });

--- a/tests/integration/teams-cli.test.ts
+++ b/tests/integration/teams-cli.test.ts
@@ -44,18 +44,18 @@ describe("Teams CLI Commands", () => {
       expect(stderr).not.toContain("error");
 
       // Should return valid JSON
-      const teams = JSON.parse(stdout);
-      expect(Array.isArray(teams)).toBe(true);
+      const response = JSON.parse(stdout);
+      expect(Array.isArray(response.nodes)).toBe(true);
     });
 
     it.skipIf(!hasApiToken)("should return valid team structure", async () => {
       const { stdout } = await execAsync(`node ${CLI_PATH} teams list`);
-      const teams = JSON.parse(stdout);
+      const response = JSON.parse(stdout);
 
       // Should have at least one team
-      expect(teams.length).toBeGreaterThan(0);
+      expect(response.nodes.length).toBeGreaterThan(0);
 
-      const team = teams[0];
+      const team = response.nodes[0];
 
       // Verify team has expected fields
       expect(team).toHaveProperty("id");
@@ -66,13 +66,13 @@ describe("Teams CLI Commands", () => {
 
     it.skipIf(!hasApiToken)("should return teams sorted by name", async () => {
       const { stdout } = await execAsync(`node ${CLI_PATH} teams list`);
-      const teams = JSON.parse(stdout);
+      const response = JSON.parse(stdout);
 
-      if (teams.length > 1) {
+      if (response.nodes.length > 1) {
         // Verify alphabetical order
-        for (let i = 1; i < teams.length; i++) {
-          const prev = teams[i - 1].name.toLowerCase();
-          const curr = teams[i].name.toLowerCase();
+        for (let i = 1; i < response.nodes.length; i++) {
+          const prev = response.nodes[i - 1].name.toLowerCase();
+          const curr = response.nodes[i].name.toLowerCase();
           expect(prev.localeCompare(curr)).toBeLessThanOrEqual(0);
         }
       }

--- a/tests/integration/users-cli.test.ts
+++ b/tests/integration/users-cli.test.ts
@@ -44,18 +44,18 @@ describe("Users CLI Commands", () => {
       expect(stderr).not.toContain("error");
 
       // Should return valid JSON
-      const users = JSON.parse(stdout);
-      expect(Array.isArray(users)).toBe(true);
+      const response = JSON.parse(stdout);
+      expect(Array.isArray(response.nodes)).toBe(true);
     });
 
     it.skipIf(!hasApiToken)("should return valid user structure", async () => {
       const { stdout } = await execAsync(`node ${CLI_PATH} users list`);
-      const users = JSON.parse(stdout);
+      const response = JSON.parse(stdout);
 
       // Should have at least one user
-      expect(users.length).toBeGreaterThan(0);
+      expect(response.nodes.length).toBeGreaterThan(0);
 
-      const user = users[0];
+      const user = response.nodes[0];
 
       // Verify user has expected fields
       expect(user).toHaveProperty("id");
@@ -69,23 +69,23 @@ describe("Users CLI Commands", () => {
       const { stdout } = await execAsync(
         `node ${CLI_PATH} users list --active`,
       );
-      const users = JSON.parse(stdout);
+      const response = JSON.parse(stdout);
 
       // All returned users should be active
-      for (const user of users) {
+      for (const user of response.nodes) {
         expect(user.active).toBe(true);
       }
     });
 
     it.skipIf(!hasApiToken)("should return users sorted by name", async () => {
       const { stdout } = await execAsync(`node ${CLI_PATH} users list`);
-      const users = JSON.parse(stdout);
+      const response = JSON.parse(stdout);
 
-      if (users.length > 1) {
+      if (response.nodes.length > 1) {
         // Verify alphabetical order
-        for (let i = 1; i < users.length; i++) {
-          const prev = users[i - 1].name.toLowerCase();
-          const curr = users[i].name.toLowerCase();
+        for (let i = 1; i < response.nodes.length; i++) {
+          const prev = response.nodes[i - 1].name.toLowerCase();
+          const curr = response.nodes[i].name.toLowerCase();
           expect(prev.localeCompare(curr)).toBeLessThanOrEqual(0);
         }
       }

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -52,8 +52,13 @@ vi.mock("../../../src/resolvers/status-resolver.js", () => ({
 }));
 
 vi.mock("../../../src/services/issue-service.js", () => ({
+  archiveIssue: vi.fn().mockResolvedValue({ id: "resolved-issue-uuid" }),
   createIssue: vi.fn().mockResolvedValue({ id: "new-issue-id" }),
+  deleteIssue: vi
+    .fn()
+    .mockResolvedValue({ id: "resolved-issue-uuid", success: true }),
   updateIssue: vi.fn().mockResolvedValue({ id: "updated-issue-id" }),
+  unarchiveIssue: vi.fn().mockResolvedValue({ id: "resolved-issue-uuid" }),
   getIssue: vi.fn().mockResolvedValue({
     id: "resolved-issue-uuid",
     team: { id: "team-uuid", key: "ENG" },
@@ -72,9 +77,13 @@ vi.mock("../../../src/services/issue-relation-service.js", () => ({
 }));
 
 import { setupIssuesCommands } from "../../../src/commands/issues.js";
+import { resolveIssueId } from "../../../src/resolvers/issue-resolver.js";
 import { resolveUserId } from "../../../src/resolvers/user-resolver.js";
 import {
+  archiveIssue,
   createIssue,
+  deleteIssue,
+  unarchiveIssue,
   updateIssue,
 } from "../../../src/services/issue-service.js";
 
@@ -199,5 +208,50 @@ describe("issues update --assignee", () => {
     ]);
 
     expect(resolveUserId).not.toHaveBeenCalled();
+  });
+});
+
+describe("issues lifecycle commands", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("issues archive resolves identifier and calls archiveIssue", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "test", "issues", "archive", "ENG-42"]);
+
+    expect(resolveIssueId).toHaveBeenCalledWith(expect.anything(), "ENG-42");
+    expect(archiveIssue).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+    );
+  });
+
+  it("issues unarchive resolves identifier and calls unarchiveIssue", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "test", "issues", "unarchive", "ENG-42"]);
+
+    expect(resolveIssueId).toHaveBeenCalledWith(expect.anything(), "ENG-42");
+    expect(unarchiveIssue).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+    );
+  });
+
+  it("issues delete resolves identifier and calls deleteIssue", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "test", "issues", "delete", "ENG-42"]);
+
+    expect(resolveIssueId).toHaveBeenCalledWith(expect.anything(), "ENG-42");
+    expect(deleteIssue).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+    );
   });
 });

--- a/tests/unit/services/issue-service.test.ts
+++ b/tests/unit/services/issue-service.test.ts
@@ -2,10 +2,18 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import {
+  ArchiveIssueDocument,
+  DeleteIssueDocument,
+  UnarchiveIssueDocument,
+} from "../../../src/gql/graphql.js";
+import {
+  archiveIssue,
+  deleteIssue,
   getIssue,
   getIssueByIdentifier,
   listIssues,
   searchIssues,
+  unarchiveIssue,
 } from "../../../src/services/issue-service.js";
 
 function mockGqlClient(response: Record<string, unknown>) {
@@ -155,5 +163,88 @@ describe("searchIssues", () => {
       first: 5,
       after: "prevCursor",
     });
+  });
+});
+
+describe("archiveIssue", () => {
+  it("returns archived issue entity on success", async () => {
+    const client = mockGqlClient({
+      issueArchive: {
+        success: true,
+        entity: { id: "issue-1", identifier: "ENG-1", title: "Archived" },
+      },
+    });
+
+    const result = await archiveIssue(client, "issue-1");
+
+    expect(result.id).toBe("issue-1");
+    expect(client.request).toHaveBeenCalledWith(ArchiveIssueDocument, {
+      id: "issue-1",
+    });
+  });
+
+  it("throws when archive fails", async () => {
+    const client = mockGqlClient({
+      issueArchive: { success: false, entity: null },
+    });
+
+    await expect(archiveIssue(client, "issue-1")).rejects.toThrow(
+      'Failed to archive issue "issue-1"',
+    );
+  });
+});
+
+describe("unarchiveIssue", () => {
+  it("returns unarchived issue entity on success", async () => {
+    const client = mockGqlClient({
+      issueUnarchive: {
+        success: true,
+        entity: { id: "issue-1", identifier: "ENG-1", title: "Restored" },
+      },
+    });
+
+    const result = await unarchiveIssue(client, "issue-1");
+
+    expect(result.id).toBe("issue-1");
+    expect(client.request).toHaveBeenCalledWith(UnarchiveIssueDocument, {
+      id: "issue-1",
+    });
+  });
+
+  it("throws when unarchive fails", async () => {
+    const client = mockGqlClient({
+      issueUnarchive: { success: false, entity: null },
+    });
+
+    await expect(unarchiveIssue(client, "issue-1")).rejects.toThrow(
+      'Failed to unarchive issue "issue-1"',
+    );
+  });
+});
+
+describe("deleteIssue", () => {
+  it("returns normalized delete result on success", async () => {
+    const client = mockGqlClient({
+      issueDelete: { success: true, entity: { id: "issue-1" } },
+    });
+
+    await expect(deleteIssue(client, "issue-1")).resolves.toEqual({
+      id: "issue-1",
+      success: true,
+    });
+
+    expect(client.request).toHaveBeenCalledWith(DeleteIssueDocument, {
+      id: "issue-1",
+    });
+  });
+
+  it("throws when delete fails", async () => {
+    const client = mockGqlClient({
+      issueDelete: { success: false, entity: null },
+    });
+
+    await expect(deleteIssue(client, "issue-1")).rejects.toThrow(
+      'Failed to delete issue "issue-1"',
+    );
   });
 });

--- a/vitest.base.config.ts
+++ b/vitest.base.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "vitest/config";
+
+export const baseVitestConfig = defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    // Set timeout for tests that might call Linear API
+    testTimeout: 30000,
+    hookTimeout: 30000,
+  },
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,22 +1,21 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig, mergeConfig } from "vitest/config";
+import { baseVitestConfig } from "./vitest.base.config.js";
 
-export default defineConfig({
-  test: {
-    globals: true,
-    environment: "node",
-    include: ["tests/unit/**/*.test.ts"],
-    coverage: {
-      provider: "v8",
-      reporter: ["text", "json", "html"],
-      include: ["src/**/*.ts"],
-      exclude: [
-        "src/**/*.d.ts",
-        "src/main.ts", // Entry point, tested via integration
-        "dist/**",
-      ],
+export default mergeConfig(
+  baseVitestConfig,
+  defineConfig({
+    test: {
+      include: ["tests/unit/**/*.test.ts"],
+      coverage: {
+        provider: "v8",
+        reporter: ["text", "json", "html"],
+        include: ["src/**/*.ts"],
+        exclude: [
+          "src/**/*.d.ts",
+          "src/main.ts", // Entry point, tested via integration
+          "dist/**",
+        ],
+      },
     },
-    // Set timeout for tests that might call Linear API
-    testTimeout: 30000,
-    hookTimeout: 30000,
-  },
-});
+  }),
+);

--- a/vitest.integration.config.ts
+++ b/vitest.integration.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig, mergeConfig } from "vitest/config";
+import { baseVitestConfig } from "./vitest.base.config.js";
+
+export default mergeConfig(
+  baseVitestConfig,
+  defineConfig({
+    test: {
+      include: ["tests/integration/**/*.test.ts"],
+    },
+  }),
+);


### PR DESCRIPTION
## What does this PR do?

Adds issue lifecycle support to the CLI with new commands:
- `issues archive <issue>`
- `issues unarchive <issue>`
- `issues delete <issue>`

Includes typed GraphQL mutations, service functions, command wiring, unit tests, integration coverage, and integration test runner/config updates.

Closes #140

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [x] Tests
- [x] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Ran successfully:
- `npm run check:ci`
- `npx tsc --noEmit`
- `npm test`
- `npm run build`
- `npm run test:integration`

Integration notes:
- Lifecycle integration test is token-gated with `LINEAR_API_TOKEN`.
- Without token, gated tests skip cleanly.

## Notes for reviewers

- Linear schema for `issueDelete` in current environment returns `entity { id }` (not `entityId`), so service normalizes delete output to `{ id, success: true }` from `entity.id`.
- Added dedicated Vitest integration config so `npm run test:integration` works both with and without path filters.
