### PR TITLE
feat(labels): add project label listing support

### DIFF
--- a/graphql/queries/labels.graphql
+++ b/graphql/queries/labels.graphql
@@ -22,6 +22,13 @@ fragment LabelFields on IssueLabel {
   description
 }
 
+fragment ProjectLabelFields on ProjectLabel {
+  id
+  name
+  color
+  description
+}
+
 # List labels in the workspace
 #
 # Fetches a list of issue labels with optional team filtering.
@@ -35,6 +42,18 @@ query GetLabels($first: Int = 50, $after: String, $filter: IssueLabelFilter) {
   issueLabels(first: $first, after: $after, filter: $filter) {
     nodes {
       ...LabelFields
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+
+query GetProjectLabels($first: Int = 50, $after: String) {
+  projectLabels(first: $first, after: $after) {
+    nodes {
+      ...ProjectLabelFields
     }
     pageInfo {
       hasNextPage

--- a/src/commands/labels.ts
+++ b/src/commands/labels.ts
@@ -1,25 +1,45 @@
 import type { Command } from "commander";
 import { type CommandOptions, createContext } from "../common/context.js";
+import { invalidParameterError } from "../common/errors.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import { resolveTeamId } from "../resolvers/team-resolver.js";
-import { listLabels } from "../services/label-service.js";
+import {
+  type LabelType,
+  listLabels,
+  listProjectLabels,
+} from "../services/label-service.js";
 
 interface ListLabelsOptions extends CommandOptions {
   team?: string;
+  type?: string;
   limit: string;
   after?: string;
 }
 
+function parseLabelType(value?: string): LabelType {
+  if (value === undefined || value === "issue" || value === "project") {
+    return value ?? "issue";
+  }
+
+  throw invalidParameterError("--type", 'must be one of "issue" or "project"');
+}
+
 export const LABELS_META: DomainMeta = {
   name: "labels",
-  summary: "categorization tags, workspace-wide or team-scoped",
+  summary: "categorization tags for issues and projects",
   context: [
-    "labels categorize issues. they can exist at workspace level or be",
-    "scoped to a specific team. use with issues create/update --labels.",
+    "issue labels can exist at workspace level or be scoped to a specific",
+    "team. project labels are workspace-level only. use with issues",
+    "create/update --labels and projects create/update --labels.",
   ].join("\n"),
   arguments: {},
-  seeAlso: ["issues create --labels", "issues update --labels"],
+  seeAlso: [
+    "issues create --labels",
+    "issues update --labels",
+    "projects create --labels",
+    "projects update --labels",
+  ],
 };
 
 export function setupLabelsCommands(program: Command): void {
@@ -30,6 +50,7 @@ export function setupLabelsCommands(program: Command): void {
   labels
     .command("list")
     .description("list available labels")
+    .option("--type <type>", "label type: issue (default) or project", "issue")
     .option("--team <team>", "filter by team (key, name, or UUID)")
     .option("-l, --limit <n>", "max results", "50")
     .option("--after <cursor>", "cursor for next page")
@@ -37,16 +58,29 @@ export function setupLabelsCommands(program: Command): void {
       handleCommand(async (...args: unknown[]) => {
         const [options, command] = args as [ListLabelsOptions, Command];
         const ctx = createContext(command.parent!.parent!.opts());
+        const type = parseLabelType(options.type);
+        const pagination = {
+          limit: parseLimit(options.limit),
+          after: options.after,
+        };
+
+        if (type === "project") {
+          if (options.team) {
+            throw invalidParameterError(
+              "--team",
+              "cannot be used with --type project because project labels are workspace-scoped",
+            );
+          }
+
+          outputSuccess(await listProjectLabels(ctx.gql, pagination));
+          return;
+        }
 
         const teamId = options.team
           ? await resolveTeamId(ctx.sdk, options.team)
           : undefined;
 
-        const result = await listLabels(ctx.gql, teamId, {
-          limit: parseLimit(options.limit),
-          after: options.after,
-        });
-        outputSuccess(result);
+        outputSuccess(await listLabels(ctx.gql, teamId, pagination));
       }),
     );
 

--- a/src/services/label-service.ts
+++ b/src/services/label-service.ts
@@ -1,12 +1,20 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
 import type { PaginatedResult, PaginationOptions } from "../common/types.js";
-import { GetLabelsDocument, type GetLabelsQuery } from "../gql/graphql.js";
+import {
+  GetLabelsDocument,
+  type GetLabelsQuery,
+  GetProjectLabelsDocument,
+  type GetProjectLabelsQuery,
+} from "../gql/graphql.js";
+
+export type LabelType = "issue" | "project";
 
 export interface Label {
   id: string;
   name: string;
   color: string;
   description?: string;
+  type: LabelType;
 }
 
 export async function listLabels(
@@ -29,7 +37,34 @@ export async function listLabels(
       name: label.name,
       color: label.color,
       description: label.description ?? undefined,
+      type: "issue",
     })),
     pageInfo: result.issueLabels.pageInfo,
+  };
+}
+
+export async function listProjectLabels(
+  client: GraphQLClient,
+  options: PaginationOptions = {},
+): Promise<PaginatedResult<Label>> {
+  const { limit = 50, after } = options;
+
+  const result = await client.request<GetProjectLabelsQuery>(
+    GetProjectLabelsDocument,
+    {
+      first: limit,
+      after,
+    },
+  );
+
+  return {
+    nodes: result.projectLabels.nodes.map((label) => ({
+      id: label.id,
+      name: label.name,
+      color: label.color,
+      description: label.description ?? undefined,
+      type: "project",
+    })),
+    pageInfo: result.projectLabels.pageInfo,
   };
 }

--- a/tests/unit/commands/labels.test.ts
+++ b/tests/unit/commands/labels.test.ts
@@ -1,0 +1,217 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/common/context.js", () => ({
+  createContext: vi.fn(() => ({
+    gql: { request: vi.fn() },
+    sdk: { sdk: {} },
+  })),
+}));
+
+vi.mock("../../../src/common/output.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../src/common/output.js")>();
+  return {
+    ...actual,
+    outputSuccess: vi.fn(),
+  };
+});
+
+vi.mock("../../../src/resolvers/team-resolver.js", () => ({
+  resolveTeamId: vi.fn().mockResolvedValue("resolved-team-uuid"),
+}));
+
+vi.mock("../../../src/services/label-service.js", () => ({
+  listLabels: vi.fn().mockResolvedValue({
+    nodes: [{ id: "lbl-1", name: "Bug", color: "#ff0000", type: "issue" }],
+    pageInfo: { hasNextPage: false, endCursor: null },
+  }),
+  listProjectLabels: vi.fn().mockResolvedValue({
+    nodes: [
+      {
+        id: "plbl-1",
+        name: "Customer",
+        color: "#0000ff",
+        type: "project",
+      },
+    ],
+    pageInfo: { hasNextPage: false, endCursor: null },
+  }),
+}));
+
+import { setupLabelsCommands } from "../../../src/commands/labels.js";
+import { outputSuccess } from "../../../src/common/output.js";
+import { resolveTeamId } from "../../../src/resolvers/team-resolver.js";
+import {
+  listLabels,
+  listProjectLabels,
+} from "../../../src/services/label-service.js";
+
+function createProgram(): Command {
+  const program = new Command();
+  program.option("--api-token <token>");
+  setupLabelsCommands(program);
+  return program;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.restoreAllMocks();
+  vi.spyOn(console, "log").mockImplementation(() => {});
+  vi.spyOn(console, "error").mockImplementation(() => {});
+  vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+});
+
+describe("labels list", () => {
+  it("routes to issue labels by default", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "test", "labels", "list"]);
+
+    expect(listLabels).toHaveBeenCalledWith(expect.anything(), undefined, {
+      limit: 50,
+      after: undefined,
+    });
+    expect(listProjectLabels).not.toHaveBeenCalled();
+    expect(resolveTeamId).not.toHaveBeenCalled();
+    expect(outputSuccess).toHaveBeenCalledWith({
+      nodes: [{ id: "lbl-1", name: "Bug", color: "#ff0000", type: "issue" }],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    });
+  });
+
+  it("resolves team and lists issue labels", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "list",
+      "--team",
+      "ENG",
+      "--limit",
+      "10",
+      "--after",
+      "cur1",
+    ]);
+
+    expect(resolveTeamId).toHaveBeenCalledWith(expect.anything(), "ENG");
+    expect(listLabels).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-team-uuid",
+      {
+        limit: 10,
+        after: "cur1",
+      },
+    );
+    expect(listProjectLabels).not.toHaveBeenCalled();
+  });
+
+  it("accepts an explicit issue type", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "list",
+      "--type",
+      "issue",
+    ]);
+
+    expect(listLabels).toHaveBeenCalledWith(expect.anything(), undefined, {
+      limit: 50,
+      after: undefined,
+    });
+    expect(listProjectLabels).not.toHaveBeenCalled();
+    expect(resolveTeamId).not.toHaveBeenCalled();
+  });
+
+  it("routes project label requests without team resolution", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "list",
+      "--type",
+      "project",
+      "--limit",
+      "25",
+      "--after",
+      "cur2",
+    ]);
+
+    expect(listProjectLabels).toHaveBeenCalledWith(expect.anything(), {
+      limit: 25,
+      after: "cur2",
+    });
+    expect(listLabels).not.toHaveBeenCalled();
+    expect(resolveTeamId).not.toHaveBeenCalled();
+    expect(outputSuccess).toHaveBeenCalledWith({
+      nodes: [
+        {
+          id: "plbl-1",
+          name: "Customer",
+          color: "#0000ff",
+          type: "project",
+        },
+      ],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    });
+  });
+});
+
+describe("labels list validation", () => {
+  it("rejects unsupported label types", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "list",
+      "--type",
+      "initiative",
+    ]);
+
+    const errorOutput = JSON.parse(
+      vi.mocked(console.error).mock.calls[0][0] as string,
+    ) as { error: string };
+
+    expect(errorOutput.error).toBe(
+      'Invalid --type: must be one of "issue" or "project"',
+    );
+    expect(listLabels).not.toHaveBeenCalled();
+    expect(listProjectLabels).not.toHaveBeenCalled();
+    expect(resolveTeamId).not.toHaveBeenCalled();
+  });
+
+  it("rejects team filters for project labels", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "list",
+      "--type",
+      "project",
+      "--team",
+      "ENG",
+    ]);
+
+    const errorOutput = JSON.parse(
+      vi.mocked(console.error).mock.calls[0][0] as string,
+    ) as { error: string };
+
+    expect(errorOutput.error).toBe(
+      "Invalid --team: cannot be used with --type project because project labels are workspace-scoped",
+    );
+    expect(listLabels).not.toHaveBeenCalled();
+    expect(listProjectLabels).not.toHaveBeenCalled();
+    expect(resolveTeamId).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/services/label-service.test.ts
+++ b/tests/unit/services/label-service.test.ts
@@ -1,7 +1,9 @@
-// tests/unit/services/label-service.test.ts
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
-import { listLabels } from "../../../src/services/label-service.js";
+import {
+  listLabels,
+  listProjectLabels,
+} from "../../../src/services/label-service.js";
 
 function mockGqlClient(response: Record<string, unknown>): GraphQLClient {
   return {
@@ -10,7 +12,7 @@ function mockGqlClient(response: Record<string, unknown>): GraphQLClient {
 }
 
 describe("listLabels", () => {
-  it("returns labels", async () => {
+  it("returns issue labels with type", async () => {
     const client = mockGqlClient({
       issueLabels: {
         nodes: [
@@ -19,11 +21,18 @@ describe("listLabels", () => {
         pageInfo: { hasNextPage: false, endCursor: "c1" },
       },
     });
+
     const result = await listLabels(client);
-    expect(result.nodes).toHaveLength(1);
-    expect(result.nodes[0].id).toBe("lbl-1");
-    expect(result.nodes[0].name).toBe("Bug");
-    expect(result.nodes[0].color).toBe("#ff0000");
+
+    expect(result.nodes).toEqual([
+      {
+        id: "lbl-1",
+        name: "Bug",
+        color: "#ff0000",
+        description: "A bug",
+        type: "issue",
+      },
+    ]);
     expect(result.pageInfo).toEqual({ hasNextPage: false, endCursor: "c1" });
   });
 
@@ -34,7 +43,9 @@ describe("listLabels", () => {
         pageInfo: { hasNextPage: false, endCursor: null },
       },
     });
+
     const result = await listLabels(client);
+
     expect(result.nodes).toEqual([]);
     expect(result.pageInfo.hasNextPage).toBe(false);
   });
@@ -46,7 +57,9 @@ describe("listLabels", () => {
         pageInfo: { hasNextPage: false, endCursor: null },
       },
     });
+
     await listLabels(client, undefined, { after: "cur1" });
+
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       first: 50,
       after: "cur1",
@@ -61,7 +74,9 @@ describe("listLabels", () => {
         pageInfo: { hasNextPage: false, endCursor: null },
       },
     });
+
     await listLabels(client);
+
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       first: 50,
       after: undefined,
@@ -76,7 +91,9 @@ describe("listLabels", () => {
         pageInfo: { hasNextPage: false, endCursor: null },
       },
     });
+
     await listLabels(client, "team-1");
+
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       first: 50,
       after: undefined,
@@ -93,7 +110,94 @@ describe("listLabels", () => {
         pageInfo: { hasNextPage: false, endCursor: null },
       },
     });
+
     const result = await listLabels(client);
+
     expect(result.nodes[0].description).toBeUndefined();
+    expect(result.nodes[0].type).toBe("issue");
+  });
+});
+
+describe("listProjectLabels", () => {
+  it("returns project labels with type", async () => {
+    const client = mockGqlClient({
+      projectLabels: {
+        nodes: [
+          {
+            id: "plbl-1",
+            name: "Customer",
+            color: "#0000ff",
+            description: "Customer-facing",
+          },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: "p1" },
+      },
+    });
+
+    const result = await listProjectLabels(client);
+
+    expect(result.nodes).toEqual([
+      {
+        id: "plbl-1",
+        name: "Customer",
+        color: "#0000ff",
+        description: "Customer-facing",
+        type: "project",
+      },
+    ]);
+    expect(result.pageInfo).toEqual({ hasNextPage: false, endCursor: "p1" });
+  });
+
+  it("uses default limit of 50", async () => {
+    const client = mockGqlClient({
+      projectLabels: {
+        nodes: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+
+    await listProjectLabels(client);
+
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      first: 50,
+      after: undefined,
+    });
+  });
+
+  it("passes pagination without filter", async () => {
+    const client = mockGqlClient({
+      projectLabels: {
+        nodes: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+
+    await listProjectLabels(client, { limit: 25, after: "cur2" });
+
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      first: 25,
+      after: "cur2",
+    });
+  });
+
+  it("converts null description to undefined", async () => {
+    const client = mockGqlClient({
+      projectLabels: {
+        nodes: [
+          {
+            id: "plbl-2",
+            name: "Internal",
+            color: "#123456",
+            description: null,
+          },
+        ],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+
+    const result = await listProjectLabels(client);
+
+    expect(result.nodes[0].description).toBeUndefined();
+    expect(result.nodes[0].type).toBe("project");
   });
 });


### PR DESCRIPTION
## What does this PR do?

Adds project label listing support to `linearis labels list` by introducing `--type issue|project`, wiring a dedicated GraphQL query/service path for project labels, and enforcing workspace-scope semantics (reject `--type project --team ...`).

Closes #115

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build / CI

## Checklist

- [ ] `npm run check:ci` passes (lint + format)
- [ ] `npx tsc --noEmit` passes (type check)
- [ ] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `npm run generate`
- `npm run check:ci`
- `npx tsc --noEmit`
- `npx tsc`
- `node dist/main.js labels usage`
- `node dist/main.js usage --all`
- GitHub Actions passed on Node 22 and Node 24

## Notes for reviewers

- Adds a `type` field to label results, per issue #115 design.
- Project label support is read-only in this PR (no CRUD expansion).
