### PR TITLE
fix(ci): use npm-publish environment in release job

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -19,6 +19,7 @@ concurrency:
 jobs:
   release:
     runs-on: ubuntu-latest
+    environment: npm-publish
     steps:
       - name: Guard workflow_dispatch caller permissions
         if: ${{ github.event_name == 'workflow_dispatch' }}
@@ -121,6 +122,16 @@ jobs:
 
       - name: Type check
         run: npx tsc --noEmit
+
+      - name: Verify npm auth
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          test -n "${NODE_AUTH_TOKEN}" || {
+            echo "NPM_TOKEN missing (check job environment + secret scope)"
+            exit 1
+          }
+          npm whoami --registry=https://registry.npmjs.org/
 
       - name: Run semantic-release
         env:


### PR DESCRIPTION
## Summary
- bind `release` job to `npm-publish` environment so environment secret `NPM_TOKEN` resolves
- add npm auth preflight (`test -n NODE_AUTH_TOKEN` + `npm whoami`) before semantic-release

## Root cause
`NPM_TOKEN` was configured as an environment secret, but the job did not declare `environment: npm-publish`, so `NODE_AUTH_TOKEN` was empty in the release step.

## Validation
- inspected failed Actions log: `NODE_AUTH_TOKEN` empty in `Run semantic-release`
- verified workflow now references the environment and fails early if auth is missing
