### PR TITLE
fix: exit immediately after command completes

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -92,4 +92,5 @@ program
     }
   });
 
+program.hook("postAction", () => process.exit(0));
 program.parse();


### PR DESCRIPTION
## Summary

The Linear SDK's HTTP client holds a keep-alive connection open after requests complete, preventing the Node process from exiting for ~30 seconds. This makes every command appear to hang after printing its output.

Adds a Commander `postAction` hook that calls `process.exit(0)` once any command finishes, so the CLI exits immediately.

## Details

- The `@linear/sdk` uses `graphql-request` which uses `fetch` — Node's global fetch keeps connections alive with no exposed way to close them
- The 30s delay matches the `REQUEST_TIMEOUT_MS` constant in the GraphQL client
- The hook fires after the command action completes, so all output is already written to stdout
- One-line change in `src/main.ts`