### PR TITLE
chore(ci): migrate release workflow labels to linearis-bot app naming

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -75,14 +75,14 @@ jobs:
           ref: ${{ steps.target.outputs.branch }}
           persist-credentials: false
 
-      - name: Create GitHub App token
+      - name: Create linearis-bot app token
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
-      - name: Resolve GitHub App bot identity
+      - name: Resolve linearis-bot app bot identity
         id: app-bot
         shell: bash
         env:
@@ -94,7 +94,7 @@ jobs:
           echo "name=${slug}[bot]" >> "$GITHUB_OUTPUT"
           echo "email=${id}+${slug}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
 
-      - name: Configure git identity
+      - name: Configure git identity (linearis-bot app)
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/sync-main-release-back-to-next.yml
+++ b/.github/workflows/sync-main-release-back-to-next.yml
@@ -24,14 +24,14 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
-      - name: Create GitHub App token
+      - name: Create linearis-bot app token
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
           app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
-      - name: Resolve GitHub App bot identity
+      - name: Resolve linearis-bot app bot identity
         id: app-bot
         shell: bash
         env:
@@ -43,7 +43,7 @@ jobs:
           echo "name=${slug}[bot]" >> "$GITHUB_OUTPUT"
           echo "email=${id}+${slug}[bot]@users.noreply.github.com" >> "$GITHUB_OUTPUT"
 
-      - name: Configure git
+      - name: Configure git (linearis-bot app identity)
         env:
           GH_APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |


### PR DESCRIPTION
## Summary
- rename GitHub Actions step labels in release workflows to explicitly reference linearis-bot app identity
- update both sync and release-check workflows with text-only label changes
- preserve workflow behavior (no id/env/secret/script/trigger/permission changes)

## Test Plan
- [x] rg label checks for both workflow files (new labels present, old labels removed)
- [x] npm run check:ci
- [x] npm test