### PR TITLE
feat(issues): add --estimate and --clear-estimate to issues commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file. The format 
 
 ## [Unreleased]
 
+### Fixed
+
+- enforce strict team-scale estimate validation for `issues create --estimate` and `issues update --estimate`, including hard fail when team estimates are disabled (`notUsed`)
+
 ---
 
 ## [2026.4.5] - 2026-04-19

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import type { CommandContext } from "../common/context.js";
 import { createContext } from "../common/context.js";
+import { validateEstimateAgainstTeamConfig } from "../common/estimate-validation.js";
 import {
   isUuid,
   parseDueDate,
@@ -20,12 +21,18 @@ import {
   type IssueUpdateInput,
 } from "../gql/graphql.js";
 import { resolveCycleId } from "../resolvers/cycle-resolver.js";
-import { resolveIssueId } from "../resolvers/issue-resolver.js";
+import {
+  resolveIssueEstimateContext,
+  resolveIssueId,
+} from "../resolvers/issue-resolver.js";
 import { resolveLabelIds } from "../resolvers/label-resolver.js";
 import { resolveMilestoneId } from "../resolvers/milestone-resolver.js";
 import { resolveProjectId } from "../resolvers/project-resolver.js";
 import { resolveStatusId } from "../resolvers/status-resolver.js";
-import { resolveTeamId } from "../resolvers/team-resolver.js";
+import {
+  resolveTeamEstimateContext,
+  resolveTeamId,
+} from "../resolvers/team-resolver.js";
 import { resolveUserId } from "../resolvers/user-resolver.js";
 import { buildIssueFilter } from "../services/issue-filter.js";
 import {
@@ -445,7 +452,26 @@ export function setupIssuesCommands(program: Command): void {
         if (!options.team) {
           throw new Error("--team is required");
         }
-        const teamId = await resolveTeamId(ctx.sdk, options.team);
+
+        const teamEstimateContext =
+          parsedEstimate !== undefined
+            ? await resolveTeamEstimateContext(ctx.sdk, options.team)
+            : undefined;
+
+        const teamId = teamEstimateContext
+          ? teamEstimateContext.teamId
+          : await resolveTeamId(ctx.sdk, options.team);
+
+        if (parsedEstimate !== undefined && teamEstimateContext) {
+          validateEstimateAgainstTeamConfig(parsedEstimate, {
+            teamKey: teamEstimateContext.teamKey,
+            issueEstimationType: teamEstimateContext.issueEstimationType,
+            issueEstimationExtended:
+              teamEstimateContext.issueEstimationExtended,
+            issueEstimationAllowZero:
+              teamEstimateContext.issueEstimationAllowZero,
+          });
+        }
 
         const input: IssueCreateInput = {
           title,
@@ -623,7 +649,25 @@ export function setupIssuesCommands(program: Command): void {
 
         const ctx = createContext(command.parent!.parent!.opts());
 
-        const resolvedIssueId = await resolveIssueId(ctx.sdk, issue);
+        const issueEstimateContext =
+          parsedEstimate !== undefined
+            ? await resolveIssueEstimateContext(ctx.sdk, issue)
+            : undefined;
+
+        const resolvedIssueId = issueEstimateContext
+          ? issueEstimateContext.issueId
+          : await resolveIssueId(ctx.sdk, issue);
+
+        if (parsedEstimate !== undefined && issueEstimateContext) {
+          validateEstimateAgainstTeamConfig(parsedEstimate, {
+            teamKey: issueEstimateContext.team.teamKey,
+            issueEstimationType: issueEstimateContext.team.issueEstimationType,
+            issueEstimationExtended:
+              issueEstimateContext.team.issueEstimationExtended,
+            issueEstimationAllowZero:
+              issueEstimateContext.team.issueEstimationAllowZero,
+          });
+        }
 
         const needsContext =
           options.status ||

--- a/src/common/estimate-validation.ts
+++ b/src/common/estimate-validation.ts
@@ -1,0 +1,95 @@
+import { invalidParameterError } from "./errors.js";
+
+export interface TeamEstimateValidationContext {
+  teamKey: string;
+  issueEstimationType:
+    | "notUsed"
+    | "exponential"
+    | "fibonacci"
+    | "linear"
+    | "tShirt";
+  issueEstimationExtended: boolean;
+  issueEstimationAllowZero: boolean;
+}
+
+function describeScale(config: TeamEstimateValidationContext): string {
+  const flags: string[] = [config.issueEstimationType];
+  if (config.issueEstimationExtended) flags.push("extended");
+  if (config.issueEstimationAllowZero) flags.push("zero allowed");
+  return flags.join(", ");
+}
+
+function baseScale(
+  type: TeamEstimateValidationContext["issueEstimationType"],
+): number[] {
+  switch (type) {
+    case "exponential":
+      return [1, 2, 4, 8, 16];
+    case "fibonacci":
+    case "tShirt":
+      return [1, 2, 3, 5, 8];
+    case "linear":
+      return [1, 2, 3, 4, 5];
+    case "notUsed":
+      return [];
+    default:
+      throw new Error(`Unknown issueEstimationType: "${String(type)}"`);
+  }
+}
+
+function extendedScale(
+  type: TeamEstimateValidationContext["issueEstimationType"],
+): number[] {
+  switch (type) {
+    case "exponential":
+      return [32, 64];
+    case "fibonacci":
+    case "tShirt":
+      return [13, 21];
+    case "linear":
+      return [6, 7];
+    case "notUsed":
+      return [];
+    default:
+      throw new Error(`Unknown issueEstimationType: "${String(type)}"`);
+  }
+}
+
+export function getAllowedEstimates(
+  config: TeamEstimateValidationContext,
+): number[] {
+  if (config.issueEstimationType === "notUsed") {
+    return [];
+  }
+
+  const values = [...baseScale(config.issueEstimationType)];
+  if (config.issueEstimationExtended) {
+    values.push(...extendedScale(config.issueEstimationType));
+  }
+
+  if (config.issueEstimationAllowZero && !values.includes(0)) {
+    values.unshift(0);
+  }
+
+  return values;
+}
+
+export function validateEstimateAgainstTeamConfig(
+  estimate: number,
+  config: TeamEstimateValidationContext,
+): void {
+  if (config.issueEstimationType === "notUsed") {
+    throw invalidParameterError(
+      "--estimate",
+      `team "${config.teamKey}" has estimates disabled (issueEstimationType=notUsed)`,
+    );
+  }
+
+  const allowed = getAllowedEstimates(config);
+  if (!allowed.includes(estimate)) {
+    throw invalidParameterError(
+      "--estimate",
+      `must be one of [${allowed.join(", ")}] for team "${config.teamKey}" (${describeScale(config)})`,
+    );
+  }
+}

--- a/src/resolvers/issue-resolver.ts
+++ b/src/resolvers/issue-resolver.ts
@@ -1,6 +1,113 @@
 import type { LinearSdkClient } from "../client/linear-client.js";
 import { notFoundError } from "../common/errors.js";
 import { isUuid, parseIssueIdentifier } from "../common/identifier.js";
+import type { TeamEstimateContext } from "./team-resolver.js";
+
+type TeamEstimationType =
+  | "notUsed"
+  | "exponential"
+  | "fibonacci"
+  | "linear"
+  | "tShirt";
+
+type IssueEstimateNode = {
+  id: string;
+  team: {
+    id: string;
+    key: string;
+    name: string;
+    issueEstimationType: TeamEstimationType;
+    issueEstimationExtended: boolean;
+    issueEstimationAllowZero: boolean;
+  };
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isTeamEstimationType(value: unknown): value is TeamEstimationType {
+  return (
+    value === "notUsed" ||
+    value === "exponential" ||
+    value === "fibonacci" ||
+    value === "linear" ||
+    value === "tShirt"
+  );
+}
+
+function toIssueEstimateNode(
+  node: unknown,
+  issueIdOrIdentifier: string,
+): IssueEstimateNode {
+  if (!isRecord(node)) {
+    throw new Error(
+      `Issue "${issueIdOrIdentifier}" is missing required team estimation context`,
+    );
+  }
+
+  const issueId = node.id;
+  const team = node.team;
+
+  if (typeof issueId !== "string" || !isRecord(team)) {
+    throw new Error(
+      `Issue "${issueIdOrIdentifier}" is missing required team estimation context`,
+    );
+  }
+
+  const teamId = team.id;
+  const teamKey = team.key;
+  const teamName = team.name;
+  const issueEstimationType = team.issueEstimationType;
+  const issueEstimationExtended = team.issueEstimationExtended;
+  const issueEstimationAllowZero = team.issueEstimationAllowZero;
+
+  if (
+    typeof teamId !== "string" ||
+    typeof teamKey !== "string" ||
+    typeof teamName !== "string" ||
+    !isTeamEstimationType(issueEstimationType) ||
+    typeof issueEstimationExtended !== "boolean" ||
+    typeof issueEstimationAllowZero !== "boolean"
+  ) {
+    throw new Error(
+      `Issue "${issueIdOrIdentifier}" is missing required team estimation context`,
+    );
+  }
+
+  return {
+    id: issueId,
+    team: {
+      id: teamId,
+      key: teamKey,
+      name: teamName,
+      issueEstimationType,
+      issueEstimationExtended,
+      issueEstimationAllowZero,
+    },
+  };
+}
+
+function mapIssueNodeToEstimateContext(
+  node: IssueEstimateNode,
+): IssueEstimateContext {
+  return {
+    issueId: node.id,
+    team: {
+      teamId: node.team.id,
+      teamKey: node.team.key,
+      teamName: node.team.name,
+      issueEstimationType: node.team.issueEstimationType,
+      issueEstimationExtended: node.team.issueEstimationExtended,
+      issueEstimationAllowZero: node.team.issueEstimationAllowZero,
+    },
+  };
+}
+
+export interface IssueEstimateContext {
+  issueId: string;
+  team: TeamEstimateContext;
+}
 
 /**
  * Resolves issue identifier to UUID.
@@ -33,4 +140,34 @@ export async function resolveIssueId(
   }
 
   return issues.nodes[0].id;
+}
+
+export async function resolveIssueEstimateContext(
+  client: LinearSdkClient,
+  issueIdOrIdentifier: string,
+): Promise<IssueEstimateContext> {
+  const issues = isUuid(issueIdOrIdentifier)
+    ? await client.sdk.issues({
+        filter: { id: { eq: issueIdOrIdentifier } },
+        first: 1,
+      })
+    : await client.sdk.issues({
+        filter: {
+          number: {
+            eq: parseIssueIdentifier(issueIdOrIdentifier).issueNumber,
+          },
+          team: {
+            key: { eq: parseIssueIdentifier(issueIdOrIdentifier).teamKey },
+          },
+        },
+        first: 1,
+      });
+
+  if (issues.nodes.length === 0) {
+    throw notFoundError("Issue", issueIdOrIdentifier);
+  }
+
+  return mapIssueNodeToEstimateContext(
+    toIssueEstimateNode(issues.nodes[0], issueIdOrIdentifier),
+  );
 }

--- a/src/resolvers/team-resolver.ts
+++ b/src/resolvers/team-resolver.ts
@@ -2,6 +2,138 @@ import type { LinearSdkClient } from "../client/linear-client.js";
 import { notFoundError } from "../common/errors.js";
 import { isUuid } from "../common/identifier.js";
 
+type TeamEstimationType =
+  | "notUsed"
+  | "exponential"
+  | "fibonacci"
+  | "linear"
+  | "tShirt";
+
+export interface TeamEstimateContext {
+  teamId: string;
+  teamKey: string;
+  teamName: string;
+  issueEstimationType: TeamEstimationType;
+  issueEstimationExtended: boolean;
+  issueEstimationAllowZero: boolean;
+}
+
+type TeamEstimateNode = {
+  id: string;
+  key: string;
+  name: string;
+  issueEstimationType: TeamEstimationType;
+  issueEstimationExtended: boolean;
+  issueEstimationAllowZero: boolean;
+};
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isTeamEstimationType(value: unknown): value is TeamEstimationType {
+  return (
+    value === "notUsed" ||
+    value === "exponential" ||
+    value === "fibonacci" ||
+    value === "linear" ||
+    value === "tShirt"
+  );
+}
+
+function toTeamEstimateNode(
+  node: unknown,
+  keyOrNameOrId: string,
+): TeamEstimateNode {
+  if (!isRecord(node)) {
+    throw new Error(
+      `Team "${keyOrNameOrId}" is missing required estimation context`,
+    );
+  }
+
+  const id = node.id;
+  const key = node.key;
+  const name = node.name;
+  const issueEstimationType = node.issueEstimationType;
+  const issueEstimationExtended = node.issueEstimationExtended;
+  const issueEstimationAllowZero = node.issueEstimationAllowZero;
+
+  if (
+    typeof id !== "string" ||
+    typeof key !== "string" ||
+    typeof name !== "string" ||
+    !isTeamEstimationType(issueEstimationType) ||
+    typeof issueEstimationExtended !== "boolean" ||
+    typeof issueEstimationAllowZero !== "boolean"
+  ) {
+    throw new Error(
+      `Team "${keyOrNameOrId}" is missing required estimation context`,
+    );
+  }
+
+  return {
+    id,
+    key,
+    name,
+    issueEstimationType,
+    issueEstimationExtended,
+    issueEstimationAllowZero,
+  };
+}
+
+function mapTeamNodeToEstimateContext(
+  node: TeamEstimateNode,
+): TeamEstimateContext {
+  return {
+    teamId: node.id,
+    teamKey: node.key,
+    teamName: node.name,
+    issueEstimationType: node.issueEstimationType,
+    issueEstimationExtended: node.issueEstimationExtended,
+    issueEstimationAllowZero: node.issueEstimationAllowZero,
+  };
+}
+
+export async function resolveTeamEstimateContext(
+  client: LinearSdkClient,
+  keyOrNameOrId: string,
+): Promise<TeamEstimateContext> {
+  if (isUuid(keyOrNameOrId)) {
+    const byId = await client.sdk.teams({
+      filter: { id: { eq: keyOrNameOrId } },
+      first: 1,
+    });
+    if (byId.nodes.length > 0) {
+      return mapTeamNodeToEstimateContext(
+        toTeamEstimateNode(byId.nodes[0], keyOrNameOrId),
+      );
+    }
+    throw notFoundError("Team", keyOrNameOrId);
+  }
+
+  const byKey = await client.sdk.teams({
+    filter: { key: { eq: keyOrNameOrId } },
+    first: 1,
+  });
+  if (byKey.nodes.length > 0) {
+    return mapTeamNodeToEstimateContext(
+      toTeamEstimateNode(byKey.nodes[0], keyOrNameOrId),
+    );
+  }
+
+  const byName = await client.sdk.teams({
+    filter: { name: { eq: keyOrNameOrId } },
+    first: 1,
+  });
+  if (byName.nodes.length > 0) {
+    return mapTeamNodeToEstimateContext(
+      toTeamEstimateNode(byName.nodes[0], keyOrNameOrId),
+    );
+  }
+
+  throw notFoundError("Team", keyOrNameOrId);
+}
+
 export async function resolveTeamId(
   client: LinearSdkClient,
   keyOrNameOrId: string,

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -25,10 +25,29 @@ vi.mock("../../../src/resolvers/user-resolver.js", () => ({
 
 vi.mock("../../../src/resolvers/team-resolver.js", () => ({
   resolveTeamId: vi.fn().mockResolvedValue("resolved-team-uuid"),
+  resolveTeamEstimateContext: vi.fn().mockResolvedValue({
+    teamId: "resolved-team-uuid",
+    teamKey: "ENG",
+    teamName: "Engineering",
+    issueEstimationType: "fibonacci",
+    issueEstimationExtended: false,
+    issueEstimationAllowZero: false,
+  }),
 }));
 
 vi.mock("../../../src/resolvers/issue-resolver.js", () => ({
   resolveIssueId: vi.fn().mockResolvedValue("resolved-issue-uuid"),
+  resolveIssueEstimateContext: vi.fn().mockResolvedValue({
+    issueId: "resolved-issue-uuid",
+    team: {
+      teamId: "team-uuid",
+      teamKey: "ENG",
+      teamName: "Engineering",
+      issueEstimationType: "linear",
+      issueEstimationExtended: false,
+      issueEstimationAllowZero: false,
+    },
+  }),
 }));
 
 vi.mock("../../../src/resolvers/project-resolver.js", () => ({
@@ -77,8 +96,14 @@ vi.mock("../../../src/services/issue-relation-service.js", () => ({
 }));
 
 import { setupIssuesCommands } from "../../../src/commands/issues.js";
-import { resolveIssueId } from "../../../src/resolvers/issue-resolver.js";
-import { resolveTeamId } from "../../../src/resolvers/team-resolver.js";
+import {
+  resolveIssueEstimateContext,
+  resolveIssueId,
+} from "../../../src/resolvers/issue-resolver.js";
+import {
+  resolveTeamEstimateContext,
+  resolveTeamId,
+} from "../../../src/resolvers/team-resolver.js";
 import { resolveUserId } from "../../../src/resolvers/user-resolver.js";
 import {
   createIssue,
@@ -197,7 +222,16 @@ describe("issues create --estimate", () => {
     );
   });
 
-  it("passes estimate 0 through to createIssue", async () => {
+  it("passes estimate 0 through to createIssue when team allows zero", async () => {
+    vi.mocked(resolveTeamEstimateContext).mockResolvedValueOnce({
+      teamId: "resolved-team-uuid",
+      teamKey: "ENG",
+      teamName: "Engineering",
+      issueEstimationType: "fibonacci",
+      issueEstimationExtended: false,
+      issueEstimationAllowZero: true,
+    });
+
     const program = createProgram();
     await program.parseAsync([
       "node",
@@ -233,6 +267,62 @@ describe("issues create --estimate", () => {
       expect.anything(),
       expect.not.objectContaining({ estimate: expect.anything() }),
     );
+  });
+
+  it("rejects create estimate outside team scale before mutation", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "create",
+      "Strict estimate",
+      "--team",
+      "ENG",
+      "--estimate",
+      "9",
+    ]);
+
+    const outOfScaleCreateError = JSON.parse(
+      vi.mocked(console.error).mock.calls[0][0] as string,
+    ) as { error: string };
+    expect(outOfScaleCreateError.error).toBe(
+      'Invalid --estimate: must be one of [1, 2, 3, 5, 8] for team "ENG" (fibonacci)',
+    );
+    expect(createIssue).not.toHaveBeenCalled();
+  });
+
+  it("rejects create estimate when team estimation disabled", async () => {
+    vi.mocked(resolveTeamEstimateContext).mockResolvedValueOnce({
+      teamId: "resolved-team-uuid",
+      teamKey: "ENG",
+      teamName: "Engineering",
+      issueEstimationType: "notUsed",
+      issueEstimationExtended: false,
+      issueEstimationAllowZero: false,
+    });
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "create",
+      "Strict estimate",
+      "--team",
+      "ENG",
+      "--estimate",
+      "3",
+    ]);
+
+    const disabledEstimationCreateError = JSON.parse(
+      vi.mocked(console.error).mock.calls[0][0] as string,
+    ) as { error: string };
+    expect(disabledEstimationCreateError.error).toBe(
+      'Invalid --estimate: team "ENG" has estimates disabled (issueEstimationType=notUsed)',
+    );
+    expect(createIssue).not.toHaveBeenCalled();
   });
 });
 
@@ -396,13 +486,13 @@ describe("issues update --estimate", () => {
       "update",
       "ENG-42",
       "--estimate",
-      "8",
+      "3",
     ]);
 
     expect(updateIssue).toHaveBeenCalledWith(
       expect.anything(),
       "resolved-issue-uuid",
-      expect.objectContaining({ estimate: 8 }),
+      expect.objectContaining({ estimate: 3 }),
     );
   });
 
@@ -421,6 +511,45 @@ describe("issues update --estimate", () => {
       expect.anything(),
       "resolved-issue-uuid",
       expect.objectContaining({ estimate: null }),
+    );
+  });
+
+  it("rejects update estimate outside issue team scale before mutation", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--estimate",
+      "8",
+    ]);
+
+    const outOfScaleUpdateError = JSON.parse(
+      vi.mocked(console.error).mock.calls[0][0] as string,
+    ) as { error: string };
+    expect(outOfScaleUpdateError.error).toBe(
+      'Invalid --estimate: must be one of [1, 2, 3, 4, 5] for team "ENG" (linear)',
+    );
+    expect(updateIssue).not.toHaveBeenCalled();
+  });
+
+  it("uses issue estimate context resolver when --estimate is present", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--estimate",
+      "3",
+    ]);
+
+    expect(resolveIssueEstimateContext).toHaveBeenCalledWith(
+      expect.anything(),
+      "ENG-42",
     );
   });
 
@@ -454,6 +583,25 @@ describe("issues update --estimate", () => {
     ]);
 
     expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("skips scale validation when --clear-estimate is used", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--clear-estimate",
+    ]);
+
+    expect(resolveIssueEstimateContext).not.toHaveBeenCalled();
+    expect(updateIssue).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+      expect.objectContaining({ estimate: null }),
+    );
   });
 });
 
@@ -518,13 +666,13 @@ describe("issues update numeric option validation", () => {
       "--priority",
       "1",
       "--estimate",
-      "8",
+      "5",
     ]);
 
     expect(updateIssue).toHaveBeenCalledWith(
       expect.anything(),
       "resolved-issue-uuid",
-      expect.objectContaining({ priority: 1, estimate: 8 }),
+      expect.objectContaining({ priority: 1, estimate: 5 }),
     );
   });
 });

--- a/tests/unit/common/estimate-validation.test.ts
+++ b/tests/unit/common/estimate-validation.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from "vitest";
+import {
+  getAllowedEstimates,
+  type TeamEstimateValidationContext,
+  validateEstimateAgainstTeamConfig,
+} from "../../../src/common/estimate-validation.js";
+
+const base: Omit<TeamEstimateValidationContext, "issueEstimationType"> = {
+  teamKey: "ENG",
+  issueEstimationExtended: false,
+  issueEstimationAllowZero: false,
+};
+
+describe("getAllowedEstimates", () => {
+  it("returns exponential base scale", () => {
+    expect(
+      getAllowedEstimates({ ...base, issueEstimationType: "exponential" }),
+    ).toEqual([1, 2, 4, 8, 16]);
+  });
+
+  it("returns exponential extended scale", () => {
+    expect(
+      getAllowedEstimates({
+        ...base,
+        issueEstimationType: "exponential",
+        issueEstimationExtended: true,
+      }),
+    ).toEqual([1, 2, 4, 8, 16, 32, 64]);
+  });
+
+  it("returns linear base scale", () => {
+    expect(
+      getAllowedEstimates({ ...base, issueEstimationType: "linear" }),
+    ).toEqual([1, 2, 3, 4, 5]);
+  });
+
+  it("returns linear zero-enabled scale", () => {
+    expect(
+      getAllowedEstimates({
+        ...base,
+        issueEstimationType: "linear",
+        issueEstimationAllowZero: true,
+      }),
+    ).toEqual([0, 1, 2, 3, 4, 5]);
+  });
+
+  it("returns empty scale for notUsed", () => {
+    expect(
+      getAllowedEstimates({ ...base, issueEstimationType: "notUsed" }),
+    ).toEqual([]);
+  });
+
+  it("returns fibonacci extended + zero scale", () => {
+    expect(
+      getAllowedEstimates({
+        ...base,
+        issueEstimationType: "fibonacci",
+        issueEstimationExtended: true,
+        issueEstimationAllowZero: true,
+      }),
+    ).toEqual([0, 1, 2, 3, 5, 8, 13, 21]);
+  });
+
+  it("maps tShirt to fibonacci buckets", () => {
+    expect(
+      getAllowedEstimates({ ...base, issueEstimationType: "tShirt" }),
+    ).toEqual([1, 2, 3, 5, 8]);
+  });
+});
+
+describe("validateEstimateAgainstTeamConfig", () => {
+  it("throws deterministic disabled-estimation error for notUsed", () => {
+    expect(() =>
+      validateEstimateAgainstTeamConfig(3, {
+        ...base,
+        issueEstimationType: "notUsed",
+      }),
+    ).toThrow(
+      'Invalid --estimate: team "ENG" has estimates disabled (issueEstimationType=notUsed)',
+    );
+  });
+
+  it("throws deterministic out-of-scale error", () => {
+    expect(() =>
+      validateEstimateAgainstTeamConfig(9, {
+        ...base,
+        issueEstimationType: "linear",
+      }),
+    ).toThrow(
+      'Invalid --estimate: must be one of [1, 2, 3, 4, 5] for team "ENG" (linear)',
+    );
+  });
+
+  it("throws explicit internal error for unknown estimation type", () => {
+    expect(() =>
+      getAllowedEstimates({
+        ...base,
+        issueEstimationType:
+          "mystery" as TeamEstimateValidationContext["issueEstimationType"],
+      }),
+    ).toThrow('Unknown issueEstimationType: "mystery"');
+  });
+});

--- a/tests/unit/resolvers/issue-resolver.test.ts
+++ b/tests/unit/resolvers/issue-resolver.test.ts
@@ -1,9 +1,29 @@
 // tests/unit/resolvers/issue-resolver.test.ts
 import { describe, expect, it, vi } from "vitest";
 import type { LinearSdkClient } from "../../../src/client/linear-client.js";
-import { resolveIssueId } from "../../../src/resolvers/issue-resolver.js";
+import {
+  resolveIssueEstimateContext,
+  resolveIssueId,
+} from "../../../src/resolvers/issue-resolver.js";
 
-function mockSdkClient(nodes: Array<{ id: string }>) {
+type IssueNode = {
+  id: string;
+  team?: {
+    id: string;
+    key: string;
+    name: string;
+    issueEstimationType:
+      | "notUsed"
+      | "exponential"
+      | "fibonacci"
+      | "linear"
+      | "tShirt";
+    issueEstimationExtended: boolean;
+    issueEstimationAllowZero: boolean;
+  };
+};
+
+function mockSdkClient(nodes: IssueNode[]) {
   return {
     sdk: {
       issues: vi.fn().mockResolvedValue({ nodes }),
@@ -31,6 +51,92 @@ describe("resolveIssueId", () => {
     const client = mockSdkClient([]);
     await expect(resolveIssueId(client, "ENG-999")).rejects.toThrow(
       'Issue "ENG-999" not found',
+    );
+  });
+});
+
+describe("resolveIssueEstimateContext", () => {
+  it("resolves by identifier with issueId + nested team estimate context fields", async () => {
+    const client = mockSdkClient([
+      {
+        id: "issue-uuid",
+        team: {
+          id: "team-uuid",
+          key: "ENG",
+          name: "Engineering",
+          issueEstimationType: "exponential",
+          issueEstimationExtended: false,
+          issueEstimationAllowZero: false,
+        },
+      },
+    ]);
+
+    await expect(
+      resolveIssueEstimateContext(client, "ENG-42"),
+    ).resolves.toEqual({
+      issueId: "issue-uuid",
+      team: {
+        teamId: "team-uuid",
+        teamKey: "ENG",
+        teamName: "Engineering",
+        issueEstimationType: "exponential",
+        issueEstimationExtended: false,
+        issueEstimationAllowZero: false,
+      },
+    });
+  });
+
+  it("resolves by UUID and verifies sdk issues filter id eq", async () => {
+    const issues = vi.fn().mockResolvedValue({
+      nodes: [
+        {
+          id: "issue-uuid",
+          team: {
+            id: "team-uuid",
+            key: "OPS",
+            name: "Operations",
+            issueEstimationType: "linear",
+            issueEstimationExtended: true,
+            issueEstimationAllowZero: true,
+          },
+        },
+      ],
+    });
+
+    const client = { sdk: { issues } } as unknown as LinearSdkClient;
+
+    await resolveIssueEstimateContext(
+      client,
+      "550e8400-e29b-41d4-a716-446655440000",
+    );
+
+    expect(issues).toHaveBeenCalledWith({
+      filter: { id: { eq: "550e8400-e29b-41d4-a716-446655440000" } },
+      first: 1,
+    });
+  });
+
+  it("throws Issue not found", async () => {
+    const client = mockSdkClient([]);
+
+    await expect(
+      resolveIssueEstimateContext(client, "ENG-999"),
+    ).rejects.toThrow('Issue "ENG-999" not found');
+  });
+
+  it("throws when issue team estimation context is missing", async () => {
+    const issues = vi.fn().mockResolvedValue({
+      nodes: [
+        {
+          id: "issue-uuid",
+        },
+      ],
+    });
+
+    const client = { sdk: { issues } } as unknown as LinearSdkClient;
+
+    await expect(resolveIssueEstimateContext(client, "ENG-42")).rejects.toThrow(
+      'Issue "ENG-42" is missing required team estimation context',
     );
   });
 });

--- a/tests/unit/resolvers/team-resolver.test.ts
+++ b/tests/unit/resolvers/team-resolver.test.ts
@@ -1,11 +1,26 @@
 // tests/unit/resolvers/team-resolver.test.ts
 import { describe, expect, it, vi } from "vitest";
 import type { LinearSdkClient } from "../../../src/client/linear-client.js";
-import { resolveTeamId } from "../../../src/resolvers/team-resolver.js";
+import {
+  resolveTeamEstimateContext,
+  resolveTeamId,
+} from "../../../src/resolvers/team-resolver.js";
 
 function mockSdkClient(
   ...callResults: Array<{
-    nodes: Array<{ id: string; key?: string; name?: string }>;
+    nodes: Array<{
+      id: string;
+      key?: string;
+      name?: string;
+      issueEstimationType?:
+        | "notUsed"
+        | "exponential"
+        | "fibonacci"
+        | "linear"
+        | "tShirt";
+      issueEstimationExtended?: boolean;
+      issueEstimationAllowZero?: boolean;
+    }>;
   }>
 ) {
   const teams = vi.fn();
@@ -44,6 +59,118 @@ describe("resolveTeamId", () => {
   it("throws when team not found by key or name", async () => {
     const client = mockSdkClient({ nodes: [] }, { nodes: [] });
     await expect(resolveTeamId(client, "NOPE")).rejects.toThrow(
+      'Team "NOPE" not found',
+    );
+  });
+});
+
+describe("resolveTeamEstimateContext", () => {
+  it("resolves by key with full context fields", async () => {
+    const client = mockSdkClient({
+      nodes: [
+        {
+          id: "uuid-1",
+          key: "ENG",
+          name: "Engineering",
+          issueEstimationType: "fibonacci",
+          issueEstimationExtended: true,
+          issueEstimationAllowZero: false,
+        },
+      ],
+    });
+
+    await expect(resolveTeamEstimateContext(client, "ENG")).resolves.toEqual({
+      teamId: "uuid-1",
+      teamKey: "ENG",
+      teamName: "Engineering",
+      issueEstimationType: "fibonacci",
+      issueEstimationExtended: true,
+      issueEstimationAllowZero: false,
+    });
+  });
+
+  it("resolves by UUID and queries sdk with id eq filter", async () => {
+    const client = mockSdkClient({
+      nodes: [
+        {
+          id: "team-uuid",
+          key: "OPS",
+          name: "Operations",
+          issueEstimationType: "linear",
+          issueEstimationExtended: false,
+          issueEstimationAllowZero: true,
+        },
+      ],
+    });
+
+    const result = await resolveTeamEstimateContext(
+      client,
+      "550e8400-e29b-41d4-a716-446655440000",
+    );
+
+    expect(result.teamId).toBe("team-uuid");
+    expect(client.sdk.teams).toHaveBeenCalledWith({
+      filter: { id: { eq: "550e8400-e29b-41d4-a716-446655440000" } },
+      first: 1,
+    });
+  });
+
+  it("falls back to name when key lookup misses", async () => {
+    const client = mockSdkClient(
+      { nodes: [] },
+      {
+        nodes: [
+          {
+            id: "uuid-2",
+            key: "ENG",
+            name: "Engineering",
+            issueEstimationType: "linear",
+            issueEstimationExtended: false,
+            issueEstimationAllowZero: true,
+          },
+        ],
+      },
+    );
+
+    await expect(
+      resolveTeamEstimateContext(client, "Engineering"),
+    ).resolves.toEqual({
+      teamId: "uuid-2",
+      teamKey: "ENG",
+      teamName: "Engineering",
+      issueEstimationType: "linear",
+      issueEstimationExtended: false,
+      issueEstimationAllowZero: true,
+    });
+
+    expect(client.sdk.teams).toHaveBeenNthCalledWith(1, {
+      filter: { key: { eq: "Engineering" } },
+      first: 1,
+    });
+    expect(client.sdk.teams).toHaveBeenNthCalledWith(2, {
+      filter: { name: { eq: "Engineering" } },
+      first: 1,
+    });
+  });
+
+  it("throws not found for UUID when id lookup has no nodes and does not fallback", async () => {
+    const teamId = "550e8400-e29b-41d4-a716-446655440000";
+    const client = mockSdkClient({ nodes: [] });
+
+    await expect(resolveTeamEstimateContext(client, teamId)).rejects.toThrow(
+      `Team "${teamId}" not found`,
+    );
+
+    expect(client.sdk.teams).toHaveBeenCalledTimes(1);
+    expect(client.sdk.teams).toHaveBeenCalledWith({
+      filter: { id: { eq: teamId } },
+      first: 1,
+    });
+  });
+
+  it("throws not found when no nodes", async () => {
+    const client = mockSdkClient({ nodes: [] }, { nodes: [] });
+    await expect(resolveTeamEstimateContext(client, "NOPE")).rejects.toThrow(
       'Team "NOPE" not found',
     );
   });


### PR DESCRIPTION
## What does this PR do?

Adds estimate support to issues command workflows:
- `issues create --estimate`
- `issues update --estimate`
- `issues update --clear-estimate`

It also includes unit coverage for command wiring and service-layer handling of estimate set/clear behavior.

Refs #96

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build / CI

## Checklist

- [ ] `npm run check:ci` passes (lint + format)
- [ ] `npx tsc --noEmit` passes (type check)
- [ ] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `npx vitest run tests/unit/commands/issues.test.ts`
- `npx vitest run tests/unit/services/issue-service.test.ts`

## Notes for reviewers

- Branch restored from reflog to pre-"rebase onto next" state.
- Plan/spec documents are not included.
