### PR TITLE
feat(teams): add teams read command with estimation helpers

### DIFF
--- a/graphql/queries/teams.graphql
+++ b/graphql/queries/teams.graphql
@@ -21,6 +21,39 @@ fragment TeamFields on Team {
   name
 }
 
+fragment TeamDetailFields on Team {
+  id
+  key
+  name
+  description
+  private
+  timezone
+  color
+  icon
+  issueCount
+  parent {
+    id
+    key
+    name
+  }
+  issueEstimationType
+  issueEstimationExtended
+  issueEstimationAllowZero
+  defaultIssueEstimate
+  inheritIssueEstimation
+  cyclesEnabled
+  cycleDuration
+  cycleCooldownTime
+  cycleStartDay
+  upcomingCycleCount
+  triageEnabled
+  requirePriorityToLeaveTriage
+  autoClosePeriod
+  autoArchivePeriod
+  autoCloseChildIssues
+  autoCloseParentIssues
+}
+
 # List all teams in the workspace
 #
 # Fetches a list of all teams. Teams are typically limited in number
@@ -37,5 +70,11 @@ query GetTeams($first: Int = 50, $after: String) {
       hasNextPage
       endCursor
     }
+  }
+}
+
+query GetTeamById($id: String!) {
+  team(id: $id) {
+    ...TeamDetailFields
   }
 }

--- a/src/commands/teams.ts
+++ b/src/commands/teams.ts
@@ -2,7 +2,8 @@ import type { Command } from "commander";
 import { createContext } from "../common/context.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
-import { listTeams } from "../services/team-service.js";
+import { resolveTeamId } from "../resolvers/team-resolver.js";
+import { getTeam, listTeams } from "../services/team-service.js";
 
 export const TEAMS_META: DomainMeta = {
   name: "teams",
@@ -36,6 +37,20 @@ export function setupTeamsCommands(program: Command): void {
           limit: parseLimit(options.limit),
           after: options.after,
         });
