### PR TITLE
fix(ci): use deploy key for release automation git pushes

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -72,6 +72,16 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ steps.target.outputs.branch }}
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
+          persist-credentials: false
+
+      - name: Configure git remote for SSH pushes
+        shell: bash
+        run: |
+          set -euo pipefail
+          git remote set-url origin git@github.com:${GITHUB_REPOSITORY}.git
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -101,4 +111,5 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_REF: refs/heads/${{ steps.target.outputs.branch }}
           GITHUB_REF_NAME: ${{ steps.target.outputs.branch }}
+          SEMANTIC_RELEASE_REPOSITORY_URL: git@github.com:${{ github.repository }}.git
         run: npm run release:run

--- a/.github/workflows/sync-main-release-back-to-next.yml
+++ b/.github/workflows/sync-main-release-back-to-next.yml
@@ -22,9 +22,12 @@ jobs:
         with:
           ref: next
           fetch-depth: 0
+          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
+          persist-credentials: false
 
       - name: Configure git
         run: |
+          git remote set-url origin git@github.com:${GITHUB_REPOSITORY}.git
           git config user.name "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -1,4 +1,7 @@
 module.exports = {
+  repositoryUrl:
+    process.env.SEMANTIC_RELEASE_REPOSITORY_URL ??
+    "git@github.com:linearis-oss/linearis.git",
   branches: ["main", { name: "next", prerelease: "next" }],
   tagFormat: `v\${version}`,
   plugins: [


### PR DESCRIPTION
## What does this PR do?

Fixes post-merge release automation failures caused by git auth mismatch in protected-branch workflows.

- Use repo deploy key for workflows that must push commits/tags (`release-check`, `sync-main-release-back-to-next`)
- Force SSH remote for push path in those workflows
- Configure semantic-release repository URL to SSH so `@semantic-release/git` push/tag uses deploy key auth

This keeps workflow behavior same, only auth transport changes.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [x] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [ ] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Validated by configuration-level checks and dry-run release initialization:

```bash
npm run check:ci
npm run release:dry-run
```

Also verified failing production run root cause and fix target:
- Release failure was `@semantic-release/git` push rejected by branch rules using HTTPS/token path.
- New wiring routes pushes through SSH deploy key path.

## Notes for reviewers

- Kept branch lean: no promote-token changes (that path already fixed upstream and now passing).
- PR should target `next`.
