### PR TITLE
fix: resolve timeout lifecycle and remove forced CLI exit

### DIFF
--- a/src/client/graphql-client.ts
+++ b/src/client/graphql-client.ts
@@ -32,17 +32,27 @@ export class GraphQLClient {
     variables?: Record<string, unknown>,
   ): Promise<TResult> {
     try {
-      const response = await withRetry(() =>
-        Promise.race([
-          this.rawClient.rawRequest(print(document), variables),
-          new Promise<never>((_, reject) =>
-            setTimeout(
+      const response = await withRetry(async () => {
+        let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+
+        try {
+          const timeoutPromise = new Promise<never>((_, reject) => {
+            timeoutHandle = setTimeout(
               () => reject(new Error("Request timed out")),
               REQUEST_TIMEOUT_MS,
-            ),
-          ),
-        ]),
-      );
+            );
+          });
+
+          return await Promise.race([
+            this.rawClient.rawRequest(print(document), variables),
+            timeoutPromise,
+          ]);
+        } finally {
+          if (timeoutHandle !== undefined) {
+            clearTimeout(timeoutHandle);
+          }
+        }
+      });
       return response.data as TResult;
     } catch (error: unknown) {
       const gqlError = error as GraphQLErrorResponse;

--- a/src/client/graphql-client.ts
+++ b/src/client/graphql-client.ts
@@ -14,17 +14,24 @@ interface GraphQLErrorResponse {
 }
 
 export class GraphQLClient {
-  private rawClient: InstanceType<typeof LinearClient>["client"];
+  private readonly apiToken: string;
 
   constructor(apiToken: string) {
+    this.apiToken = apiToken;
+  }
+
+  private createRawClient(
+    signal?: AbortSignal,
+  ): InstanceType<typeof LinearClient>["client"] {
     const linearClient = new LinearClient({
-      apiKey: apiToken,
+      apiKey: this.apiToken,
+      signal,
       headers: {
         // Request 1-hour signed URLs for file downloads (see file-service.ts)
         "public-file-urls-expire-in": "3600",
       },
     });
-    this.rawClient = linearClient.client;
+    return linearClient.client;
   }
 
   async request<TResult>(
@@ -33,24 +40,26 @@ export class GraphQLClient {
   ): Promise<TResult> {
     try {
       const response = await withRetry(async () => {
-        let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+        const timeoutController = new AbortController();
+        const timeoutHandle = setTimeout(() => {
+          timeoutController.abort();
+        }, REQUEST_TIMEOUT_MS);
 
         try {
-          const timeoutPromise = new Promise<never>((_, reject) => {
-            timeoutHandle = setTimeout(
-              () => reject(new Error("Request timed out")),
-              REQUEST_TIMEOUT_MS,
-            );
-          });
-
-          return await Promise.race([
-            this.rawClient.rawRequest(print(document), variables),
-            timeoutPromise,
-          ]);
-        } finally {
-          if (timeoutHandle !== undefined) {
-            clearTimeout(timeoutHandle);
+          return await this.createRawClient(
+            timeoutController.signal,
+          ).rawRequest(print(document), variables);
+        } catch (error: unknown) {
+          if (
+            timeoutController.signal.aborted &&
+            error instanceof Error &&
+            error.message.toLowerCase().includes("aborted")
+          ) {
+            throw new Error("Request timed out");
           }
+          throw error;
+        } finally {
+          clearTimeout(timeoutHandle);
         }
       });
       return response.data as TResult;

--- a/src/main.ts
+++ b/src/main.ts
@@ -92,5 +92,4 @@ program
     }
   });
 
-program.hook("postAction", () => process.exit(0));
 program.parse();

--- a/tests/unit/client/graphql-client.test.ts
+++ b/tests/unit/client/graphql-client.test.ts
@@ -169,7 +169,9 @@ describe("GraphQLClient", () => {
         >[0];
 
         const promise = client.request(fakeDoc);
-        await vi.runAllTimersAsync();
+
+        // Advance only the first retry backoff (500ms), without draining unrelated timers.
+        await vi.advanceTimersByTimeAsync(500);
 
         await expect(promise).resolves.toEqual({ foo: "bar" });
         expect(mockRawRequest).toHaveBeenCalledTimes(2);

--- a/tests/unit/client/graphql-client.test.ts
+++ b/tests/unit/client/graphql-client.test.ts
@@ -6,12 +6,17 @@ import { AuthenticationError } from "../../../src/common/errors.js";
 // The constructor creates a real LinearClient, so we mock at module level
 vi.mock("@linear/sdk", () => {
   const mockRawRequest = vi.fn();
+  const mockConstructorCalls: Array<{ signal?: AbortSignal }> = [];
   return {
     // biome-ignore lint/complexity/useArrowFunction: vitest v4 requires regular function for constructor mocks
-    LinearClient: vi.fn().mockImplementation(function () {
+    LinearClient: vi.fn().mockImplementation(function (options?: {
+      signal?: AbortSignal;
+    }) {
+      mockConstructorCalls.push(options ?? {});
       return { client: { rawRequest: mockRawRequest } };
     }),
     __mockRawRequest: mockRawRequest,
+    __mockConstructorCalls: mockConstructorCalls,
   };
 });
 
@@ -23,13 +28,17 @@ describe("GraphQLClient", () => {
 
   describe("request", () => {
     let mockRawRequest: ReturnType<typeof vi.fn>;
+    let mockConstructorCalls: Array<{ signal?: AbortSignal }>;
 
     beforeEach(async () => {
       const sdk = (await import("@linear/sdk")) as unknown as {
         __mockRawRequest: ReturnType<typeof vi.fn>;
+        __mockConstructorCalls: Array<{ signal?: AbortSignal }>;
       };
       mockRawRequest = sdk.__mockRawRequest;
+      mockConstructorCalls = sdk.__mockConstructorCalls;
       mockRawRequest.mockReset();
+      mockConstructorCalls.length = 0;
     });
 
     it("throws AuthenticationError on 'Authentication required' error", async () => {
@@ -124,6 +133,35 @@ describe("GraphQLClient", () => {
         await expect(client.request(fakeDoc)).rejects.toThrow(
           "Entity not found",
         );
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("aborts in-flight request when timeout elapses", async () => {
+      vi.useFakeTimers();
+      try {
+        mockRawRequest.mockImplementation(() => {
+          const call = mockConstructorCalls.at(-1);
+          return new Promise((_, reject) => {
+            call?.signal?.addEventListener("abort", () => {
+              reject(new Error("aborted-by-signal"));
+            });
+          });
+        });
+
+        const client = new GraphQLClient("good-token");
+        const fakeDoc = { kind: "Document", definitions: [] } as Parameters<
+          typeof client.request
+        >[0];
+
+        const promise = client.request(fakeDoc);
+        const rejection = expect(promise).rejects.toThrow("Request timed out");
+        await vi.runAllTimersAsync();
+
+        await rejection;
+        expect(mockConstructorCalls.at(-1)?.signal?.aborted).toBe(true);
         expect(vi.getTimerCount()).toBe(0);
       } finally {
         vi.useRealTimers();

--- a/tests/unit/client/graphql-client.test.ts
+++ b/tests/unit/client/graphql-client.test.ts
@@ -88,6 +88,48 @@ describe("GraphQLClient", () => {
       }
     });
 
+    it("clears timeout timer when request succeeds before timeout", async () => {
+      vi.useFakeTimers();
+      try {
+        mockRawRequest.mockResolvedValueOnce({ data: { ok: true } });
+
+        const client = new GraphQLClient("good-token");
+        const fakeDoc = { kind: "Document", definitions: [] } as Parameters<
+          typeof client.request
+        >[0];
+
+        const result = await client.request<{ ok: boolean }>(fakeDoc);
+
+        expect(result).toEqual({ ok: true });
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("clears timeout timer on non-retryable GraphQL error", async () => {
+      vi.useFakeTimers();
+      try {
+        mockRawRequest.mockRejectedValueOnce({
+          response: {
+            errors: [{ message: "Entity not found" }],
+          },
+        });
+
+        const client = new GraphQLClient("good-token");
+        const fakeDoc = { kind: "Document", definitions: [] } as Parameters<
+          typeof client.request
+        >[0];
+
+        await expect(client.request(fakeDoc)).rejects.toThrow(
+          "Entity not found",
+        );
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("retries on 429 and succeeds on next attempt", async () => {
       const rateLimitError = { response: { status: 429 } };
       mockRawRequest
@@ -100,13 +142,41 @@ describe("GraphQLClient", () => {
       >[0];
 
       vi.useFakeTimers();
-      const promise = client.request(fakeDoc);
-      await vi.runAllTimersAsync();
-      const result = await promise;
+      try {
+        const promise = client.request(fakeDoc);
+        await vi.runAllTimersAsync();
+        const result = await promise;
 
-      expect(result).toEqual({ foo: "bar" });
-      expect(mockRawRequest).toHaveBeenCalledTimes(2);
-      vi.useRealTimers();
+        expect(result).toEqual({ foo: "bar" });
+        expect(mockRawRequest).toHaveBeenCalledTimes(2);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("clears timeout timers across retry attempts", async () => {
+      vi.useFakeTimers();
+      try {
+        const rateLimitError = { response: { status: 429 } };
+        mockRawRequest
+          .mockRejectedValueOnce(rateLimitError)
+          .mockResolvedValueOnce({ data: { foo: "bar" } });
+
+        const client = new GraphQLClient("good-token");
+        const fakeDoc = { kind: "Document", definitions: [] } as Parameters<
+          typeof client.request
+        >[0];
+
+        const promise = client.request(fakeDoc);
+        await vi.runAllTimersAsync();
+
+        await expect(promise).resolves.toEqual({ foo: "bar" });
+        expect(mockRawRequest).toHaveBeenCalledTimes(2);
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes timeout lifecycle in GraphQL requests and removes forced process exit so CLI exits naturally after work completes.

Closes #157

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `npx vitest run tests/unit/client/graphql-client.test.ts`
- `npm run check:ci`
- `npx tsc --noEmit`
- `npm test`
- `npm run build`
- `node dist/main.js usage > /tmp/linearis-usage.txt`

## Notes for reviewers

- Removed global `program.hook(\"postAction\", () => process.exit(0));` workaround.
- `GraphQLClient.request()` now creates timeout handle per retry attempt and always clears it in `finally`.
- Added regression tests asserting no pending timers on success, non-retryable error, and retry-success paths.