### PR TITLE
fix(ci): avoid bash regex parser error in promotion metadata

### DIFF
--- a/.github/workflows/release-promote-next-to-main.yml
+++ b/.github/workflows/release-promote-next-to-main.yml
@@ -78,7 +78,8 @@ jobs:
             local scope=""
             local bang=""
 
-            if [[ "$subject" =~ ^([a-z]+)(\(([^)]+)\))?(!)?:[[:space:]] ]]; then
+            local conventional_re='^([a-z]+)(\(([^()]*)\))?(!)?:[[:space:]]'
+            if [[ "$subject" =~ $conventional_re ]]; then
               type="${BASH_REMATCH[1]}"
               scope="${BASH_REMATCH[3]:-}"
               bang="${BASH_REMATCH[4]:-}"


### PR DESCRIPTION
## What does this PR do?

Fixes the promotion workflow metadata step by moving the Conventional Commit regex into a bash variable before `[[ ... =~ ... ]]` matching. This avoids bash parser errors in GitHub Actions.

Refs #172

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [x] Build / CI

## Checklist

- [ ] `npm run check:ci` passes (lint + format)
- [ ] `npx tsc --noEmit` passes (type check)
- [ ] `npm test` passes (unit tests)
- [ ] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- Triggered workflow: `release-promote-next-to-main.yml`
- Run succeeded after fix: https://github.com/linearis-oss/linearis/actions/runs/24839528142

## Notes for reviewers

- Change is intentionally minimal (single workflow line pattern adjustment).
- No runtime/app code touched.
