### PR TITLE
feat: support linear binary alias with packed-artifact verification

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,12 +94,8 @@ jobs:
       - name: Install deps
         run: npm ci
 
-      - name: Pack and install
-        run: |
-          npm pack
-          npm install -g ./linearis-*.tgz
-          linearis --help
-          npm uninstall -g linearis
+      - name: Verify packed binaries
+        run: npm run verify:packed-binaries
 
   guard-plan-files:
     name: Reject plan files

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,6 +102,7 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     permissions:
+      contents: read
       pull-requests: write
     steps:
       - uses: actions/checkout@v6

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,8 +46,22 @@ Integration tests (`tests/integration/`) require `LINEAR_API_TOKEN` in your envi
 To publish a new version locally (maintainers only):
 
 ```bash
-npm run release    # Runs tests, builds, and publishes via clean-publish
+npm run release    # Runs tests, builds, verifies packed binaries, and publishes via clean-publish
 ```
+
+Manual final guard (run from packed artifact/environment):
+
+```bash
+npm pack
+TMP_DIR=$(mktemp -d)
+cd "$TMP_DIR"
+npm init -y
+npm install /path/to/linearis-<version>.tgz
+npx linearis usage
+npx linear usage
+```
+
+Both commands must exit with status code 0.
 
 In CI, publishing is handled automatically by the publish workflow when a version tag is pushed. The workflow uses `clean-publish` to strip dev artifacts (scripts, devDependencies, etc.) from the published package.
 

--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ The trade-off is coverage. An MCP exposes the entire Linear API; Linearis covers
 npm install -g linearis
 ```
 
+`linearis` is the canonical documented command; `linear` is a fully supported alias that runs the same CLI.
+
 Requires Node.js >= 22.
 
 ## Authentication

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "check": "biome check --write .",
     "check:ci": "biome check .",
     "verify:packed-binaries": "node scripts/verify-packed-binaries.mjs",
-    "release": "npm test && npm run build && npx clean-publish --access public",
+    "release": "npm test && npm run build && npm run verify:packed-binaries && npx clean-publish --access public",
     "prestart": "npm run generate",
     "predev": "npm run generate",
     "prebuild": "npm run generate && npm run generate:usage",

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "lint:check": "biome lint .",
     "check": "biome check --write .",
     "check:ci": "biome check .",
+    "verify:packed-binaries": "node scripts/verify-packed-binaries.mjs",
     "release": "npm test && npm run build && npx clean-publish --access public",
     "prestart": "npm run generate",
     "predev": "npm run generate",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "dist/main.js",
   "type": "module",
   "bin": {
-    "linearis": "dist/main.js"
+    "linearis": "dist/main.js",
+    "linear": "dist/main.js"
   },
   "files": [
     "dist/",

--- a/scripts/verify-packed-binaries.mjs
+++ b/scripts/verify-packed-binaries.mjs
@@ -1,0 +1,98 @@
+import { execFile as execFileCb } from "node:child_process";
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const execFile = promisify(execFileCb);
+
+async function run(command, args, cwd) {
+  try {
+    const { stdout, stderr } = await execFile(command, args, {
+      cwd,
+      env: process.env,
+      shell: false,
+    });
+
+    if (stdout) {
+      process.stdout.write(stdout);
+    }
+
+    if (stderr) {
+      process.stderr.write(stderr);
+    }
+
+    return { stdout, stderr };
+  } catch (error) {
+    const err = error;
+
+    if (typeof err?.stdout === "string" && err.stdout.length > 0) {
+      process.stdout.write(err.stdout);
+    }
+
+    if (typeof err?.stderr === "string" && err.stderr.length > 0) {
+      process.stderr.write(err.stderr);
+    }
+
+    throw new Error(
+      `Command failed: ${command} ${args.join(" ")} (exit code ${String(err?.code ?? "unknown")})`,
+    );
+  }
+}
+
+async function main() {
+  const repoRoot = process.cwd();
+  let tempProject;
+  let tarballPath;
+
+  try {
+    const packed = await run("npm", ["pack", "--json"], repoRoot);
+    const jsonStart =
+      packed.stdout.lastIndexOf("\n[") >= 0
+        ? packed.stdout.lastIndexOf("\n[") + 1
+        : packed.stdout.indexOf("[");
+
+    if (jsonStart < 0) {
+      throw new Error("npm pack output did not contain JSON metadata");
+    }
+
+    const packMeta = JSON.parse(packed.stdout.slice(jsonStart).trim());
+
+    if (!Array.isArray(packMeta) || packMeta.length === 0) {
+      throw new Error("npm pack returned no metadata");
+    }
+
+    const firstEntry = packMeta[0];
+    if (
+      !firstEntry ||
+      typeof firstEntry.filename !== "string" ||
+      firstEntry.filename.length === 0
+    ) {
+      throw new Error("npm pack did not return tarball filename");
+    }
+
+    tarballPath = join(repoRoot, firstEntry.filename);
+    tempProject = await mkdtemp(join(tmpdir(), "linearis-pack-verify-"));
+
+    await run("npm", ["init", "-y"], tempProject);
+    await run("npm", ["install", tarballPath], tempProject);
+    await run("npx", ["--no-install", "linearis", "usage"], tempProject);
+    await run("npx", ["--no-install", "linear", "usage"], tempProject);
+
+    console.log("✅ Packed artifact exposes both binaries: linearis + linear");
+  } finally {
+    if (tempProject) {
+      await rm(tempProject, { recursive: true, force: true });
+    }
+
+    if (tarballPath) {
+      await rm(tarballPath, { force: true });
+    }
+  }
+}
+
+main().catch((error) => {
+  const message = error instanceof Error ? error.message : String(error);
+  console.error(`❌ Binary verification failed: ${message}`);
+  process.exit(1);
+});

--- a/src/common/usage.ts
+++ b/src/common/usage.ts
@@ -13,6 +13,7 @@ export function formatOverview(version: string, metas: DomainMeta[]): string {
   lines.push(
     `linearis v${version} — CLI for Linear.app (project management / issue tracking)`,
   );
+  lines.push("alias: linear (supported alias; docs/examples use linearis)");
   lines.push(
     "auth: linearis auth login | --api-token <token> | LINEAR_API_TOKEN | ~/.linearis/token",
   );

--- a/tests/unit/common/usage.test.ts
+++ b/tests/unit/common/usage.test.ts
@@ -28,6 +28,9 @@ describe("formatOverview", () => {
     const result = formatOverview("2025.12.3", metas);
 
     expect(result).toContain("linearis v2025.12.3");
+    expect(result).toContain(
+      "alias: linear (supported alias; docs/examples use linearis)",
+    );
     expect(result).toContain("CLI for Linear.app");
     expect(result).toContain(
       "auth: linearis auth login | --api-token <token> | LINEAR_API_TOKEN | ~/.linearis/token",


### PR DESCRIPTION
## What does this PR do?

Adds `linear` as a fully supported alias for `linearis` and enforces binary availability from packed artifacts.

Also updates CI/release/docs so both binaries are validated consistently.

Closes #143

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [x] Tests
- [x] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Ran locally:

- `npm run verify:packed-binaries` (validates `npx linearis usage` + `npx linear usage` from packed tarball)
- `npm run check:ci`
- `npx tsc --noEmit`
- `npm test`
- `npm run build`

All passed.

## Notes for reviewers

- Canonical docs/examples remain `linearis`; `linear` is documented as supported alias.
- Added deterministic packed-artifact verifier (`scripts/verify-packed-binaries.mjs`) and wired it into CI smoke test + release script.
