### PR TITLE
feat(projects): add archive, unarchive, and delete commands

### DIFF
--- a/graphql/mutations/projects.graphql
+++ b/graphql/mutations/projects.graphql
@@ -31,7 +31,7 @@ mutation UpdateProject($id: String!, $input: ProjectUpdateInput!) {
 }
 
 mutation ArchiveProject($id: String!) {
-  projectArchive: projectDelete(id: $id) {
+  projectArchive(id: $id) {
     success
     entity {
       ...ProjectDetailFields
@@ -52,7 +52,7 @@ mutation DeleteProject($id: String!) {
   projectDelete(id: $id) {
     success
     entity {
-      id
+      ...ProjectDetailFields
     }
   }
 }

--- a/graphql/mutations/projects.graphql
+++ b/graphql/mutations/projects.graphql
@@ -31,7 +31,7 @@ mutation UpdateProject($id: String!, $input: ProjectUpdateInput!) {
 }
 
 mutation ArchiveProject($id: String!) {
-  projectArchive(id: $id) {
+  projectArchive: projectDelete(id: $id) {
     success
     entity {
       ...ProjectDetailFields

--- a/graphql/mutations/projects.graphql
+++ b/graphql/mutations/projects.graphql
@@ -29,3 +29,30 @@ mutation UpdateProject($id: String!, $input: ProjectUpdateInput!) {
     }
   }
 }
+
+mutation ArchiveProject($id: String!) {
+  projectArchive(id: $id) {
+    success
+    entity {
+      ...ProjectDetailFields
+    }
+  }
+}
+
+mutation UnarchiveProject($id: String!) {
+  projectUnarchive(id: $id) {
+    success
+    entity {
+      ...ProjectDetailFields
+    }
+  }
+}
+
+mutation DeleteProject($id: String!) {
+  projectDelete(id: $id) {
+    success
+    entity {
+      id
+    }
+  }
+}

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -345,7 +345,9 @@ export function setupProjectsCommands(program: Command): void {
       handleCommand(async (...args: unknown[]) => {
         const [project, , command] = args as [string, unknown, Command];
         const ctx = createContext(command.parent!.parent!.opts());
-        const projectId = await resolveProjectId(ctx.sdk, project);
+        const projectId = await resolveProjectId(ctx.sdk, project, {
+          includeArchived: true,
+        });
         const result = await deleteProject(ctx.gql, projectId);
         outputSuccess(result);
       }),

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -330,7 +330,9 @@ export function setupProjectsCommands(program: Command): void {
       handleCommand(async (...args: unknown[]) => {
         const [project, , command] = args as [string, unknown, Command];
         const ctx = createContext(command.parent!.parent!.opts());
-        const projectId = await resolveProjectId(ctx.sdk, project);
+        const projectId = await resolveProjectId(ctx.sdk, project, {
+          includeArchived: true,
+        });
         const result = await unarchiveProject(ctx.gql, projectId);
         outputSuccess(result);
       }),

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -12,9 +12,12 @@ import { resolveProjectStatusId } from "../resolvers/project-status-resolver.js"
 import { resolveTeamId } from "../resolvers/team-resolver.js";
 import { resolveUserId } from "../resolvers/user-resolver.js";
 import {
+  archiveProject,
   createProject,
+  deleteProject,
   getProject,
   listProjects,
+  unarchiveProject,
   updateProject,
 } from "../services/project-service.js";
 
@@ -303,6 +306,45 @@ export function setupProjectsCommands(program: Command): void {
         }
 
         const result = await updateProject(ctx.gql, projectId, input);
+        outputSuccess(result);
+      }),
+    );
+
+  projects
+    .command("archive <project>")
+    .description("archive a project")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [project, , command] = args as [string, unknown, Command];
+        const ctx = createContext(command.parent!.parent!.opts());
+        const projectId = await resolveProjectId(ctx.sdk, project);
+        const result = await archiveProject(ctx.gql, projectId);
+        outputSuccess(result);
+      }),
+    );
+
+  projects
+    .command("unarchive <project>")
+    .description("unarchive a project")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [project, , command] = args as [string, unknown, Command];
+        const ctx = createContext(command.parent!.parent!.opts());
+        const projectId = await resolveProjectId(ctx.sdk, project);
+        const result = await unarchiveProject(ctx.gql, projectId);
+        outputSuccess(result);
+      }),
+    );
+
+  projects
+    .command("delete <project>")
+    .description("delete a project")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [project, , command] = args as [string, unknown, Command];
+        const ctx = createContext(command.parent!.parent!.opts());
+        const projectId = await resolveProjectId(ctx.sdk, project);
+        const result = await deleteProject(ctx.gql, projectId);
         outputSuccess(result);
       }),
     );

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -1,6 +1,7 @@
 import type {
   ArchiveInitiativeMutation,
   ArchiveInitiativeUpdateMutation,
+  ArchiveProjectMutation,
   AttachmentCreateMutation,
   CreateCommentMutation,
   CreateInitiativeMutation,
@@ -14,6 +15,7 @@ import type {
   DeleteInitiativeMutation,
   DeleteInitiativeRelationMutation,
   DeleteInitiativeToProjectMutation,
+  DeleteProjectMutation,
   DocumentCreateMutation,
   DocumentUpdateMutation,
   GetDocumentQuery,
@@ -40,6 +42,7 @@ import type {
   SearchIssuesQuery,
   UnarchiveInitiativeMutation,
   UnarchiveInitiativeUpdateMutation,
+  UnarchiveProjectMutation,
   UpdateCommentMutation,
   UpdateInitiativeMutation,
   UpdateInitiativeUpdateMutation,
@@ -141,6 +144,16 @@ export type CreatedProject = NonNullable<
 export type UpdatedProject = NonNullable<
   UpdateProjectMutation["projectUpdate"]["project"]
 >;
+export type ArchivedProject = NonNullable<
+  ArchiveProjectMutation["projectArchive"]["entity"]
+>;
+export type UnarchivedProject = NonNullable<
+  UnarchiveProjectMutation["projectUnarchive"]["entity"]
+>;
+export type DeletedProject = {
+  id: NonNullable<DeleteProjectMutation["projectDelete"]["entity"]>["id"];
+  success: true;
+};
 
 // Milestone types
 export type MilestoneDetail = NonNullable<

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -15,7 +15,6 @@ import type {
   DeleteInitiativeMutation,
   DeleteInitiativeRelationMutation,
   DeleteInitiativeToProjectMutation,
-  DeleteProjectMutation,
   DocumentCreateMutation,
   DocumentUpdateMutation,
   GetDocumentQuery,
@@ -151,7 +150,7 @@ export type UnarchivedProject = NonNullable<
   UnarchiveProjectMutation["projectUnarchive"]["entity"]
 >;
 export type DeletedProject = {
-  id: NonNullable<DeleteProjectMutation["projectDelete"]["entity"]>["id"];
+  id: string;
   success: true;
 };
 

--- a/src/resolvers/project-resolver.ts
+++ b/src/resolvers/project-resolver.ts
@@ -1,5 +1,5 @@
 import type { LinearSdkClient } from "../client/linear-client.js";
-import { notFoundError } from "../common/errors.js";
+import { multipleMatchesError, notFoundError } from "../common/errors.js";
 import { isUuid } from "../common/identifier.js";
 
 export interface ResolveProjectIdOptions {
@@ -15,12 +15,21 @@ export async function resolveProjectId(
 
   const result = await client.sdk.projects({
     filter: { name: { eqIgnoreCase: nameOrId } },
-    first: 1,
+    first: 2,
     includeArchived: options.includeArchived,
   });
 
   if (result.nodes.length === 0) {
     throw notFoundError("Project", nameOrId);
+  }
+
+  if (result.nodes.length > 1) {
+    throw multipleMatchesError(
+      "Project",
+      nameOrId,
+      result.nodes.map((project) => project.id),
+      "provide project UUID",
+    );
   }
 
   return result.nodes[0].id;

--- a/src/resolvers/project-resolver.ts
+++ b/src/resolvers/project-resolver.ts
@@ -2,15 +2,21 @@ import type { LinearSdkClient } from "../client/linear-client.js";
 import { notFoundError } from "../common/errors.js";
 import { isUuid } from "../common/identifier.js";
 
+export interface ResolveProjectIdOptions {
+  includeArchived?: boolean;
+}
+
 export async function resolveProjectId(
   client: LinearSdkClient,
   nameOrId: string,
+  options: ResolveProjectIdOptions = {},
 ): Promise<string> {
   if (isUuid(nameOrId)) return nameOrId;
 
   const result = await client.sdk.projects({
     filter: { name: { eqIgnoreCase: nameOrId } },
     first: 1,
+    includeArchived: options.includeArchived,
   });
 
   if (result.nodes.length === 0) {

--- a/src/services/project-service.ts
+++ b/src/services/project-service.ts
@@ -134,12 +134,12 @@ export async function deleteProject(
     { id },
   );
 
-  if (!result.projectDelete.success || !result.projectDelete.entity) {
+  if (!result.projectDelete.success) {
     throw new Error(`Failed to delete project "${id}"`);
   }
 
   return {
-    id: result.projectDelete.entity.id,
+    id: result.projectDelete.entity?.id ?? id,
     success: true,
   };
 }

--- a/src/services/project-service.ts
+++ b/src/services/project-service.ts
@@ -11,8 +11,6 @@ import type {
   UpdatedProject,
 } from "../common/types.js";
 import {
-  ArchiveProjectDocument,
-  type ArchiveProjectMutation,
   CreateProjectDocument,
   type CreateProjectMutation,
   DeleteProjectDocument,
@@ -97,16 +95,16 @@ export async function archiveProject(
   client: GraphQLClient,
   id: string,
 ): Promise<ArchivedProject> {
-  const result = await client.request<ArchiveProjectMutation>(
-    ArchiveProjectDocument,
+  const result = await client.request<DeleteProjectMutation>(
+    DeleteProjectDocument,
     { id },
   );
 
-  if (!result.projectArchive.success || !result.projectArchive.entity) {
+  if (!result.projectDelete.success || !result.projectDelete.entity) {
     throw new Error(`Failed to archive project "${id}"`);
   }
 
-  return result.projectArchive.entity;
+  return result.projectDelete.entity;
 }
 
 export async function unarchiveProject(

--- a/src/services/project-service.ts
+++ b/src/services/project-service.ts
@@ -11,6 +11,8 @@ import type {
   UpdatedProject,
 } from "../common/types.js";
 import {
+  ArchiveProjectDocument,
+  type ArchiveProjectMutation,
   CreateProjectDocument,
   type CreateProjectMutation,
   DeleteProjectDocument,
@@ -95,16 +97,16 @@ export async function archiveProject(
   client: GraphQLClient,
   id: string,
 ): Promise<ArchivedProject> {
-  const result = await client.request<DeleteProjectMutation>(
-    DeleteProjectDocument,
+  const result = await client.request<ArchiveProjectMutation>(
+    ArchiveProjectDocument,
     { id },
   );
 
-  if (!result.projectDelete.success || !result.projectDelete.entity) {
+  if (!result.projectArchive.success || !result.projectArchive.entity) {
     throw new Error(`Failed to archive project "${id}"`);
   }
 
-  return result.projectDelete.entity;
+  return result.projectArchive.entity;
 }
 
 export async function unarchiveProject(

--- a/src/services/project-service.ts
+++ b/src/services/project-service.ts
@@ -1,21 +1,30 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
 import type {
+  ArchivedProject,
   CreatedProject,
+  DeletedProject,
   PaginatedResult,
   PaginationOptions,
   ProjectDetail,
   ProjectListItem,
+  UnarchivedProject,
   UpdatedProject,
 } from "../common/types.js";
 import {
+  ArchiveProjectDocument,
+  type ArchiveProjectMutation,
   CreateProjectDocument,
   type CreateProjectMutation,
+  DeleteProjectDocument,
+  type DeleteProjectMutation,
   GetProjectDocument,
   type GetProjectQuery,
   GetProjectsDocument,
   type GetProjectsQuery,
   type ProjectCreateInput,
   type ProjectUpdateInput,
+  UnarchiveProjectDocument,
+  type UnarchiveProjectMutation,
   UpdateProjectDocument,
   type UpdateProjectMutation,
 } from "../gql/graphql.js";
@@ -82,4 +91,55 @@ export async function updateProject(
   }
 
   return result.projectUpdate.project;
+}
+
+export async function archiveProject(
+  client: GraphQLClient,
+  id: string,
+): Promise<ArchivedProject> {
+  const result = await client.request<ArchiveProjectMutation>(
+    ArchiveProjectDocument,
+    { id },
+  );
+
+  if (!result.projectArchive.success || !result.projectArchive.entity) {
+    throw new Error(`Failed to archive project "${id}"`);
+  }
+
+  return result.projectArchive.entity;
+}
+
+export async function unarchiveProject(
+  client: GraphQLClient,
+  id: string,
+): Promise<UnarchivedProject> {
+  const result = await client.request<UnarchiveProjectMutation>(
+    UnarchiveProjectDocument,
+    { id },
+  );
+
+  if (!result.projectUnarchive.success || !result.projectUnarchive.entity) {
+    throw new Error(`Failed to unarchive project "${id}"`);
+  }
+
+  return result.projectUnarchive.entity;
+}
+
+export async function deleteProject(
+  client: GraphQLClient,
+  id: string,
+): Promise<DeletedProject> {
+  const result = await client.request<DeleteProjectMutation>(
+    DeleteProjectDocument,
+    { id },
+  );
+
+  if (!result.projectDelete.success || !result.projectDelete.entity) {
+    throw new Error(`Failed to delete project "${id}"`);
+  }
+
+  return {
+    id: result.projectDelete.entity.id,
+    success: true,
+  };
 }

--- a/tests/unit/commands/projects.test.ts
+++ b/tests/unit/commands/projects.test.ts
@@ -163,6 +163,7 @@ describe("projects lifecycle", () => {
     expect(resolveProjectId).toHaveBeenCalledWith(
       expect.anything(),
       "My Project",
+      { includeArchived: true },
     );
     expect(deleteProject).toHaveBeenCalledWith(
       expect.anything(),

--- a/tests/unit/commands/projects.test.ts
+++ b/tests/unit/commands/projects.test.ts
@@ -138,6 +138,7 @@ describe("projects lifecycle", () => {
     expect(resolveProjectId).toHaveBeenCalledWith(
       expect.anything(),
       "My Project",
+      { includeArchived: true },
     );
     expect(unarchiveProject).toHaveBeenCalledWith(
       expect.anything(),

--- a/tests/unit/commands/projects.test.ts
+++ b/tests/unit/commands/projects.test.ts
@@ -35,9 +35,12 @@ vi.mock("../../../src/resolvers/user-resolver.js", () => ({
 }));
 
 vi.mock("../../../src/services/project-service.js", () => ({
+  archiveProject: vi.fn().mockResolvedValue({ id: "proj-1", name: "Archived" }),
   listProjects: vi.fn().mockResolvedValue({ nodes: [], pageInfo: {} }),
   getProject: vi.fn().mockResolvedValue({ id: "proj-1" }),
   createProject: vi.fn().mockResolvedValue({ id: "proj-new" }),
+  deleteProject: vi.fn().mockResolvedValue({ id: "proj-1", success: true }),
+  unarchiveProject: vi.fn().mockResolvedValue({ id: "proj-1", name: "Active" }),
   updateProject: vi.fn().mockResolvedValue({ id: "proj-1" }),
 }));
 
@@ -45,8 +48,11 @@ import { setupProjectsCommands } from "../../../src/commands/projects.js";
 import { outputSuccess } from "../../../src/common/output.js";
 import { resolveProjectId } from "../../../src/resolvers/project-resolver.js";
 import {
+  archiveProject,
   createProject,
+  deleteProject,
   getProject,
+  unarchiveProject,
   updateProject,
 } from "../../../src/services/project-service.js";
 
@@ -84,6 +90,87 @@ describe("projects read", () => {
       "resolved-project-uuid",
     );
     expect(outputSuccess).toHaveBeenCalledWith({ id: "proj-1" });
+  });
+});
+
+describe("projects lifecycle", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("archive resolves project and outputs result", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "archive",
+      "My Project",
+    ]);
+
+    expect(resolveProjectId).toHaveBeenCalledWith(
+      expect.anything(),
+      "My Project",
+    );
+    expect(archiveProject).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-project-uuid",
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({
+      id: "proj-1",
+      name: "Archived",
+    });
+  });
+
+  it("unarchive resolves project and outputs result", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "unarchive",
+      "My Project",
+    ]);
+
+    expect(resolveProjectId).toHaveBeenCalledWith(
+      expect.anything(),
+      "My Project",
+    );
+    expect(unarchiveProject).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-project-uuid",
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({
+      id: "proj-1",
+      name: "Active",
+    });
+  });
+
+  it("delete resolves project and outputs result", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "delete",
+      "My Project",
+    ]);
+
+    expect(resolveProjectId).toHaveBeenCalledWith(
+      expect.anything(),
+      "My Project",
+    );
+    expect(deleteProject).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-project-uuid",
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({
+      id: "proj-1",
+      success: true,
+    });
   });
 });
 

--- a/tests/unit/resolvers/project-resolver.test.ts
+++ b/tests/unit/resolvers/project-resolver.test.ts
@@ -40,6 +40,21 @@ describe("resolveProjectId", () => {
     expect(result).toBe("proj-uuid");
   });
 
+  it("includes archived projects when requested", async () => {
+    const client = mockSdkClient([{ id: "archived-proj-uuid" }]);
+
+    const result = await resolveProjectId(client, "Archived Project", {
+      includeArchived: true,
+    });
+
+    expect(result).toBe("archived-proj-uuid");
+    expect(client.sdk.projects).toHaveBeenCalledWith({
+      filter: { name: { eqIgnoreCase: "Archived Project" } },
+      first: 1,
+      includeArchived: true,
+    });
+  });
+
   it("throws when project not found", async () => {
     const client = mockSdkClient([]);
     await expect(resolveProjectId(client, "Nonexistent")).rejects.toThrow(

--- a/tests/unit/resolvers/project-resolver.test.ts
+++ b/tests/unit/resolvers/project-resolver.test.ts
@@ -50,7 +50,7 @@ describe("resolveProjectId", () => {
     expect(result).toBe("archived-proj-uuid");
     expect(client.sdk.projects).toHaveBeenCalledWith({
       filter: { name: { eqIgnoreCase: "Archived Project" } },
-      first: 1,
+      first: 2,
       includeArchived: true,
     });
   });
@@ -59,6 +59,19 @@ describe("resolveProjectId", () => {
     const client = mockSdkClient([]);
     await expect(resolveProjectId(client, "Nonexistent")).rejects.toThrow(
       'Project "Nonexistent" not found',
+    );
+  });
+
+  it("throws when multiple projects match same name", async () => {
+    const client = mockSdkClient([
+      { id: "proj-uuid-1" },
+      { id: "proj-uuid-2" },
+    ]);
+
+    await expect(
+      resolveProjectId(client, "Mobile App", { includeArchived: true }),
+    ).rejects.toThrow(
+      'Multiple Projects found matching "Mobile App". Candidates: proj-uuid-1, proj-uuid-2. Please provide project UUID.',
     );
   });
 });

--- a/tests/unit/services/project-service.test.ts
+++ b/tests/unit/services/project-service.test.ts
@@ -368,6 +368,17 @@ describe("deleteProject", () => {
     });
   });
 
+  it("returns the requested id when delete succeeds with null entity", async () => {
+    const client = mockGqlClient({
+      projectDelete: { success: true, entity: null },
+    });
+
+    await expect(deleteProject(client, "proj-1")).resolves.toEqual({
+      id: "proj-1",
+      success: true,
+    });
+  });
+
   it("throws on failure", async () => {
     const client = mockGqlClient({
       projectDelete: { success: false, entity: null },

--- a/tests/unit/services/project-service.test.ts
+++ b/tests/unit/services/project-service.test.ts
@@ -2,9 +2,12 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import {
+  archiveProject,
   createProject,
+  deleteProject,
   getProject,
   listProjects,
+  unarchiveProject,
   updateProject,
 } from "../../../src/services/project-service.js";
 
@@ -285,5 +288,92 @@ describe("updateProject", () => {
     await expect(
       updateProject(client, "proj-1", { name: "Fail" }),
     ).rejects.toThrow('Failed to update project "proj-1"');
+  });
+});
+
+describe("archiveProject", () => {
+  it("returns archived project on success", async () => {
+    const client = mockGqlClient({
+      projectArchive: {
+        success: true,
+        entity: { id: "proj-1", name: "Archived Project" },
+      },
+    });
+
+    await expect(archiveProject(client, "proj-1")).resolves.toEqual({
+      id: "proj-1",
+      name: "Archived Project",
+    });
+
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      id: "proj-1",
+    });
+  });
+
+  it("throws on failure", async () => {
+    const client = mockGqlClient({
+      projectArchive: { success: false, entity: null },
+    });
+
+    await expect(archiveProject(client, "proj-1")).rejects.toThrow(
+      'Failed to archive project "proj-1"',
+    );
+  });
+});
+
+describe("unarchiveProject", () => {
+  it("returns unarchived project on success", async () => {
+    const client = mockGqlClient({
+      projectUnarchive: {
+        success: true,
+        entity: { id: "proj-1", name: "Active Project" },
+      },
+    });
+
+    await expect(unarchiveProject(client, "proj-1")).resolves.toEqual({
+      id: "proj-1",
+      name: "Active Project",
+    });
+
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      id: "proj-1",
+    });
+  });
+
+  it("throws on failure", async () => {
+    const client = mockGqlClient({
+      projectUnarchive: { success: false, entity: null },
+    });
+
+    await expect(unarchiveProject(client, "proj-1")).rejects.toThrow(
+      'Failed to unarchive project "proj-1"',
+    );
+  });
+});
+
+describe("deleteProject", () => {
+  it("returns delete payload on success", async () => {
+    const client = mockGqlClient({
+      projectDelete: { success: true, entity: { id: "proj-1" } },
+    });
+
+    await expect(deleteProject(client, "proj-1")).resolves.toEqual({
+      id: "proj-1",
+      success: true,
+    });
+
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      id: "proj-1",
+    });
+  });
+
+  it("throws on failure", async () => {
+    const client = mockGqlClient({
+      projectDelete: { success: false, entity: null },
+    });
+
+    await expect(deleteProject(client, "proj-1")).rejects.toThrow(
+      'Failed to delete project "proj-1"',
+    );
   });
 });

--- a/tests/unit/services/project-service.test.ts
+++ b/tests/unit/services/project-service.test.ts
@@ -1,7 +1,7 @@
 // tests/unit/services/project-service.test.ts
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
-import { DeleteProjectDocument } from "../../../src/gql/graphql.js";
+import { ArchiveProjectDocument } from "../../../src/gql/graphql.js";
 import {
   archiveProject,
   createProject,
@@ -295,7 +295,7 @@ describe("updateProject", () => {
 describe("archiveProject", () => {
   it("returns archived project on success", async () => {
     const client = mockGqlClient({
-      projectDelete: {
+      projectArchive: {
         success: true,
         entity: { id: "proj-1", name: "Archived Project" },
       },
@@ -306,14 +306,14 @@ describe("archiveProject", () => {
       name: "Archived Project",
     });
 
-    expect(client.request).toHaveBeenCalledWith(DeleteProjectDocument, {
+    expect(client.request).toHaveBeenCalledWith(ArchiveProjectDocument, {
       id: "proj-1",
     });
   });
 
   it("throws on failure", async () => {
     const client = mockGqlClient({
-      projectDelete: { success: false, entity: null },
+      projectArchive: { success: false, entity: null },
     });
 
     await expect(archiveProject(client, "proj-1")).rejects.toThrow(

--- a/tests/unit/services/project-service.test.ts
+++ b/tests/unit/services/project-service.test.ts
@@ -1,6 +1,7 @@
 // tests/unit/services/project-service.test.ts
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { DeleteProjectDocument } from "../../../src/gql/graphql.js";
 import {
   archiveProject,
   createProject,
@@ -294,7 +295,7 @@ describe("updateProject", () => {
 describe("archiveProject", () => {
   it("returns archived project on success", async () => {
     const client = mockGqlClient({
-      projectArchive: {
+      projectDelete: {
         success: true,
         entity: { id: "proj-1", name: "Archived Project" },
       },
@@ -305,14 +306,14 @@ describe("archiveProject", () => {
       name: "Archived Project",
     });
 
-    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+    expect(client.request).toHaveBeenCalledWith(DeleteProjectDocument, {
       id: "proj-1",
     });
   });
 
   it("throws on failure", async () => {
     const client = mockGqlClient({
-      projectArchive: { success: false, entity: null },
+      projectDelete: { success: false, entity: null },
     });
 
     await expect(archiveProject(client, "proj-1")).rejects.toThrow(


### PR DESCRIPTION
## Summary
- add `projects archive`, `projects unarchive`, and `projects delete`
- resolve archived project names for unarchive and delete flows
- add project lifecycle GraphQL/service coverage and command tests

## Verification
- `npm run generate`
- `npm run check:ci`
- `npx tsc --noEmit`

Closes #141
