### PR TITLE
feat(issues): batch-resolve refs for issue create/update/search filters

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,9 +61,10 @@ CLI Input → Command → Resolver → Service → JSON Output
    - Resolvers must not import services (or vice versa).
    - Commands must not import `GraphQLClient` directly.
 3. **Client-layer contract:**
-   - Resolvers → `LinearSdkClient` only.
+   - Resolvers → `LinearSdkClient` by default.
    - Services → `GraphQLClient` only.
    - Commands → both, via `createContext()`.
+   - **Narrow exceptions allowed only when SDK lacks required capability**, with explicit `ARCHITECTURAL EXCEPTION` docstring in code (current examples: milestone/project-status lookups, initiative relation/link ID lookup helpers).
 4. **ID resolution happens once**, in resolvers only. Services accept UUIDs.
 5. **All commands** use `handleCommand()` wrapper and `outputSuccess()` for output.
 6. **Explicit return types** on all exported functions.
@@ -83,8 +84,9 @@ Need a new GraphQL operation?
 
 Need to resolve a human-friendly ID?
   → Add/edit src/resolvers/*-resolver.ts
-  → Use LinearSdkClient, return UUID string
+  → Prefer LinearSdkClient, return UUID string
   → Pattern: UUID passthrough → SDK lookup → notFoundError()
+  → If SDK cannot express lookup, use GraphQL as documented ARCHITECTURAL EXCEPTION (include rationale in resolver docstring)
 
 Need business logic / CRUD?
   → Add/edit src/services/*-service.ts

--- a/graphql/queries/issues.graphql
+++ b/graphql/queries/issues.graphql
@@ -353,156 +353,118 @@ query FilteredSearchIssues(
 # Comprehensive batch resolve for update operations
 #
 # Resolves all necessary entity references in a single batch query
-# before issue update. Includes labels, projects, teams, and parent issues.
-# This prevents N+1 queries during update operations.
+# before issue update.
 query BatchResolveForUpdate(
-  $labelNames: [String!]
+  $assigneeQuery: String
   $projectName: String
+  $projectId: ID
+  $labelNames: [String!]
+  $statusName: String
+  $cycleName: String
   $teamKey: String
-  $issueNumber: Float
+  $teamId: ID
   $milestoneName: String
-) {
-  # Resolve labels if provided
-  labels: issueLabels(filter: { name: { in: $labelNames } }) {
-    nodes {
-      id
-      name
-      isGroup
-      parent {
-        id
-        name
-      }
-      children {
-        nodes {
-          id
-          name
-        }
-      }
-    }
-  }
-
-  # Resolve project if provided (case-insensitive to be user-friendly)
-  projects(filter: { name: { eqIgnoreCase: $projectName } }, first: 1) {
-    nodes {
-      id
-      name
-      projectMilestones {
-        nodes {
-          id
-          name
-        }
-      }
-    }
-  }
-
-  # Resolve milestone if provided (standalone query in case no project context)
-  milestones: projectMilestones(
-    filter: { name: { eq: $milestoneName } }
-    first: 1
-  ) {
-    nodes {
-      id
-      name
-    }
-  }
-
-  # Resolve issue identifier if provided
-  issues(
-    filter: {
-      and: [
-        { team: { key: { eq: $teamKey } } }
-        { number: { eq: $issueNumber } }
-      ]
-    }
-    first: 1
-  ) {
-    nodes {
-      id
-      identifier
-      labels {
-        nodes {
-          id
-          name
-        }
-      }
-      team {
-        id
-        key
-        name
-      }
-      project {
-        id
-        projectMilestones {
-          nodes {
-            id
-            name
-          }
-        }
-      }
-    }
-  }
-}
-
-# Comprehensive batch resolve for create operations
-#
-# Resolves all entity references needed for issue creation in a single
-# batch query. Prevents N+1 queries during issue creation by
-# pre-resolving teams, projects, labels, and parent issues.
-query BatchResolveForCreate(
-  $teamKey: String
-  $teamName: String
-  $projectName: String
-  $labelNames: [String!]
   $parentTeamKey: String
   $parentIssueNumber: Float
 ) {
-  # Resolve team if provided
-  teams(
-    filter: { or: [{ key: { eq: $teamKey } }, { name: { eq: $teamName } }] }
-    first: 1
+  assignees: users(
+    filter: {
+      or: [
+        { displayName: { eqIgnoreCase: $assigneeQuery } }
+        { email: { eqIgnoreCase: $assigneeQuery } }
+      ]
+    }
+    first: 10
   ) {
     nodes {
       id
-      key
       name
+      email
+      displayName
     }
   }
 
-  # Resolve project if provided (case-insensitive to be user-friendly)
-  projects(filter: { name: { eqIgnoreCase: $projectName } }, first: 1) {
+  projects(
+    filter: {
+      or: [{ name: { eqIgnoreCase: $projectName } }, { id: { eq: $projectId } }]
+    }
+    first: 10
+  ) {
     nodes {
       id
       name
-      projectMilestones {
+      projectMilestones(
+        filter: { name: { eqIgnoreCase: $milestoneName } }
+        first: 10
+      ) {
         nodes {
           id
           name
         }
       }
-      # Projects don't own cycles directly, but include teams for context if needed
     }
   }
 
-  # Resolve labels if provided
   labels: issueLabels(filter: { name: { in: $labelNames } }) {
     nodes {
       id
       name
-      isGroup
-      parent {
-        id
-        name
-      }
-      children {
-        nodes {
-          id
-          name
+    }
+  }
+
+  statuses: workflowStates(
+    filter: {
+      and: [
+        { name: { eqIgnoreCase: $statusName } }
+        {
+          or: [
+            { team: { key: { eq: $teamKey } } }
+            { team: { id: { eq: $teamId } } }
+          ]
         }
+      ]
+    }
+    first: 10
+  ) {
+    nodes {
+      id
+      name
+      team {
+        id
+        key
       }
     }
   }
 
-  # Resolve parent issue if provided
+  cycles(
+    filter: {
+      and: [
+        { name: { eq: $cycleName } }
+        {
+          or: [
+            { team: { key: { eq: $teamKey } } }
+            { team: { id: { eq: $teamId } } }
+          ]
+        }
+      ]
+    }
+    first: 10
+  ) {
+    nodes {
+      id
+      name
+      isActive
+      isNext
+      isPrevious
+      number
+      startsAt
+      team {
+        id
+        key
+      }
+    }
+  }
+
   parentIssues: issues(
     filter: {
       and: [
@@ -517,8 +479,333 @@ query BatchResolveForCreate(
       identifier
     }
   }
+}
 
-  # Resolve cycles by name (team-scoped lookup is preferred but we also provide global fallback)
+# Comprehensive batch resolve for create operations
+#
+# Resolves all entity references needed for issue creation in a single
+# batch query.
+query BatchResolveForCreate(
+  $teamKey: String
+  $teamName: String
+  $teamId: ID
+  $assigneeQuery: String
+  $projectName: String
+  $projectId: ID
+  $labelNames: [String!]
+  $statusName: String
+  $cycleName: String
+  $milestoneName: String
+  $parentTeamKey: String
+  $parentIssueNumber: Float
+) {
+  teams(
+    filter: { or: [{ key: { eq: $teamKey } }, { name: { eq: $teamName } }] }
+    first: 10
+  ) {
+    nodes {
+      id
+      key
+      name
+    }
+  }
+
+  assignees: users(
+    filter: {
+      or: [
+        { displayName: { eqIgnoreCase: $assigneeQuery } }
+        { email: { eqIgnoreCase: $assigneeQuery } }
+      ]
+    }
+    first: 10
+  ) {
+    nodes {
+      id
+      name
+      email
+      displayName
+    }
+  }
+
+  projects(
+    filter: {
+      or: [{ name: { eqIgnoreCase: $projectName } }, { id: { eq: $projectId } }]
+    }
+    first: 10
+  ) {
+    nodes {
+      id
+      name
+      projectMilestones(
+        filter: { name: { eqIgnoreCase: $milestoneName } }
+        first: 10
+      ) {
+        nodes {
+          id
+          name
+        }
+      }
+    }
+  }
+
+  labels: issueLabels(filter: { name: { in: $labelNames } }) {
+    nodes {
+      id
+      name
+    }
+  }
+
+  statuses: workflowStates(
+    filter: {
+      and: [
+        { name: { eqIgnoreCase: $statusName } }
+        {
+          or: [
+            { team: { key: { eq: $teamKey } } }
+            { team: { name: { eq: $teamName } } }
+            { team: { id: { eq: $teamId } } }
+          ]
+        }
+      ]
+    }
+    first: 10
+  ) {
+    nodes {
+      id
+      name
+      team {
+        id
+        key
+      }
+    }
+  }
+
+  cycles(
+    filter: {
+      and: [
+        { name: { eq: $cycleName } }
+        {
+          or: [
+            { team: { key: { eq: $teamKey } } }
+            { team: { name: { eq: $teamName } } }
+            { team: { id: { eq: $teamId } } }
+          ]
+        }
+      ]
+    }
+    first: 10
+  ) {
+    nodes {
+      id
+      name
+      isActive
+      isNext
+      isPrevious
+      number
+      startsAt
+      team {
+        id
+        key
+      }
+    }
+  }
+
+  parentIssues: issues(
+    filter: {
+      and: [
+        { team: { key: { eq: $parentTeamKey } } }
+        { number: { eq: $parentIssueNumber } }
+      ]
+    }
+    first: 1
+  ) {
+    nodes {
+      id
+      identifier
+    }
+  }
+}
+
+query BatchResolveForSearch(
+  $teamKey: String
+  $teamName: String
+  $teamId: ID
+  $assigneeQuery: String
+  $creatorQuery: String
+  $projectName: String
+  $projectId: ID
+  $labelNames: [String!]
+  $cycleName: String
+  $parentTeamKey: String
+  $parentIssueNumber: Float
+  $milestoneName: String
+) {
+  teams(
+    filter: { or: [{ key: { eq: $teamKey } }, { name: { eq: $teamName } }] }
+    first: 10
+  ) {
+    nodes {
+      id
+      key
+      name
+    }
+  }
+
+  assignees: users(
+    filter: {
+      or: [
+        { displayName: { eqIgnoreCase: $assigneeQuery } }
+        { email: { eqIgnoreCase: $assigneeQuery } }
+      ]
+    }
+    first: 10
+  ) {
+    nodes {
+      id
+      name
+      email
+      displayName
+    }
+  }
+
+  creators: users(
+    filter: {
+      or: [
+        { displayName: { eqIgnoreCase: $creatorQuery } }
+        { email: { eqIgnoreCase: $creatorQuery } }
+      ]
+    }
+    first: 10
+  ) {
+    nodes {
+      id
+      name
+      email
+      displayName
+    }
+  }
+
+  projects(
+    filter: {
+      or: [{ name: { eqIgnoreCase: $projectName } }, { id: { eq: $projectId } }]
+    }
+    first: 10
+  ) {
+    nodes {
+      id
+      name
+      projectMilestones(
+        filter: { name: { eqIgnoreCase: $milestoneName } }
+        first: 10
+      ) {
+        nodes {
+          id
+          name
+        }
+      }
+    }
+  }
+
+  labels: issueLabels(filter: { name: { in: $labelNames } }) {
+    nodes {
+      id
+      name
+    }
+  }
+
+  statuses: workflowStates(
+    filter: {
+      or: [
+        { team: { key: { eq: $teamKey } } }
+        { team: { name: { eq: $teamName } } }
+        { team: { id: { eq: $teamId } } }
+      ]
+    }
+    first: 50
+  ) {
+    nodes {
+      id
+      name
+      team {
+        id
+        key
+      }
+    }
+  }
+
+  cycles(
+    filter: {
+      and: [
+        { name: { eq: $cycleName } }
+        {
+          or: [
+            { team: { key: { eq: $teamKey } } }
+            { team: { name: { eq: $teamName } } }
+            { team: { id: { eq: $teamId } } }
+          ]
+        }
+      ]
+    }
+    first: 10
+  ) {
+    nodes {
+      id
+      name
+      isActive
+      isNext
+      isPrevious
+      number
+      startsAt
+      team {
+        id
+        key
+      }
+    }
+  }
+
+  parentIssues: issues(
+    filter: {
+      and: [
+        { team: { key: { eq: $parentTeamKey } } }
+        { number: { eq: $parentIssueNumber } }
+      ]
+    }
+    first: 1
+  ) {
+    nodes {
+      id
+      identifier
+    }
+  }
+}
+
+query BatchResolveIssueLabelsPage($first: Int!, $after: String) {
+  issueLabels(first: $first, after: $after) {
+    nodes {
+      id
+      name
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+
+query BatchResolveWorkflowStatesPage($first: Int!, $after: String) {
+  workflowStates(first: $first, after: $after) {
+    nodes {
+      id
+      name
+      team {
+        id
+      }
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
 }
 
 # Complete issue fragment with attachments

--- a/src/common/resolve-filters.ts
+++ b/src/common/resolve-filters.ts
@@ -1,11 +1,5 @@
-import { resolveCycleId } from "../resolvers/cycle-resolver.js";
-import { resolveIssueId } from "../resolvers/issue-resolver.js";
-import { resolveLabelIds } from "../resolvers/label-resolver.js";
+import { resolveSearchFilterIds } from "../resolvers/issue-filter-resolver.js";
 import { resolveMilestoneId } from "../resolvers/milestone-resolver.js";
-import { resolveProjectId } from "../resolvers/project-resolver.js";
-import { resolveStatusId } from "../resolvers/status-resolver.js";
-import { resolveTeamId } from "../resolvers/team-resolver.js";
-import { resolveUserId } from "../resolvers/user-resolver.js";
 import type { CommandContext } from "./context.js";
 import { invalidParameterError } from "./errors.js";
 import { parseDueDate } from "./identifier.js";
@@ -101,62 +95,49 @@ export async function resolveFilterOptions(
   validateDateRange(opts.updatedAfter, opts.updatedBefore, "updated date");
 
   // 4. ID resolution
-  const resolved: IssueFilterOptions = {};
+  const hasResolvableFilters =
+    opts.team !== undefined ||
+    opts.assignee !== undefined ||
+    opts.creator !== undefined ||
+    opts.project !== undefined ||
+    parsedStatusNames !== undefined ||
+    parsedLabelNames !== undefined ||
+    opts.cycle !== undefined ||
+    opts.parent !== undefined;
 
-  if (opts.team) {
-    resolved.teamId = await resolveTeamId(ctx.sdk, opts.team);
-  }
-  if (opts.assignee) {
-    resolved.assigneeId = await resolveUserId(ctx.sdk, opts.assignee);
-  }
-  if (opts.creator) {
-    resolved.creatorId = await resolveUserId(ctx.sdk, opts.creator);
-  }
-  if (opts.project) {
-    resolved.projectId = await resolveProjectId(ctx.sdk, opts.project);
-  }
-  if (parsedStatusNames) {
-    const statusIds = await Promise.all(
-      parsedStatusNames.map((s) =>
-        resolveStatusId(ctx.sdk, s, resolved.teamId),
-      ),
-    );
-    resolved.stateIds = statusIds;
-  }
-  if (parsedLabelNames) {
-    resolved.labelIds = await resolveLabelIds(ctx.sdk, parsedLabelNames);
-  }
-  if (opts.cycle) {
-    resolved.cycleId = await resolveCycleId(
-      ctx.sdk,
-      opts.cycle,
-      resolved.teamId,
-    );
-  }
-  if (opts.parent) {
-    resolved.parentId = await resolveIssueId(ctx.sdk, opts.parent);
-  }
-  if (opts.milestone) {
-    resolved.milestoneId = await resolveMilestoneId(
-      ctx.gql,
-      ctx.sdk,
-      opts.milestone,
-      resolved.projectId,
-    );
-  }
+  const batchResolved = hasResolvableFilters
+    ? await resolveSearchFilterIds(ctx.sdk, {
+        team: opts.team,
+        assignee: opts.assignee,
+        creator: opts.creator,
+        project: opts.project,
+        statusNames: parsedStatusNames,
+        labelNames: parsedLabelNames,
+        cycle: opts.cycle,
+        parent: opts.parent,
+      })
+    : {};
 
-  resolved.priority = parsedPriority;
-  resolved.estimate = parsedEstimate;
-  resolved.dueBefore = opts.dueBefore;
-  resolved.dueAfter = opts.dueAfter;
-  resolved.createdAfter = opts.createdAfter;
-  resolved.createdBefore = opts.createdBefore;
-  resolved.completedAfter = opts.completedAfter;
-  resolved.completedBefore = opts.completedBefore;
-  resolved.updatedAfter = opts.updatedAfter;
-  resolved.updatedBefore = opts.updatedBefore;
-  resolved.hasBlockers = opts.hasBlockers;
-  resolved.isBlocking = opts.isBlocking;
+  const milestoneId = opts.milestone
+    ? await resolveMilestoneId(ctx.gql, ctx.sdk, opts.milestone, opts.project)
+    : undefined;
+
+  const resolved: IssueFilterOptions = {
+    ...batchResolved,
+    milestoneId,
+    priority: parsedPriority,
+    estimate: parsedEstimate,
+    dueBefore: opts.dueBefore,
+    dueAfter: opts.dueAfter,
+    createdAfter: opts.createdAfter,
+    createdBefore: opts.createdBefore,
+    completedAfter: opts.completedAfter,
+    completedBefore: opts.completedBefore,
+    updatedAfter: opts.updatedAfter,
+    updatedBefore: opts.updatedBefore,
+    hasBlockers: opts.hasBlockers,
+    isBlocking: opts.isBlocking,
+  };
 
   return resolved;
 }

--- a/src/resolvers/issue-filter-resolver.ts
+++ b/src/resolvers/issue-filter-resolver.ts
@@ -1,0 +1,79 @@
+import type { LinearSdkClient } from "../client/linear-client.js";
+import { resolveCycleId } from "./cycle-resolver.js";
+import { resolveIssueId } from "./issue-resolver.js";
+import { resolveLabelIds } from "./label-resolver.js";
+import { resolveProjectId } from "./project-resolver.js";
+import { resolveStatusId } from "./status-resolver.js";
+import { resolveTeamId } from "./team-resolver.js";
+import { resolveUserId } from "./user-resolver.js";
+
+export interface SearchFilterResolutionInput {
+  team?: string;
+  assignee?: string;
+  creator?: string;
+  project?: string;
+  statusNames?: string[];
+  labelNames?: string[];
+  cycle?: string;
+  parent?: string;
+}
+
+export interface SearchFilterResolution {
+  teamId?: string;
+  assigneeId?: string;
+  creatorId?: string;
+  projectId?: string;
+  stateIds?: string[];
+  labelIds?: string[];
+  cycleId?: string;
+  parentId?: string;
+}
+
+export async function resolveSearchFilterIds(
+  sdkClient: LinearSdkClient,
+  input: SearchFilterResolutionInput,
+): Promise<SearchFilterResolution> {
+  const resolved: SearchFilterResolution = {};
+
+  if (input.team) {
+    resolved.teamId = await resolveTeamId(sdkClient, input.team);
+  }
+
+  if (input.assignee) {
+    resolved.assigneeId = await resolveUserId(sdkClient, input.assignee);
+  }
+
+  if (input.creator) {
+    resolved.creatorId = await resolveUserId(sdkClient, input.creator);
+  }
+
+  if (input.project) {
+    resolved.projectId = await resolveProjectId(sdkClient, input.project);
+  }
+
+  if (input.statusNames && input.statusNames.length > 0) {
+    resolved.stateIds = await Promise.all(
+      input.statusNames.map((status) =>
+        resolveStatusId(sdkClient, status, resolved.teamId),
+      ),
+    );
+  }
+
+  if (input.labelNames && input.labelNames.length > 0) {
+    resolved.labelIds = await resolveLabelIds(sdkClient, input.labelNames);
+  }
+
+  if (input.cycle) {
+    resolved.cycleId = await resolveCycleId(
+      sdkClient,
+      input.cycle,
+      resolved.teamId ?? input.team,
+    );
+  }
+
+  if (input.parent) {
+    resolved.parentId = await resolveIssueId(sdkClient, input.parent);
+  }
+
+  return resolved;
+}

--- a/tests/unit/common/resolve-filters.test.ts
+++ b/tests/unit/common/resolve-filters.test.ts
@@ -3,28 +3,22 @@ import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import type { LinearSdkClient } from "../../../src/client/linear-client.js";
 import type { CommandContext } from "../../../src/common/context.js";
 import { resolveFilterOptions } from "../../../src/common/resolve-filters.js";
+import { resolveSearchFilterIds } from "../../../src/resolvers/issue-filter-resolver.js";
+import { resolveMilestoneId } from "../../../src/resolvers/milestone-resolver.js";
 
-vi.mock("../../../src/resolvers/team-resolver.js", () => ({
-  resolveTeamId: vi.fn().mockResolvedValue("team-uuid"),
+vi.mock("../../../src/resolvers/issue-filter-resolver.js", () => ({
+  resolveSearchFilterIds: vi.fn().mockResolvedValue({
+    teamId: "team-uuid",
+    assigneeId: "user-uuid",
+    creatorId: "user-uuid",
+    projectId: "project-uuid",
+    stateIds: ["status-uuid"],
+    labelIds: ["label-uuid-1", "label-uuid-2"],
+    cycleId: "cycle-uuid",
+    parentId: "issue-uuid",
+  }),
 }));
-vi.mock("../../../src/resolvers/user-resolver.js", () => ({
-  resolveUserId: vi.fn().mockResolvedValue("user-uuid"),
-}));
-vi.mock("../../../src/resolvers/project-resolver.js", () => ({
-  resolveProjectId: vi.fn().mockResolvedValue("project-uuid"),
-}));
-vi.mock("../../../src/resolvers/status-resolver.js", () => ({
-  resolveStatusId: vi.fn().mockResolvedValue("status-uuid"),
-}));
-vi.mock("../../../src/resolvers/label-resolver.js", () => ({
-  resolveLabelIds: vi.fn().mockResolvedValue(["label-uuid-1", "label-uuid-2"]),
-}));
-vi.mock("../../../src/resolvers/cycle-resolver.js", () => ({
-  resolveCycleId: vi.fn().mockResolvedValue("cycle-uuid"),
-}));
-vi.mock("../../../src/resolvers/issue-resolver.js", () => ({
-  resolveIssueId: vi.fn().mockResolvedValue("issue-uuid"),
-}));
+
 vi.mock("../../../src/resolvers/milestone-resolver.js", () => ({
   resolveMilestoneId: vi.fn().mockResolvedValue("milestone-uuid"),
 }));
@@ -42,9 +36,11 @@ describe("resolveFilterOptions", () => {
   });
 
   it("returns empty options when no flags provided", async () => {
-    const ctx = mockContext();
-    const result = await resolveFilterOptions(ctx, {});
+    const result = await resolveFilterOptions(mockContext(), {});
+
+    expect(resolveSearchFilterIds).not.toHaveBeenCalled();
     expect(result).toEqual({
+      milestoneId: undefined,
       priority: undefined,
       estimate: undefined,
       dueBefore: undefined,
@@ -60,334 +56,158 @@ describe("resolveFilterOptions", () => {
     });
   });
 
-  it("resolves team ID via resolver", async () => {
-    const { resolveTeamId } = await import(
-      "../../../src/resolvers/team-resolver.js"
-    );
-    const ctx = mockContext();
-    const result = await resolveFilterOptions(ctx, { team: "ENG" });
-    expect(resolveTeamId).toHaveBeenCalledWith(ctx.sdk, "ENG");
-    expect(result.teamId).toBe("team-uuid");
-  });
-
-  it("resolves assignee ID via resolver", async () => {
-    const { resolveUserId } = await import(
-      "../../../src/resolvers/user-resolver.js"
-    );
-    const ctx = mockContext();
-    const result = await resolveFilterOptions(ctx, { assignee: "alice" });
-    expect(resolveUserId).toHaveBeenCalledWith(ctx.sdk, "alice");
-    expect(result.assigneeId).toBe("user-uuid");
-  });
-
-  it("resolves creator ID via resolver", async () => {
-    const { resolveUserId } = await import(
-      "../../../src/resolvers/user-resolver.js"
-    );
-    const ctx = mockContext();
-    const result = await resolveFilterOptions(ctx, { creator: "bob" });
-    expect(resolveUserId).toHaveBeenCalledWith(ctx.sdk, "bob");
-    expect(result.creatorId).toBe("user-uuid");
-  });
-
-  it("resolves project ID via resolver", async () => {
-    const { resolveProjectId } = await import(
-      "../../../src/resolvers/project-resolver.js"
-    );
-    const ctx = mockContext();
-    const result = await resolveFilterOptions(ctx, { project: "Backend" });
-    expect(resolveProjectId).toHaveBeenCalledWith(ctx.sdk, "Backend");
-    expect(result.projectId).toBe("project-uuid");
-  });
-
-  it("resolves comma-separated status IDs with team dependency", async () => {
-    const { resolveStatusId } = await import(
-      "../../../src/resolvers/status-resolver.js"
-    );
-    const ctx = mockContext();
-    const result = await resolveFilterOptions(ctx, {
+  it("calls resolveSearchFilterIds once after validation", async () => {
+    const result = await resolveFilterOptions(mockContext(), {
       team: "ENG",
-      status: "Todo,In Progress",
-    });
-    expect(resolveStatusId).toHaveBeenCalledWith(ctx.sdk, "Todo", "team-uuid");
-    expect(resolveStatusId).toHaveBeenCalledWith(
-      ctx.sdk,
-      "In Progress",
-      "team-uuid",
-    );
-    expect(result.stateIds).toEqual(["status-uuid", "status-uuid"]);
-  });
-
-  it("resolves comma-separated label IDs", async () => {
-    const { resolveLabelIds } = await import(
-      "../../../src/resolvers/label-resolver.js"
-    );
-    const ctx = mockContext();
-    const result = await resolveFilterOptions(ctx, { label: "Bug,Critical" });
-    expect(resolveLabelIds).toHaveBeenCalledWith(ctx.sdk, ["Bug", "Critical"]);
-    expect(result.labelIds).toEqual(["label-uuid-1", "label-uuid-2"]);
-  });
-
-  it("resolves cycle ID with resolved team ID", async () => {
-    const { resolveCycleId } = await import(
-      "../../../src/resolvers/cycle-resolver.js"
-    );
-    const ctx = mockContext();
-    const result = await resolveFilterOptions(ctx, {
-      team: "ENG",
-      cycle: "Sprint 1",
-    });
-    expect(resolveCycleId).toHaveBeenCalledWith(
-      ctx.sdk,
-      "Sprint 1",
-      "team-uuid",
-    );
-    expect(result.cycleId).toBe("cycle-uuid");
-  });
-
-  it("resolves parent issue ID", async () => {
-    const { resolveIssueId } = await import(
-      "../../../src/resolvers/issue-resolver.js"
-    );
-    const ctx = mockContext();
-    const result = await resolveFilterOptions(ctx, { parent: "ENG-123" });
-    expect(resolveIssueId).toHaveBeenCalledWith(ctx.sdk, "ENG-123");
-    expect(result.parentId).toBe("issue-uuid");
-  });
-
-  it("resolves milestone ID with resolved project ID", async () => {
-    const { resolveMilestoneId } = await import(
-      "../../../src/resolvers/milestone-resolver.js"
-    );
-    const ctx = mockContext();
-    const result = await resolveFilterOptions(ctx, {
+      assignee: "alice",
+      creator: "bob",
       project: "Backend",
+      status: "Todo",
+      label: "Bug,Critical",
+      cycle: "Sprint 1",
+      parent: "ENG-123",
       milestone: "v1.0",
+      priority: "2",
+      estimate: "5",
+    });
+
+    expect(resolveSearchFilterIds).toHaveBeenCalledTimes(1);
+    expect(resolveSearchFilterIds).toHaveBeenCalledWith(expect.anything(), {
+      team: "ENG",
+      assignee: "alice",
+      creator: "bob",
+      project: "Backend",
+      statusNames: ["Todo"],
+      labelNames: ["Bug", "Critical"],
+      cycle: "Sprint 1",
+      parent: "ENG-123",
     });
     expect(resolveMilestoneId).toHaveBeenCalledWith(
-      ctx.gql,
-      ctx.sdk,
+      expect.anything(),
+      expect.anything(),
       "v1.0",
-      "project-uuid",
+      "Backend",
     );
-    expect(result.milestoneId).toBe("milestone-uuid");
-  });
-
-  it("parses priority string to number", async () => {
-    const ctx = mockContext();
-    const result = await resolveFilterOptions(ctx, { priority: "2" });
+    expect(result.teamId).toBe("team-uuid");
+    expect(result.stateIds).toEqual(["status-uuid"]);
     expect(result.priority).toBe(2);
-  });
-
-  it("parses estimate string to number", async () => {
-    const ctx = mockContext();
-    const result = await resolveFilterOptions(ctx, { estimate: "5" });
     expect(result.estimate).toBe(5);
   });
 
-  it("passes through date values unchanged", async () => {
-    const ctx = mockContext();
-    const result = await resolveFilterOptions(ctx, {
-      dueBefore: "2025-12-31",
-      dueAfter: "2025-01-01",
-      createdAfter: "2025-02-01",
-      createdBefore: "2025-11-01",
-    });
-    expect(result.dueBefore).toBe("2025-12-31");
-    expect(result.dueAfter).toBe("2025-01-01");
-    expect(result.createdAfter).toBe("2025-02-01");
-    expect(result.createdBefore).toBe("2025-11-01");
-  });
-
-  it("passes through boolean flags", async () => {
-    const ctx = mockContext();
-    const result = await resolveFilterOptions(ctx, {
-      hasBlockers: true,
-      isBlocking: true,
-    });
-    expect(result.hasBlockers).toBe(true);
-    expect(result.isBlocking).toBe(true);
-  });
-
-  // Validation error cases
-  it("throws on invalid priority string", async () => {
-    const ctx = mockContext();
+  it("throws on invalid priority string before network call", async () => {
     await expect(
-      resolveFilterOptions(ctx, { priority: "abc" }),
+      resolveFilterOptions(mockContext(), { priority: "abc" }),
     ).rejects.toThrow("--priority");
+    expect(resolveSearchFilterIds).not.toHaveBeenCalled();
   });
 
-  it("throws on decimal priority", async () => {
-    const ctx = mockContext();
+  it("throws on invalid estimate string before network call", async () => {
     await expect(
-      resolveFilterOptions(ctx, { priority: "1.5" }),
-    ).rejects.toThrow("--priority");
-  });
-
-  it("throws on out-of-range priority", async () => {
-    const ctx = mockContext();
-    await expect(resolveFilterOptions(ctx, { priority: "5" })).rejects.toThrow(
-      "priority",
-    );
-  });
-
-  it("throws on invalid estimate string", async () => {
-    const ctx = mockContext();
-    await expect(
-      resolveFilterOptions(ctx, { estimate: "abc" }),
+      resolveFilterOptions(mockContext(), { estimate: "2abc" }),
     ).rejects.toThrow("--estimate");
-  });
-
-  it("throws on partially numeric estimate", async () => {
-    const ctx = mockContext();
-    await expect(
-      resolveFilterOptions(ctx, { estimate: "2abc" }),
-    ).rejects.toThrow("--estimate");
-  });
-
-  it("throws on negative estimate", async () => {
-    const ctx = mockContext();
-    await expect(resolveFilterOptions(ctx, { estimate: "-1" })).rejects.toThrow(
-      "estimate",
-    );
+    expect(resolveSearchFilterIds).not.toHaveBeenCalled();
   });
 
   it("throws when --status used without --team", async () => {
-    const ctx = mockContext();
     await expect(
-      resolveFilterOptions(ctx, { status: "In Progress" }),
+      resolveFilterOptions(mockContext(), { status: "In Progress" }),
     ).rejects.toThrow("--team");
+    expect(resolveSearchFilterIds).not.toHaveBeenCalled();
   });
 
   it("allows status UUID without --team", async () => {
-    const { resolveTeamId } = await import(
-      "../../../src/resolvers/team-resolver.js"
-    );
-    const { resolveStatusId } = await import(
-      "../../../src/resolvers/status-resolver.js"
-    );
-    const ctx = mockContext();
-    const result = await resolveFilterOptions(ctx, {
+    await resolveFilterOptions(mockContext(), {
       status: "550e8400-e29b-41d4-a716-446655440000",
     });
-    expect(resolveTeamId).not.toHaveBeenCalled();
-    expect(resolveStatusId).toHaveBeenCalledWith(
-      ctx.sdk,
-      "550e8400-e29b-41d4-a716-446655440000",
-      undefined,
-    );
-    expect(result.stateIds).toEqual(["status-uuid"]);
+
+    expect(resolveSearchFilterIds).toHaveBeenCalledWith(expect.anything(), {
+      team: undefined,
+      assignee: undefined,
+      creator: undefined,
+      project: undefined,
+      statusNames: ["550e8400-e29b-41d4-a716-446655440000"],
+      labelNames: undefined,
+      cycle: undefined,
+      parent: undefined,
+    });
   });
 
   it("throws on malformed status list before making resolver calls", async () => {
-    const { resolveTeamId } = await import(
-      "../../../src/resolvers/team-resolver.js"
-    );
-    const { resolveStatusId } = await import(
-      "../../../src/resolvers/status-resolver.js"
-    );
-    const ctx = mockContext();
     await expect(
-      resolveFilterOptions(ctx, { team: "ENG", status: "Todo,,Done" }),
+      resolveFilterOptions(mockContext(), {
+        team: "ENG",
+        status: "Todo,,Done",
+      }),
     ).rejects.toThrow("empty");
-    expect(resolveTeamId).not.toHaveBeenCalled();
-    expect(resolveStatusId).not.toHaveBeenCalled();
+    expect(resolveSearchFilterIds).not.toHaveBeenCalled();
   });
 
   it("throws on malformed label list before making resolver calls", async () => {
-    const { resolveLabelIds } = await import(
-      "../../../src/resolvers/label-resolver.js"
-    );
-    const ctx = mockContext();
     await expect(
-      resolveFilterOptions(ctx, { label: "bug, ,ux" }),
+      resolveFilterOptions(mockContext(), { label: "bug, ,ux" }),
     ).rejects.toThrow("empty");
-    expect(resolveLabelIds).not.toHaveBeenCalled();
+    expect(resolveSearchFilterIds).not.toHaveBeenCalled();
   });
 
   it("throws when --cycle used without --team", async () => {
-    const ctx = mockContext();
     await expect(
-      resolveFilterOptions(ctx, { cycle: "Sprint 1" }),
+      resolveFilterOptions(mockContext(), { cycle: "Sprint 1" }),
     ).rejects.toThrow("--team");
+    expect(resolveSearchFilterIds).not.toHaveBeenCalled();
   });
 
   it("allows cycle UUID without --team", async () => {
-    const { resolveTeamId } = await import(
-      "../../../src/resolvers/team-resolver.js"
-    );
-    const { resolveCycleId } = await import(
-      "../../../src/resolvers/cycle-resolver.js"
-    );
-    const ctx = mockContext();
-    const result = await resolveFilterOptions(ctx, {
+    await resolveFilterOptions(mockContext(), {
       cycle: "550e8400-e29b-41d4-a716-446655440001",
     });
-    expect(resolveTeamId).not.toHaveBeenCalled();
-    expect(resolveCycleId).toHaveBeenCalledWith(
-      ctx.sdk,
-      "550e8400-e29b-41d4-a716-446655440001",
-      undefined,
-    );
-    expect(result.cycleId).toBe("cycle-uuid");
+
+    expect(resolveSearchFilterIds).toHaveBeenCalledWith(expect.anything(), {
+      team: undefined,
+      assignee: undefined,
+      creator: undefined,
+      project: undefined,
+      statusNames: undefined,
+      labelNames: undefined,
+      cycle: "550e8400-e29b-41d4-a716-446655440001",
+      parent: undefined,
+    });
   });
 
   it("throws when --milestone used without --project", async () => {
-    const ctx = mockContext();
     await expect(
-      resolveFilterOptions(ctx, { milestone: "v1.0" }),
+      resolveFilterOptions(mockContext(), { milestone: "v1.0" }),
     ).rejects.toThrow("--project");
+    expect(resolveSearchFilterIds).not.toHaveBeenCalled();
   });
 
   it("allows milestone UUID without --project", async () => {
-    const { resolveProjectId } = await import(
-      "../../../src/resolvers/project-resolver.js"
-    );
-    const { resolveMilestoneId } = await import(
-      "../../../src/resolvers/milestone-resolver.js"
-    );
-    const ctx = mockContext();
-    const result = await resolveFilterOptions(ctx, {
+    await resolveFilterOptions(mockContext(), {
       milestone: "550e8400-e29b-41d4-a716-446655440002",
     });
-    expect(resolveProjectId).not.toHaveBeenCalled();
+
+    expect(resolveSearchFilterIds).not.toHaveBeenCalled();
     expect(resolveMilestoneId).toHaveBeenCalledWith(
-      ctx.gql,
-      ctx.sdk,
+      expect.anything(),
+      expect.anything(),
       "550e8400-e29b-41d4-a716-446655440002",
       undefined,
     );
-    expect(result.milestoneId).toBe("milestone-uuid");
   });
 
-  it("throws on contradictory date range", async () => {
-    const ctx = mockContext();
+  it("throws on contradictory date range before network call", async () => {
     await expect(
-      resolveFilterOptions(ctx, {
+      resolveFilterOptions(mockContext(), {
         dueAfter: "2025-12-31",
         dueBefore: "2025-01-01",
       }),
     ).rejects.toThrow("due date");
+    expect(resolveSearchFilterIds).not.toHaveBeenCalled();
   });
 
   it("throws on invalid due date format with flag-specific message", async () => {
-    const ctx = mockContext();
     await expect(
-      resolveFilterOptions(ctx, { dueBefore: "not-a-date" }),
+      resolveFilterOptions(mockContext(), { dueBefore: "not-a-date" }),
     ).rejects.toThrow("--due-before");
-  });
-
-  it("throws on invalid created date format with flag-specific message", async () => {
-    const ctx = mockContext();
-    await expect(
-      resolveFilterOptions(ctx, { createdBefore: "not-a-date" }),
-    ).rejects.toThrow("--created-before");
-  });
-
-  it("throws on impossible completed date with flag-specific message", async () => {
-    const ctx = mockContext();
-    await expect(
-      resolveFilterOptions(ctx, { completedAfter: "2025-02-30" }),
-    ).rejects.toThrow("--completed-after");
+    expect(resolveSearchFilterIds).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/resolvers/issue-filter-resolver.test.ts
+++ b/tests/unit/resolvers/issue-filter-resolver.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { LinearSdkClient } from "../../../src/client/linear-client.js";
+import { resolveSearchFilterIds } from "../../../src/resolvers/issue-filter-resolver.js";
+
+const {
+  resolveTeamIdMock,
+  resolveUserIdMock,
+  resolveProjectIdMock,
+  resolveStatusIdMock,
+  resolveLabelIdsMock,
+  resolveCycleIdMock,
+  resolveIssueIdMock,
+} = vi.hoisted(() => ({
+  resolveTeamIdMock: vi.fn(),
+  resolveUserIdMock: vi.fn(),
+  resolveProjectIdMock: vi.fn(),
+  resolveStatusIdMock: vi.fn(),
+  resolveLabelIdsMock: vi.fn(),
+  resolveCycleIdMock: vi.fn(),
+  resolveIssueIdMock: vi.fn(),
+}));
+
+vi.mock("../../../src/resolvers/team-resolver.js", () => ({
+  resolveTeamId: resolveTeamIdMock,
+}));
+
+vi.mock("../../../src/resolvers/user-resolver.js", () => ({
+  resolveUserId: resolveUserIdMock,
+}));
+
+vi.mock("../../../src/resolvers/project-resolver.js", () => ({
+  resolveProjectId: resolveProjectIdMock,
+}));
+
+vi.mock("../../../src/resolvers/status-resolver.js", () => ({
+  resolveStatusId: resolveStatusIdMock,
+}));
+
+vi.mock("../../../src/resolvers/label-resolver.js", () => ({
+  resolveLabelIds: resolveLabelIdsMock,
+}));
+
+vi.mock("../../../src/resolvers/cycle-resolver.js", () => ({
+  resolveCycleId: resolveCycleIdMock,
+}));
+
+vi.mock("../../../src/resolvers/issue-resolver.js", () => ({
+  resolveIssueId: resolveIssueIdMock,
+}));
+
+describe("resolveSearchFilterIds", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("passes resolved team UUID to status/cycle lookups", async () => {
+    const sdk = {} as unknown as LinearSdkClient;
+
+    resolveTeamIdMock.mockResolvedValue("team-uuid");
+    resolveStatusIdMock.mockResolvedValue("state-uuid");
+    resolveCycleIdMock.mockResolvedValue("cycle-uuid");
+
+    const result = await resolveSearchFilterIds(sdk, {
+      team: "ENG",
+      statusNames: ["Todo"],
+      cycle: "Sprint 1",
+    });
+
+    expect(resolveTeamIdMock).toHaveBeenCalledWith(sdk, "ENG");
+    expect(resolveStatusIdMock).toHaveBeenCalledWith(sdk, "Todo", "team-uuid");
+    expect(resolveCycleIdMock).toHaveBeenCalledWith(
+      sdk,
+      "Sprint 1",
+      "team-uuid",
+    );
+    expect(result).toEqual({
+      teamId: "team-uuid",
+      stateIds: ["state-uuid"],
+      cycleId: "cycle-uuid",
+    });
+  });
+
+  it("falls back to raw team input for cycle lookup when team not pre-resolved", async () => {
+    const sdk = {} as unknown as LinearSdkClient;
+
+    resolveCycleIdMock.mockResolvedValue("cycle-uuid");
+
+    const result = await resolveSearchFilterIds(sdk, {
+      cycle: "Sprint 2",
+      team: "Engineering",
+    });
+
+    expect(resolveCycleIdMock).toHaveBeenCalledWith(
+      sdk,
+      "Sprint 2",
+      "Engineering",
+    );
+    expect(result).toEqual({ cycleId: "cycle-uuid" });
+  });
+});


### PR DESCRIPTION
## Summary
- add `BatchResolveForSearch` query and expand create/update batch queries with fields needed for typed resolution
- add `issue-batch-resolve-service` with one-request resolution paths for create, update, and search filters (UUID passthrough + flag-specific errors)
- wire `issues create/update` and `resolveFilterOptions` to batch service; update unit tests to assert one batch call per path

Closes #63 

## Test Plan
- [x] npx vitest run tests/unit/services/issue-batch-resolve-service.test.ts -v
- [x] npx vitest run tests/unit/common/resolve-filters.test.ts tests/unit/commands/issues.test.ts -v
- [x] npm run check:ci
- [x] npx tsc --noEmit
- [x] npm test
- [x] npm run build
