### PR TITLE
fix(release): prevent calver prerelease jumps and fail on invalid semantic drift

### DIFF
--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -6,13 +6,13 @@ module.exports = {
   tagFormat: `v\${version}`,
   plugins: [
     [
-      "@semantic-release/commit-analyzer",
+      "./scripts/release/calver-plugin.cjs",
       {
         preset: "conventionalcommits",
         releaseRules: [
-          // Calver plugin controls final version string.
-          // Custom rules here only suppress non-deliverable commits.
-          // Releasable commits (feat/fix/perf/revert/breaking) follow default analyzer rules.
+          // Suppress non-deliverable commits.
+          // Releasable commits (feat/fix/perf/revert/breaking) still trigger release,
+          // then calver-plugin maps analyzer output to patch cadence.
           { type: "refactor", release: false },
           { type: "chore", release: false },
           { type: "ci", release: false },
@@ -30,7 +30,6 @@ module.exports = {
       "@semantic-release/release-notes-generator",
       { preset: "conventionalcommits" },
     ],
-    "./scripts/release/calver-plugin.cjs",
     ["@semantic-release/changelog", { changelogFile: "CHANGELOG.md" }],
     ["@semantic-release/npm", { npmPublish: false, pkgRoot: "." }],
     [

--- a/scripts/release/calver-plugin.cjs
+++ b/scripts/release/calver-plugin.cjs
@@ -1,19 +1,65 @@
+const commitAnalyzer = require("@semantic-release/commit-analyzer");
 const { computeCalverVersion } = require("./calver.cjs");
 
-module.exports = {
-  verifyRelease: async (_, context) => {
-    const lastVersion = context.lastRelease?.version ?? "1970.1.0";
-    const branchName = context.branch?.name ?? "main";
+function mapCalverReleaseType(branchName, releaseType) {
+  if (!releaseType) {
+    return null;
+  }
 
-    const nextVersion = computeCalverVersion({
-      lastVersion,
-      branchName,
-      nowIso: new Date().toISOString(),
-    });
+  if (branchName === "main" || branchName === "next") {
+    return "patch";
+  }
 
+  return releaseType;
+}
+
+async function analyzeCommits(pluginConfig, context) {
+  const releaseType = await commitAnalyzer.analyzeCommits(
+    pluginConfig,
+    context,
+  );
+  const branchName = context.branch?.name ?? "main";
+
+  const mappedReleaseType = mapCalverReleaseType(branchName, releaseType);
+
+  if (releaseType !== mappedReleaseType) {
     context.logger.log(
-      `calver-plugin: forcing next release version to ${nextVersion}`,
+      `calver-plugin: mapped release type ${releaseType} -> ${mappedReleaseType} on ${branchName}`,
     );
-    context.nextRelease.version = nextVersion;
-  },
+  }
+
+  return mappedReleaseType;
+}
+
+async function verifyRelease(_, context) {
+  const lastVersion = context.lastRelease?.version ?? "1970.1.0";
+  const branchName = context.branch?.name ?? "main";
+  const semanticVersion = context.nextRelease?.version;
+
+  if (!semanticVersion) {
+    throw new Error("calver-plugin: missing context.nextRelease.version");
+  }
+
+  const expectedVersion = computeCalverVersion({
+    lastVersion,
+    branchName,
+    nowIso: new Date().toISOString(),
+  });
+
+  if (semanticVersion !== expectedVersion) {
+    throw new Error(
+      `calver-plugin: semantic-release computed ${semanticVersion} but calver requires ${expectedVersion}. ` +
+        "Current semantic-release version model cannot represent this calver transition.",
+    );
+  }
+
+  context.logger.log(
+    `calver-plugin: verified semantic-release version ${semanticVersion}`,
+  );
+}
+
+module.exports = {
+  analyzeCommits,
+  mapCalverReleaseType,
+  verifyRelease,
 };

--- a/scripts/release/calver-plugin.cjs
+++ b/scripts/release/calver-plugin.cjs
@@ -1,16 +1,25 @@
 const commitAnalyzer = require("@semantic-release/commit-analyzer");
-const { computeCalverVersion } = require("./calver.cjs");
+const { computeCalverVersion, isMonthRollover } = require("./calver.cjs");
 
-function mapCalverReleaseType(branchName, releaseType) {
+function mapCalverReleaseType({
+  branchName,
+  releaseType,
+  lastVersion,
+  nowIso,
+}) {
   if (!releaseType) {
     return null;
   }
 
-  if (branchName === "main" || branchName === "next") {
-    return "patch";
+  if (branchName !== "main" && branchName !== "next") {
+    return releaseType;
   }
 
-  return releaseType;
+  if (isMonthRollover({ lastVersion, branchName, nowIso })) {
+    return "minor";
+  }
+
+  return "patch";
 }
 
 async function analyzeCommits(pluginConfig, context) {
@@ -18,9 +27,17 @@ async function analyzeCommits(pluginConfig, context) {
     pluginConfig,
     context,
   );
-  const branchName = context.branch?.name ?? "main";
 
-  const mappedReleaseType = mapCalverReleaseType(branchName, releaseType);
+  const branchName = context.branch?.name ?? "main";
+  const lastVersion = context.lastRelease?.version ?? "1970.1.0";
+  const nowIso = new Date().toISOString();
+
+  const mappedReleaseType = mapCalverReleaseType({
+    branchName,
+    releaseType,
+    lastVersion,
+    nowIso,
+  });
 
   if (releaseType !== mappedReleaseType) {
     context.logger.log(
@@ -48,8 +65,7 @@ async function verifyRelease(_, context) {
 
   if (semanticVersion !== expectedVersion) {
     throw new Error(
-      `calver-plugin: semantic-release computed ${semanticVersion} but calver requires ${expectedVersion}. ` +
-        "Current semantic-release version model cannot represent this calver transition.",
+      `calver-plugin: semantic-release computed ${semanticVersion} but calver requires ${expectedVersion}`,
     );
   }
 

--- a/scripts/release/calver.cjs
+++ b/scripts/release/calver.cjs
@@ -36,6 +36,13 @@ function parseLastVersion(lastVersion, branchName) {
   };
 }
 
+function isMonthRollover({ lastVersion, branchName, nowIso }) {
+  const now = getUtcYearMonth(nowIso);
+  const last = parseLastVersion(lastVersion, branchName);
+
+  return !(last.year === now.year && last.month === now.month);
+}
+
 function computeCalverVersion({ lastVersion, branchName, nowIso }) {
   const now = getUtcYearMonth(nowIso);
   const last = parseLastVersion(lastVersion, branchName);
@@ -44,7 +51,7 @@ function computeCalverVersion({ lastVersion, branchName, nowIso }) {
 
   if (branchName === "next") {
     if (!sameMonth) {
-      return `${now.year}.${now.month}.1-next.1`;
+      return `${now.year}.${now.month}.0-next.1`;
     }
 
     const patch = last.fromPrerelease ? last.patch : last.patch + 1;
@@ -52,10 +59,11 @@ function computeCalverVersion({ lastVersion, branchName, nowIso }) {
     return `${now.year}.${now.month}.${patch}-next.${counter}`;
   }
 
-  const patch = sameMonth ? last.patch + 1 : 1;
+  const patch = sameMonth ? last.patch + 1 : 0;
   return `${now.year}.${now.month}.${patch}`;
 }
 
 module.exports = {
   computeCalverVersion,
+  isMonthRollover,
 };

--- a/tests/unit/release/calver-plugin.test.ts
+++ b/tests/unit/release/calver-plugin.test.ts
@@ -1,46 +1,91 @@
 import { describe, expect, it, vi } from "vitest";
-import { verifyRelease } from "../../../scripts/release/calver-plugin.cjs";
+import {
+  analyzeCommits,
+  mapCalverReleaseType,
+  verifyRelease,
+} from "../../../scripts/release/calver-plugin.cjs";
 
 describe("calver plugin", () => {
-  it("sets nextRelease.version in verifyRelease for main", async () => {
-    expect(verifyRelease).toBeTypeOf("function");
+  it("maps releasable commits to patch for main and next", () => {
+    expect(mapCalverReleaseType("main", "minor")).toBe("patch");
+    expect(mapCalverReleaseType("main", "major")).toBe("patch");
+    expect(mapCalverReleaseType("next", "minor")).toBe("patch");
+    expect(mapCalverReleaseType("next", "patch")).toBe("patch");
+  });
 
+  it("preserves null release type", () => {
+    expect(mapCalverReleaseType("main", null)).toBeNull();
+    expect(mapCalverReleaseType("next", null)).toBeNull();
+  });
+
+  it("delegates commit analysis but normalizes to patch cadence", async () => {
+    const pluginConfig = {
+      preset: "conventionalcommits",
+      releaseRules: [{ type: "chore", release: false }],
+    };
+
+    const context = {
+      branch: { name: "next" },
+      commits: [{ message: "feat(labels): add project labels" }],
+      cwd: process.cwd(),
+      env: process.env,
+      logger: { log: vi.fn<(message: string) => void>() },
+      options: {},
+    };
+
+    await expect(analyzeCommits(pluginConfig, context)).resolves.toBe("patch");
+  });
+
+  it("fails when semantic-release next version diverges from calver", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
 
     const context = {
-      lastRelease: { version: "2026.4.5" },
-      branch: { name: "main" },
+      lastRelease: { version: "2026.4.8-next.6" },
+      branch: { name: "next" },
       logger: { log: vi.fn<(message: string) => void>() },
-      nextRelease: { version: "0.0.0" },
+      nextRelease: { version: "2026.5.0-next.1" },
     };
 
-    await verifyRelease({}, context);
-
-    expect(context.nextRelease.version).toBe("2026.4.6");
-    expect(context.logger.log).toHaveBeenCalledWith(
-      "calver-plugin: forcing next release version to 2026.4.6",
+    await expect(verifyRelease({}, context)).rejects.toThrow(
+      "semantic-release computed 2026.5.0-next.1 but calver requires 2026.4.8-next.7",
     );
 
     vi.useRealTimers();
   });
 
-  it("increments prerelease counter on next branch", async () => {
+  it("fails loudly for month-rollover version gap", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T00:00:00.000Z"));
+
+    const context = {
+      lastRelease: { version: "2026.4.8" },
+      branch: { name: "main" },
+      logger: { log: vi.fn<(message: string) => void>() },
+      nextRelease: { version: "2026.4.9" },
+    };
+
+    await expect(verifyRelease({}, context)).rejects.toThrow(
+      "semantic-release computed 2026.4.9 but calver requires 2026.5.1",
+    );
+
+    vi.useRealTimers();
+  });
+
+  it("passes when semantic-release next version matches calver", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
 
     const context = {
-      lastRelease: { version: "2026.4.6-next.2" },
+      lastRelease: { version: "2026.4.8-next.6" },
       branch: { name: "next" },
       logger: { log: vi.fn<(message: string) => void>() },
-      nextRelease: { version: "0.0.0" },
+      nextRelease: { version: "2026.4.8-next.7" },
     };
 
-    await verifyRelease({}, context);
-
-    expect(context.nextRelease.version).toBe("2026.4.6-next.3");
+    await expect(verifyRelease({}, context)).resolves.toBeUndefined();
     expect(context.logger.log).toHaveBeenCalledWith(
-      "calver-plugin: forcing next release version to 2026.4.6-next.3",
+      "calver-plugin: verified semantic-release version 2026.4.8-next.7",
     );
 
     vi.useRealTimers();

--- a/tests/unit/release/calver-plugin.test.ts
+++ b/tests/unit/release/calver-plugin.test.ts
@@ -6,19 +6,58 @@ import {
 } from "../../../scripts/release/calver-plugin.cjs";
 
 describe("calver plugin", () => {
-  it("maps releasable commits to patch for main and next", () => {
-    expect(mapCalverReleaseType("main", "minor")).toBe("patch");
-    expect(mapCalverReleaseType("main", "major")).toBe("patch");
-    expect(mapCalverReleaseType("next", "minor")).toBe("patch");
-    expect(mapCalverReleaseType("next", "patch")).toBe("patch");
+  it("maps releasable commits to patch within same month", () => {
+    expect(
+      mapCalverReleaseType({
+        branchName: "main",
+        releaseType: "minor",
+        lastVersion: "2026.4.8",
+        nowIso: "2026-04-20T10:00:00.000Z",
+      }),
+    ).toBe("patch");
+
+    expect(
+      mapCalverReleaseType({
+        branchName: "next",
+        releaseType: "major",
+        lastVersion: "2026.4.8-next.6",
+        nowIso: "2026-04-20T10:00:00.000Z",
+      }),
+    ).toBe("patch");
+  });
+
+  it("maps releasable commits to minor on month rollover", () => {
+    expect(
+      mapCalverReleaseType({
+        branchName: "main",
+        releaseType: "patch",
+        lastVersion: "2026.4.8",
+        nowIso: "2026-05-01T00:00:00.000Z",
+      }),
+    ).toBe("minor");
+
+    expect(
+      mapCalverReleaseType({
+        branchName: "next",
+        releaseType: "patch",
+        lastVersion: "2026.4.8-next.6",
+        nowIso: "2026-05-01T00:00:00.000Z",
+      }),
+    ).toBe("minor");
   });
 
   it("preserves null release type", () => {
-    expect(mapCalverReleaseType("main", null)).toBeNull();
-    expect(mapCalverReleaseType("next", null)).toBeNull();
+    expect(
+      mapCalverReleaseType({
+        branchName: "main",
+        releaseType: null,
+        lastVersion: "2026.4.8",
+        nowIso: "2026-04-20T10:00:00.000Z",
+      }),
+    ).toBeNull();
   });
 
-  it("delegates commit analysis but normalizes to patch cadence", async () => {
+  it("delegates commit analysis and normalizes to patch cadence", async () => {
     const pluginConfig = {
       preset: "conventionalcommits",
       releaseRules: [{ type: "chore", release: false }],
@@ -31,9 +70,34 @@ describe("calver plugin", () => {
       env: process.env,
       logger: { log: vi.fn<(message: string) => void>() },
       options: {},
+      lastRelease: { version: "2026.4.8-next.6" },
     };
 
     await expect(analyzeCommits(pluginConfig, context)).resolves.toBe("patch");
+  });
+
+  it("rolls over to minor on month change during analyzeCommits", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-01T00:00:00.000Z"));
+
+    const pluginConfig = {
+      preset: "conventionalcommits",
+      releaseRules: [{ type: "chore", release: false }],
+    };
+
+    const context = {
+      branch: { name: "next" },
+      commits: [{ message: "fix(labels): repair filters" }],
+      cwd: process.cwd(),
+      env: process.env,
+      logger: { log: vi.fn<(message: string) => void>() },
+      options: {},
+      lastRelease: { version: "2026.4.8-next.6" },
+    };
+
+    await expect(analyzeCommits(pluginConfig, context)).resolves.toBe("minor");
+
+    vi.useRealTimers();
   });
 
   it("fails when semantic-release next version diverges from calver", async () => {
@@ -54,7 +118,7 @@ describe("calver plugin", () => {
     vi.useRealTimers();
   });
 
-  it("fails loudly for month-rollover version gap", async () => {
+  it("passes month-rollover semantic-release version", async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2026-05-01T00:00:00.000Z"));
 
@@ -62,12 +126,10 @@ describe("calver plugin", () => {
       lastRelease: { version: "2026.4.8" },
       branch: { name: "main" },
       logger: { log: vi.fn<(message: string) => void>() },
-      nextRelease: { version: "2026.4.9" },
+      nextRelease: { version: "2026.5.0" },
     };
 
-    await expect(verifyRelease({}, context)).rejects.toThrow(
-      "semantic-release computed 2026.4.9 but calver requires 2026.5.1",
-    );
+    await expect(verifyRelease({}, context)).resolves.toBeUndefined();
 
     vi.useRealTimers();
   });

--- a/tests/unit/release/calver.test.ts
+++ b/tests/unit/release/calver.test.ts
@@ -12,14 +12,14 @@ describe("computeCalverVersion", () => {
     expect(next).toBe("2026.4.6");
   });
 
-  it("resets patch to 1 when UTC month rolls", () => {
+  it("resets patch to 0 when UTC month rolls", () => {
     const next = computeCalverVersion({
       lastVersion: "2026.4.5",
       branchName: "main",
       nowIso: "2026-05-01T00:00:00.000Z",
     });
 
-    expect(next).toBe("2026.5.1");
+    expect(next).toBe("2026.5.0");
   });
 
   it("creates first prerelease from stable version on next branch", () => {
@@ -49,7 +49,7 @@ describe("computeCalverVersion", () => {
       nowIso: "2026-05-01T00:00:00.000Z",
     });
 
-    expect(next).toBe("2026.5.1-next.1");
+    expect(next).toBe("2026.5.0-next.1");
   });
 
   it("throws for invalid lastVersion", () => {


### PR DESCRIPTION
## Summary
- route semantic-release commit analysis through `calver-plugin`
- normalize releasable commit types by calver cadence:
  - same UTC month => `patch`
  - month rollover => `minor`
- replace unsupported `verifyRelease` context mutation with explicit calver divergence validation
- make calver month rollover semver-compatible by resetting monthly patch to `.0`
- add unit coverage for mapping logic, delegated analysis, and divergence guardrails

## Root cause addressed
`verifyRelease` tried to mutate `context.nextRelease.version`, but semantic-release passes plugins a cloned context, so mutation never persisted. semantic-release then published the original semver-derived version (`2026.5.0-next.1`).

## Behavior after this PR
- `feat`/`fix` on `next` still trigger releases with prerelease cadence
- same month on `next`: `...-next.N+1`
- month rollover on `next`: `YYYY.(M+1).0-next.1`
- release aborts loudly if semantic-release-computed version diverges from calver expectation

## Validation
- `npm run check:ci`
- `npx tsc --noEmit`
- `npm test`
- `npm run build`
- `npx vitest run tests/unit/release/calver-plugin.test.ts tests/unit/release/calver.test.ts`
