### PR TITLE
test(issue-service): capture completed-filter conflict in issues list

### DIFF
--- a/src/services/issue-service.ts
+++ b/src/services/issue-service.ts
@@ -57,7 +57,23 @@ const NON_COMPLETED_ISSUES_FILTER: IssueFilter = {
   state: { type: { neq: "completed" } },
 };
 
+function hasExplicitStateFilter(filter: IssueFilter): boolean {
+  if (filter.state) {
+    return true;
+  }
+
+  if (filter.and?.some(hasExplicitStateFilter)) {
+    return true;
+  }
+
+  return filter.or?.some(hasExplicitStateFilter) ?? false;
+}
+
 function buildListIssuesFilter(filter: IssueFilter): IssueFilter {
+  if (hasExplicitStateFilter(filter)) {
+    return filter;
+  }
+
   return {
     and: [NON_COMPLETED_ISSUES_FILTER, filter],
   };

--- a/tests/unit/services/issue-service.test.ts
+++ b/tests/unit/services/issue-service.test.ts
@@ -197,6 +197,30 @@ describe("listIssues", () => {
     });
   });
 
+  it("does not prepend the non-completed filter when an explicit state filter is provided", async () => {
+    const client = mockGqlClient({
+      issues: {
+        nodes: [{ id: "1", title: "Done issue" }],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+    const filter = {
+      and: [
+        { team: { id: { eq: "team-uuid" } } },
+        { state: { id: { in: ["done-status-id"] } } },
+      ],
+    };
+
+    await listIssues(client, { limit: 10 }, filter);
+
+    expect(client.request).toHaveBeenCalledWith(FilteredSearchIssuesDocument, {
+      first: 10,
+      after: undefined,
+      filter,
+      orderBy: PaginationOrderBy.UpdatedAt,
+    });
+  });
+
   it("uses GetIssues query when no filter provided (no regression)", async () => {
     const client = mockGqlClient({
       issues: {


### PR DESCRIPTION
## What does this PR do?
- capture completed-filter conflict in issues list
- honor explicit completion filters in issues list
- remove unsupported IssueFilter.not check

## Type of change
- fix
- tests

## Checklist
- [x] npm test
- [x] New or updated tests cover main path and key edge case

## Testing
- npm test

## Related issues
- Closes #179