+        outputSuccess(result);
+      }),
+    );
+
+  teams
+    .command("read <team>")
+    .description("get team details")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const team = args[0] as string;
+        const command = args.at(-1) as Command;
+        const ctx = createContext(command.parent!.parent!.opts());
+        const teamId = await resolveTeamId(ctx.sdk, team);
+        const result = await getTeam(ctx.gql, { id: teamId });
         outputSuccess(result);
       }),
     );

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -27,6 +27,7 @@ import type {
   GetProjectMilestoneByIdQuery,
   GetProjectQuery,
   GetProjectsQuery,
+  GetTeamByIdQuery,
   GetViewerQuery,
   ListAttachmentsQuery,
   ListCommentsQuery,
@@ -57,6 +58,19 @@ export interface PaginationOptions {
   limit?: number;
   after?: string;
 }
+
+// Team types
+export type TeamEstimateOption = {
+  value: number;
+  label: string;
+};
+
+export type TeamEstimationSource = "self" | "parent" | "self_fallback";
+
+export type TeamDetail = NonNullable<GetTeamByIdQuery["team"]> & {
+  validEstimates: TeamEstimateOption[];
+  estimationSource: TeamEstimationSource;
+};
 
 // Issue types
 export type Issue = GetIssuesQuery["issues"]["nodes"][0];

--- a/src/services/team-service.ts
+++ b/src/services/team-service.ts
@@ -1,11 +1,115 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
-import type { PaginatedResult, PaginationOptions } from "../common/types.js";
-import { GetTeamsDocument, type GetTeamsQuery } from "../gql/graphql.js";
+import type {
+  PaginatedResult,
+  PaginationOptions,
+  TeamDetail,
+  TeamEstimateOption,
+  TeamEstimationSource,
+} from "../common/types.js";
+import {
+  GetTeamByIdDocument,
+  type GetTeamByIdQuery,
+  GetTeamsDocument,
+  type GetTeamsQuery,
+} from "../gql/graphql.js";
 
 export interface Team {
   id: string;
   key: string;
   name: string;
+}
+
+interface GetTeamInput {
+  id: string;
+}
+
+type TeamConfigSource = Pick<
+  TeamDetail,
+  "issueEstimationType" | "issueEstimationExtended" | "issueEstimationAllowZero"
+>;
+
+function deriveValidEstimates(config: TeamConfigSource): TeamEstimateOption[] {
+  const type = config.issueEstimationType;
+  const extended = config.issueEstimationExtended;
+  const allowZero = config.issueEstimationAllowZero;
+
+  let base: TeamEstimateOption[] = [];
+
+  switch (type) {
+    case "fibonacci":
+      base = [1, 2, 3, 5, 8, ...(extended ? [13, 21] : [])].map((value) => ({
+        value,
+        label: String(value),
+      }));
+      break;
+    case "exponential":
+      base = [1, 2, 4, 8, 16, ...(extended ? [32, 64] : [])].map((value) => ({
+        value,
+        label: String(value),
+      }));
+      break;
+    case "linear":
+      base = [1, 2, 3, 4, 5, ...(extended ? [6, 7] : [])].map((value) => ({
+        value,
+        label: String(value),
+      }));
+      break;
+    case "tShirt": {
+      const mapping: TeamEstimateOption[] = [
+        { value: 1, label: "XS" },
+        { value: 2, label: "S" },
+        { value: 3, label: "M" },
+        { value: 5, label: "L" },
+        { value: 8, label: "XL" },
+      ];
+      const extendedValues: TeamEstimateOption[] = extended
+        ? [
+            { value: 13, label: "XXL" },
+            { value: 21, label: "XXXL" },
+          ]
+        : [];
+      base = [...mapping, ...extendedValues];
+      break;
+    }
+    case "notUsed":
+      base = [];
+      break;
+    default:
+      base = [];
+      break;
+  }
+
+  if (!allowZero || type === "notUsed" || base.length === 0) {
+    return base;
+  }
+
+  return [{ value: 0, label: "0" }, ...base];
+}
+
+async function resolveEffectiveEstimationConfig(
+  client: GraphQLClient,
+  team: NonNullable<GetTeamByIdQuery["team"]>,
+): Promise<{ config: TeamConfigSource; source: TeamEstimationSource }> {
+  if (!team.inheritIssueEstimation || !team.parent?.id) {
+    return { config: team, source: "self" };
+  }
+
+  try {
+    const parentResult = await client.request<GetTeamByIdQuery>(
+      GetTeamByIdDocument,
+      {
+        id: team.parent.id,
+      },
+    );
+
+    if (!parentResult.team) {
+      return { config: team, source: "self_fallback" };
+    }
+
+    return { config: parentResult.team, source: "parent" };
+  } catch {
+    return { config: team, source: "self_fallback" };
+  }
 }
 
 export async function listTeams(
@@ -20,5 +124,29 @@ export async function listTeams(
   return {
     nodes: result.teams.nodes,
     pageInfo: result.teams.pageInfo,
+  };
+}
+
+export async function getTeam(
+  client: GraphQLClient,
+  input: GetTeamInput,
+): Promise<TeamDetail> {
+  const result = await client.request<GetTeamByIdQuery>(GetTeamByIdDocument, {
+    id: input.id,
+  });
+
+  if (!result.team) {
+    throw new Error(`Team with ID "${input.id}" not found`);
+  }
+
+  const { config, source } = await resolveEffectiveEstimationConfig(
+    client,
+    result.team,
+  );
+
+  return {
+    ...result.team,
+    validEstimates: deriveValidEstimates(config),
+    estimationSource: source,
   };
 }

--- a/tests/unit/commands/teams.test.ts
+++ b/tests/unit/commands/teams.test.ts
@@ -1,0 +1,103 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/common/context.js", () => ({
+  createContext: vi.fn(() => ({
+    gql: { request: vi.fn() },
+    sdk: { sdk: {} },
+  })),
+}));
+
+vi.mock("../../../src/common/output.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../src/common/output.js")>();
+  return {
+    ...actual,
+    outputSuccess: vi.fn(),
+  };
+});
+
+vi.mock("../../../src/resolvers/team-resolver.js", () => ({
+  resolveTeamId: vi.fn().mockResolvedValue("resolved-team-uuid"),
+}));
+
+vi.mock("../../../src/services/team-service.js", () => ({
+  listTeams: vi.fn().mockResolvedValue({
+    nodes: [{ id: "team-1", key: "ENG", name: "Engineering" }],
+    pageInfo: { hasNextPage: false, endCursor: null },
+  }),
+  getTeam: vi.fn().mockResolvedValue({
+    id: "team-1",
+    key: "ENG",
+    validEstimates: [
+      { value: 1, label: "1" },
+      { value: 2, label: "2" },
+      { value: 3, label: "3" },
+      { value: 5, label: "5" },
+      { value: 8, label: "8" },
+    ],
+    estimationSource: "self",
+  }),
+}));
+
+import { setupTeamsCommands } from "../../../src/commands/teams.js";
+import { outputSuccess } from "../../../src/common/output.js";
+import { resolveTeamId } from "../../../src/resolvers/team-resolver.js";
+import { getTeam, listTeams } from "../../../src/services/team-service.js";
+
+function createProgram(): Command {
+  const program = new Command();
+  program.option("--api-token <token>");
+  setupTeamsCommands(program);
+  return program;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+});
+
+describe("teams read", () => {
+  it("resolves team id and outputs team detail", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "test", "teams", "read", "ENG"]);
+
+    expect(resolveTeamId).toHaveBeenCalledWith(expect.anything(), "ENG");
+    expect(getTeam).toHaveBeenCalledWith(expect.anything(), {
+      id: "resolved-team-uuid",
+    });
+    expect(outputSuccess).toHaveBeenCalledWith({
+      id: "team-1",
+      key: "ENG",
+      validEstimates: [
+        { value: 1, label: "1" },
+        { value: 2, label: "2" },
+        { value: 3, label: "3" },
+        { value: 5, label: "5" },
+        { value: 8, label: "8" },
+      ],
+      estimationSource: "self",
+    });
+  });
+});
+
+describe("teams list", () => {
+  it("uses listTeams path and outputs nodes", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "test", "teams", "list"]);
+
+    expect(listTeams).toHaveBeenCalledWith(expect.anything(), {
+      limit: 50,
+      after: undefined,
+    });
+    expect(outputSuccess).toHaveBeenCalledWith({
+      nodes: [{ id: "team-1", key: "ENG", name: "Engineering" }],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    });
+  });
+});

