### PR TITLE
chore(ci): streamline GitHub workflow naming

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -1,4 +1,4 @@
-name: CI
+name: Validate CI
 
 on:
   pull_request:
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   test:
-    name: Unit tests on node v${{ matrix.node-version }}
+    name: Run Unit Tests on Node v${{ matrix.node-version }}
     runs-on: ubuntu-latest
 
     strategy:
@@ -51,7 +51,7 @@ jobs:
       matrix:
         node-version: [22]
 
-    name: Code checks on node v${{ matrix.node-version }}
+    name: Run Code Checks on Node v${{ matrix.node-version }}
     runs-on: ubuntu-latest
 
     steps:
@@ -77,7 +77,7 @@ jobs:
         run: npx tsc --noEmit
 
   smoke-test:
-    name: Smoke test package install
+    name: Run Package Install Smoke Test
     runs-on: ubuntu-latest
     needs: [test]
 
@@ -98,7 +98,7 @@ jobs:
         run: npm run verify:packed-binaries
 
   guard-plan-files:
-    name: Reject plan files
+    name: Reject Plan Files
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     permissions:
@@ -143,7 +143,7 @@ jobs:
           echo "No plan files found — OK"
 
   guard-changelog-history:
-    name: Guard CHANGELOG history in PR
+    name: Guard CHANGELOG History in PR
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     permissions:

--- a/.github/workflows/release-promote-next-to-main.yml
+++ b/.github/workflows/release-promote-next-to-main.yml
@@ -1,4 +1,4 @@
-name: Promote next to main
+name: Promote Next to Main
 
 on:
   push:
@@ -19,6 +19,7 @@ concurrency:
 
 jobs:
   promote:
+    name: Promote Next to Main
     if: ${{ github.event_name != 'release' || (github.event.release.prerelease == true && github.event.release.target_commitish == 'next') }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Publish Release
 
 on:
   push:
@@ -17,6 +17,7 @@ concurrency:
 
 jobs:
   release:
+    name: Publish Release
     runs-on: ubuntu-latest
     environment: npm-publish
     steps:

--- a/.github/workflows/release-sync-main-back-to-next.yml
+++ b/.github/workflows/release-sync-main-back-to-next.yml
@@ -1,4 +1,4 @@
-name: Sync main release back to next
+name: Sync Main Back to Next
 
 on:
   release:
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   sync:
+    name: Sync Main Back to Next
     if: ${{ github.event.release.prerelease == false && github.event.release.target_commitish == 'main' }}
     runs-on: ubuntu-latest
     steps:

--- a/renovate.json
+++ b/renovate.json
@@ -28,10 +28,10 @@
       "groupName": "github actions"
     },
     {
-      "description": "Pin release-check workflow to minimum supported Node version",
+      "description": "Pin release-publish workflow to minimum supported Node version",
       "matchManagers": ["github-actions"],
       "matchPackageNames": ["node"],
-      "matchFileNames": [".github/workflows/release-check.yml"],
+      "matchFileNames": [".github/workflows/release-publish.yml"],
       "enabled": false
     }
   ]


### PR DESCRIPTION
## What does this PR do?

Standardizes GitHub Actions workflow naming to verb-first format for better scanability and consistency.

- Renames workflow files:
  - `.github/workflows/ci.yml` → `.github/workflows/ci-validate.yml`
  - `.github/workflows/release-check.yml` → `.github/workflows/release-publish.yml`
  - `.github/workflows/promote-next-to-main.yml` → `.github/workflows/release-promote-next-to-main.yml`
  - `.github/workflows/sync-main-release-back-to-next.yml` → `.github/workflows/release-sync-main-back-to-next.yml`
- Renames workflow display names and normalizes key job names to verb-first/title-case.
- Updates `renovate.json` workflow file reference to renamed publish workflow.

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [x] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Ran locally in worktree:

- `npm run check:ci`
- `npx tsc --noEmit`
- `npm test`
- `npm run build`

## Notes for reviewers

Status-check contexts changed due to workflow/job renaming.

Old → new examples:
- `CI / Unit tests on node v22` → `Validate CI / Run Unit Tests on Node v22`
- `CI / Code checks on node v22` → `Validate CI / Run Code Checks on Node v22`
- `CI / Smoke test package install` → `Validate CI / Run Package Install Smoke Test`

After merge, update required checks in branch protection/rulesets/merge queue to new names.
