### PR TITLE
fix(ci): prevent shell expansion in promotion PR body

### DIFF
--- a/.github/workflows/promote-next-to-main.yml
+++ b/.github/workflows/promote-next-to-main.yml
@@ -114,9 +114,14 @@ jobs:
       - name: Upsert promotion PR
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          PROMOTION_PR_TITLE: ${{ steps.meta.outputs.title }}
+          PROMOTION_PR_BODY: ${{ steps.meta.outputs.body }}
         shell: bash
         run: |
           set -euo pipefail
+
+          body_file=$(mktemp)
+          printf '%s\n' "$PROMOTION_PR_BODY" > "$body_file"
 
           existing=$(gh pr list \
             --state open \
@@ -127,14 +132,14 @@ jobs:
 
           if [ -n "$existing" ]; then
             gh pr edit "$existing" \
-              --title "${{ steps.meta.outputs.title }}" \
-              --body "${{ steps.meta.outputs.body }}"
+              --title "$PROMOTION_PR_TITLE" \
+              --body-file "$body_file"
             echo "Updated PR #$existing"
           else
             gh pr create \
               --base main \
               --head next \
-              --title "${{ steps.meta.outputs.title }}" \
-              --body "${{ steps.meta.outputs.body }}"
+              --title "$PROMOTION_PR_TITLE" \
+              --body-file "$body_file"
             echo "Created promotion PR"
           fi


### PR DESCRIPTION
## Summary
- fix promotion workflow PR update/create step to avoid shell command substitution in markdown content
- pass metadata through environment variables and use `--body-file` instead of inline `--body`

## Root cause
`steps.meta.outputs.body` includes markdown backticks (for `next`, `main`, version). Injecting that output directly into the run script as:

```bash
--body "${{ steps.meta.outputs.body }}"
```

causes the shell to evaluate backticks during command execution. That strips content (or executes command substitution), producing empty placeholders in the PR description.

## Fix
- add env vars:
  - `PROMOTION_PR_TITLE: ${{ steps.meta.outputs.title }}`
  - `PROMOTION_PR_BODY: ${{ steps.meta.outputs.body }}`
- write body to temp file with `printf '%s\n' "$PROMOTION_PR_BODY"`
- call:
  - `gh pr edit ... --title "$PROMOTION_PR_TITLE" --body-file "$body_file"`
  - `gh pr create ... --title "$PROMOTION_PR_TITLE" --body-file "$body_file"`

## Validation
- reproduces prior symptom pattern exactly (missing `next` / `main` / version)
- removes command-substitution path entirely by not embedding raw markdown output in the run script command line