--- a/tests/unit/services/team-service.test.ts
+++ b/tests/unit/services/team-service.test.ts
@@ -1,12 +1,38 @@
 // tests/unit/services/team-service.test.ts
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
-import { listTeams } from "../../../src/services/team-service.js";
+import type {
+  TeamDetail,
+  TeamEstimateOption,
+  TeamEstimationSource,
+} from "../../../src/common/types.js";
+import { getTeam, listTeams } from "../../../src/services/team-service.js";
+
+const assertTeamDetailShape = (value: TeamDetail): TeamDetail => value;
+const assertEstimateOption = (value: TeamEstimateOption): TeamEstimateOption =>
+  value;
+const assertEstimationSource = (
+  value: TeamEstimationSource,
+): TeamEstimationSource => value;
+
+void assertTeamDetailShape;
+void assertEstimateOption;
+void assertEstimationSource;
 
 function mockGqlClient(response: Record<string, unknown>): GraphQLClient {
   return {
     request: vi.fn().mockResolvedValue(response),
   } as unknown as GraphQLClient;
+}
+
+function mockGqlClientWithSequence(
+  responses: Array<Record<string, unknown>>,
+): GraphQLClient {
+  const request = vi.fn();
+  for (const response of responses) {
+    request.mockResolvedValueOnce(response);
+  }
+  return { request } as unknown as GraphQLClient;
 }
 
 describe("listTeams", () => {
@@ -63,5 +89,311 @@ describe("listTeams", () => {
       first: 50,
       after: undefined,
     });
+  });
+});
+
+describe("getTeam", () => {
+  it("returns detailed team with fibonacci estimates from self config", async () => {
+    const client = mockGqlClientWithSequence([
+      {
+        team: {
+          id: "team-1",
+          key: "ENG",
+          name: "Engineering",
+          description: null,
+          private: false,
+          timezone: "UTC",
+          color: "#fff",
+          icon: "rocket",
+          issueCount: 10,
+          parent: null,
+          issueEstimationType: "fibonacci",
+          issueEstimationExtended: false,
+          issueEstimationAllowZero: false,
+          defaultIssueEstimate: null,
+          inheritIssueEstimation: false,
+          cyclesEnabled: true,
+          cycleDuration: 2,
+          cycleCooldownTime: 0,
+          cycleStartDay: 1,
+          upcomingCycleCount: 1,
+          triageEnabled: false,
+          requirePriorityToLeaveTriage: false,
+          autoClosePeriod: null,
+          autoArchivePeriod: null,
+          autoCloseChildIssues: false,
+          autoCloseParentIssues: false,
+        },
+      },
+    ]);
+
+    const result = assertTeamDetailShape(
+      await getTeam(client, { id: "team-1" }),
+    );
+
+    expect(assertEstimationSource(result.estimationSource)).toBe("self");
+    expect(result.validEstimates).toEqual([
+      assertEstimateOption({ value: 1, label: "1" }),
+      assertEstimateOption({ value: 2, label: "2" }),
+      assertEstimateOption({ value: 3, label: "3" }),
+      assertEstimateOption({ value: 5, label: "5" }),
+      assertEstimateOption({ value: 8, label: "8" }),
+    ]);
+  });
+
+  it("uses parent config when inheritIssueEstimation=true", async () => {
+    const client = mockGqlClientWithSequence([
+      {
+        team: {
+          id: "team-child",
+          key: "CHILD",
+          name: "Child Team",
+          description: null,
+          private: false,
+          timezone: "UTC",
+          color: "#fff",
+          icon: "child",
+          issueCount: 5,
+          parent: { id: "team-parent", key: "PARENT", name: "Parent" },
+          issueEstimationType: "linear",
+          issueEstimationExtended: false,
+          issueEstimationAllowZero: false,
+          defaultIssueEstimate: null,
+          inheritIssueEstimation: true,
+          cyclesEnabled: false,
+          cycleDuration: null,
+          cycleCooldownTime: null,
+          cycleStartDay: null,
+          upcomingCycleCount: null,
+          triageEnabled: false,
+          requirePriorityToLeaveTriage: false,
+          autoClosePeriod: null,
+          autoArchivePeriod: null,
+          autoCloseChildIssues: false,
+          autoCloseParentIssues: false,
+        },
+      },
+      {
+        team: {
+          id: "team-parent",
+          key: "PARENT",
+          name: "Parent",
+          description: null,
+          private: false,
+          timezone: "UTC",
+          color: "#000",
+          icon: "parent",
+          issueCount: 99,
+          parent: null,
+          issueEstimationType: "exponential",
+          issueEstimationExtended: true,
+          issueEstimationAllowZero: true,
+          defaultIssueEstimate: null,
+          inheritIssueEstimation: false,
+          cyclesEnabled: false,
+          cycleDuration: null,
+          cycleCooldownTime: null,
+          cycleStartDay: null,
+          upcomingCycleCount: null,
+          triageEnabled: false,
+          requirePriorityToLeaveTriage: false,
+          autoClosePeriod: null,
+          autoArchivePeriod: null,
+          autoCloseChildIssues: false,
+          autoCloseParentIssues: false,
+        },
+      },
+    ]);
+
+    const result = assertTeamDetailShape(
+      await getTeam(client, { id: "team-child" }),
+    );
+
+    expect(assertEstimationSource(result.estimationSource)).toBe("parent");
+    expect(result.validEstimates).toEqual([
+      assertEstimateOption({ value: 0, label: "0" }),
+      assertEstimateOption({ value: 1, label: "1" }),
+      assertEstimateOption({ value: 2, label: "2" }),
+      assertEstimateOption({ value: 4, label: "4" }),
+      assertEstimateOption({ value: 8, label: "8" }),
+      assertEstimateOption({ value: 16, label: "16" }),
+      assertEstimateOption({ value: 32, label: "32" }),
+      assertEstimateOption({ value: 64, label: "64" }),
+    ]);
+  });
+
+  it("returns empty estimates when estimation type is notUsed", async () => {
+    const client = mockGqlClientWithSequence([
+      {
+        team: {
+          id: "team-2",
+          key: "OPS",
+          name: "Operations",
+          description: null,
+          private: false,
+          timezone: "UTC",
+          color: "#ccc",
+          icon: "ops",
+          issueCount: 1,
+          parent: null,
+          issueEstimationType: "notUsed",
+          issueEstimationExtended: false,
+          issueEstimationAllowZero: true,
+          defaultIssueEstimate: null,
+          inheritIssueEstimation: false,
+          cyclesEnabled: false,
+          cycleDuration: null,
+          cycleCooldownTime: null,
+          cycleStartDay: null,
+          upcomingCycleCount: null,
+          triageEnabled: false,
+          requirePriorityToLeaveTriage: false,
+          autoClosePeriod: null,
+          autoArchivePeriod: null,
+          autoCloseChildIssues: false,
+          autoCloseParentIssues: false,
+        },
+      },
+    ]);
+
+    const result = await getTeam(client, { id: "team-2" });
+    expect(result.validEstimates).toEqual([]);
+    expect(result.estimationSource).toBe("self");
+  });
+
+  it("returns empty estimates for unknown estimation type even when allowZero is true", async () => {
+    const client = mockGqlClientWithSequence([
+      {
+        team: {
+          id: "team-unknown",
+          key: "QA",
+          name: "Quality",
+          description: null,
+          private: false,
+          timezone: "UTC",
+          color: "#abc",
+          icon: "bug",
+          issueCount: 3,
+          parent: null,
+          issueEstimationType: "mystery",
+          issueEstimationExtended: false,
+          issueEstimationAllowZero: true,
+          defaultIssueEstimate: null,
+          inheritIssueEstimation: false,
+          cyclesEnabled: false,
+          cycleDuration: null,
+          cycleCooldownTime: null,
+          cycleStartDay: null,
+          upcomingCycleCount: null,
+          triageEnabled: false,
+          requirePriorityToLeaveTriage: false,
+          autoClosePeriod: null,
+          autoArchivePeriod: null,
+          autoCloseChildIssues: false,
+          autoCloseParentIssues: false,
+        },
+      },
+    ]);
+
+    const result = await getTeam(client, { id: "team-unknown" });
+    expect(result.validEstimates).toEqual([]);
+    expect(result.estimationSource).toBe("self");
+  });
+
+  it("maps tShirt labels correctly", async () => {
+    const client = mockGqlClientWithSequence([
+      {
+        team: {
+          id: "team-3",
+          key: "DES",
+          name: "Design",
+          description: null,
+          private: false,
+          timezone: "UTC",
+          color: "#ddd",
+          icon: "palette",
+          issueCount: 2,
+          parent: null,
+          issueEstimationType: "tShirt",
+          issueEstimationExtended: true,
+          issueEstimationAllowZero: false,
+          defaultIssueEstimate: null,
+          inheritIssueEstimation: false,
+          cyclesEnabled: false,
+          cycleDuration: null,
+          cycleCooldownTime: null,
+          cycleStartDay: null,
+          upcomingCycleCount: null,
+          triageEnabled: false,
+          requirePriorityToLeaveTriage: false,
+          autoClosePeriod: null,
+          autoArchivePeriod: null,
+          autoCloseChildIssues: false,
+          autoCloseParentIssues: false,
+        },
+      },
+    ]);
+
+    const result = await getTeam(client, { id: "team-3" });
+    expect(result.validEstimates).toEqual([
+      { value: 1, label: "XS" },
+      { value: 2, label: "S" },
+      { value: 3, label: "M" },
+      { value: 5, label: "L" },
+      { value: 8, label: "XL" },
+      { value: 13, label: "XXL" },
+      { value: 21, label: "XXXL" },
+    ]);
+  });
+
+  it("falls back to self config when parent fetch fails", async () => {
+    const client = {
+      request: vi
+        .fn()
+        .mockResolvedValueOnce({
+          team: {
+            id: "team-child",
+            key: "CHILD",
+            name: "Child Team",
+            description: null,
+            private: false,
+            timezone: "UTC",
+            color: "#fff",
+            icon: "child",
+            issueCount: 5,
+            parent: { id: "team-parent", key: "PARENT", name: "Parent" },
+            issueEstimationType: "linear",
+            issueEstimationExtended: true,
+            issueEstimationAllowZero: false,
+            defaultIssueEstimate: null,
+            inheritIssueEstimation: true,
+            cyclesEnabled: false,
+            cycleDuration: null,
+            cycleCooldownTime: null,
+            cycleStartDay: null,
+            upcomingCycleCount: null,
+            triageEnabled: false,
+            requirePriorityToLeaveTriage: false,
+            autoClosePeriod: null,
+            autoArchivePeriod: null,
+            autoCloseChildIssues: false,
+            autoCloseParentIssues: false,
+          },
+        })
+        .mockRejectedValueOnce(new Error("parent lookup failed")),
+    } as unknown as GraphQLClient;
+
+    const result = await getTeam(client, { id: "team-child" });
+
+    expect(result.estimationSource).toBe("self_fallback");
+    expect(result.validEstimates).toEqual([
+      { value: 1, label: "1" },
+      { value: 2, label: "2" },
+      { value: 3, label: "3" },
+      { value: 4, label: "4" },
+      { value: 5, label: "5" },
+      { value: 6, label: "6" },
+      { value: 7, label: "7" },
+    ]);
   });
 });


### PR DESCRIPTION
## What does this PR do?

Add `linearis teams read <team>` to return detailed team configuration plus derived estimation helpers:
- `validEstimates` (derived estimate options)
- `estimationSource` (`self` | `parent` | `self_fallback`)

Also adds GraphQL team detail query and service logic for inheritance/fallback while keeping `teams list` behavior unchanged.

Closes #95

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Ran:
- `npm run check:ci`
- `npx tsc --noEmit`
- `npm test`
- `npm run build`

Result:
- all pass in this branch.

## Notes for reviewers

- `teams read` resolves team via existing resolver and fetches detail via service.
- Estimation helpers derive from team config; if inheritance enabled and parent fetch succeeds, parent config used.
- If parent fetch fails/missing, falls back to team config with `estimationSource: "self_fallback"`.
- Unknown estimation types safely return `validEstimates: []`.
