### PR TITLE
fix(ci): switch release workflow to GitHub App token auth

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -72,16 +72,33 @@ jobs:
         with:
           fetch-depth: 0
           ref: ${{ steps.target.outputs.branch }}
-          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
           persist-credentials: false
 
-      - name: Configure git remote for SSH pushes
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Resolve GitHub App bot identity
+        id: app-bot
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          set -euo pipefail
+          slug='${{ steps.app-token.outputs.app-slug }}'
+          id="$(gh api "/users/${slug}[bot]" --jq .id)"
+          echo "name=${slug}[bot]" >> "$GITHUB_OUTPUT"
+          echo "email=${id}+${slug}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git identity
         shell: bash
         run: |
           set -euo pipefail
-          git remote set-url origin git@github.com:${GITHUB_REPOSITORY}.git
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "${{ steps.app-bot.outputs.name }}"
+          git config user.email "${{ steps.app-bot.outputs.email }}"
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -107,9 +124,9 @@ jobs:
 
       - name: Run semantic-release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_REF: refs/heads/${{ steps.target.outputs.branch }}
           GITHUB_REF_NAME: ${{ steps.target.outputs.branch }}
-          SEMANTIC_RELEASE_REPOSITORY_URL: git@github.com:${{ github.repository }}.git
         run: npm run release:run

--- a/.github/workflows/sync-main-release-back-to-next.yml
+++ b/.github/workflows/sync-main-release-back-to-next.yml
@@ -22,14 +22,34 @@ jobs:
         with:
           ref: next
           fetch-depth: 0
-          ssh-key: ${{ secrets.RELEASE_DEPLOY_KEY }}
           persist-credentials: false
 
-      - name: Configure git
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
+      - name: Resolve GitHub App bot identity
+        id: app-bot
+        shell: bash
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
-          git remote set-url origin git@github.com:${GITHUB_REPOSITORY}.git
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          set -euo pipefail
+          slug='${{ steps.app-token.outputs.app-slug }}'
+          id="$(gh api "/users/${slug}[bot]" --jq .id)"
+          echo "name=${slug}[bot]" >> "$GITHUB_OUTPUT"
+          echo "email=${id}+${slug}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
+
+      - name: Configure git
+        env:
+          GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: |
+          git remote set-url origin "https://x-access-token:${GH_APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+          git config user.name "${{ steps.app-bot.outputs.name }}"
+          git config user.email "${{ steps.app-bot.outputs.email }}"
 
       - name: Merge main into next
         shell: bash


### PR DESCRIPTION
## What does this PR do?

Migrates release automation workflows from deploy-key/default workflow-token behavior to GitHub App installation token auth, so release-related pushes use the configured ruleset bypass actor.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [x] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [ ] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Executed in the PR worktree:

- `npm run check:ci`
- `npx tsc --noEmit`
- `npm test`

Notes:

- `npm run check:ci` reports an existing Biome schema-version info message, but exits successfully.
- `npm test` outputs repeated `Paste your Linear API token:` prompt text from existing test behavior; suite still passes.

## Notes for reviewers

### `.github/workflows/release-check.yml`

- Removes deploy-key usage.
- Keeps `actions/checkout` with `persist-credentials: false` so checkout token is not used for pushes.
- Creates short-lived GitHub App installation token via `actions/create-github-app-token@v2`.
- Resolves app bot identity (`<app-slug>[bot]`) and configures git author email as `<id>+<app-slug>[bot]@users.noreply.github.com`.
- Uses app token for semantic-release (`GH_TOKEN` and `GITHUB_TOKEN`).

### `.github/workflows/sync-main-release-back-to-next.yml`

- Removes deploy-key usage.
- Keeps `actions/checkout` with `persist-credentials: false`.
- Creates short-lived GitHub App installation token via `actions/create-github-app-token@v2`.
- Resolves app bot identity and configures git author to app bot noreply identity.
- Sets origin remote to authenticated HTTPS using app token for `git push origin HEAD:next`.
