### PR TITLE
fix(release): avoid protected branch head pushes

### DIFF
--- a/.github/workflows/promote-next-to-main.yml
+++ b/.github/workflows/promote-next-to-main.yml
@@ -37,7 +37,14 @@ jobs:
         run: |
           set -euo pipefail
 
-          version=$(node -p "require('./package.json').version.replace(/-next\\.\\d+$/, '')")
+          latest_next_tag=$(git tag --list 'v*-next.*' --sort=-v:refname | head -n 1)
+          if [ -n "$latest_next_tag" ]; then
+            version=${latest_next_tag#v}
+            version=${version%-next.*}
+          else
+            version=$(node -p "require('./package.json').version.replace(/-next\\.\\d+$/, '')")
+          fi
+
           title="release ${version} to stable channel"
           compare_url="https://github.com/${GITHUB_REPOSITORY}/compare/main...next"
 

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -11,19 +11,11 @@ module.exports = {
       { preset: "conventionalcommits" },
     ],
     "./scripts/release/calver-plugin.cjs",
-    ["@semantic-release/changelog", { changelogFile: "CHANGELOG.md" }],
     ["@semantic-release/npm", { npmPublish: false, pkgRoot: "." }],
     [
       "@semantic-release/exec",
       { publishCmd: "npx clean-publish --access public -- --provenance" },
     ],
     ["@semantic-release/github", { successComment: false, failComment: false }],
-    [
-      "@semantic-release/git",
-      {
-        assets: ["package.json", "package-lock.json", "CHANGELOG.md"],
-        message: `chore(release): \${nextRelease.version} [skip ci]\n\n\${nextRelease.notes}`,
-      },
-    ],
   ],
 };


### PR DESCRIPTION
## What does this PR do?

Fixes release workflow failure on protected `next` by removing branch HEAD push behavior from semantic-release.

- removes `@semantic-release/git` plugin (no `HEAD:next` push in prepare)
- removes `@semantic-release/changelog` plugin dependency on committing changelog back to branch
- keeps package publish + GitHub release path intact
- updates promotion PR version source to latest prerelease tag (`v*-next.*`) instead of `package.json`, since release commits no longer update package version on branch

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [x] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npm run release:dry-run` passes
- [ ] `npx tsc --noEmit` passes (type check)
- [ ] `npm test` passes (unit tests)
- [ ] New code has tests (happy path + primary error case)
- [x] Commit messages follow Conventional Commits

## Testing

```bash
npm run check:ci
npm run release:dry-run
```

## Notes for reviewers

Root cause from failing run `24797176473 / 72569941408`:
semantic-release executed `git push --tags ... HEAD:next` over tokenized HTTPS URL during `@semantic-release/git` prepare. Protected branch rules reject direct branch push. This change removes that push path entirely.
