### PR TITLE
feat(labels): add issue label scope filters

### DIFF
--- a/src/commands/labels.ts
+++ b/src/commands/labels.ts
@@ -5,6 +5,7 @@ import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import { resolveTeamId } from "../resolvers/team-resolver.js";
 import {
+  type LabelScope,
   type LabelType,
   listLabels,
   listProjectLabels,
@@ -13,6 +14,7 @@ import {
 interface ListLabelsOptions extends CommandOptions {
   team?: string;
   type?: string;
+  scope?: string;
   limit: string;
   after?: string;
 }
@@ -23,6 +25,17 @@ function parseLabelType(value?: string): LabelType {
   }
 
   throw invalidParameterError("--type", 'must be one of "issue" or "project"');
+}
+
+function parseLabelScope(value?: string): LabelScope | undefined {
+  if (value === undefined || value === "workspace" || value === "team") {
+    return value;
+  }
+
+  throw invalidParameterError(
+    "--scope",
+    'must be one of "workspace" or "team"',
+  );
 }
 
 export const LABELS_META: DomainMeta = {
@@ -51,6 +64,7 @@ export function setupLabelsCommands(program: Command): void {
     .command("list")
     .description("list available labels")
     .option("--type <type>", "label type: issue (default) or project", "issue")
+    .option("--scope <scope>", "issue label scope: workspace or team")
     .option("--team <team>", "filter by team (key, name, or UUID)")
     .option("-l, --limit <n>", "max results", "50")
     .option("--after <cursor>", "cursor for next page")
@@ -59,9 +73,11 @@ export function setupLabelsCommands(program: Command): void {
         const [options, command] = args as [ListLabelsOptions, Command];
         const ctx = createContext(command.parent!.parent!.opts());
         const type = parseLabelType(options.type);
+        const scope = parseLabelScope(options.scope);
         const pagination = {
           limit: parseLimit(options.limit),
           after: options.after,
+          scope,
         };
 
         if (type === "project") {
@@ -72,8 +88,26 @@ export function setupLabelsCommands(program: Command): void {
             );
           }
 
+          if (scope) {
+            throw invalidParameterError(
+              "--scope",
+              "cannot be used with --type project because project labels are always workspace-scoped",
+            );
+          }
+
           outputSuccess(await listProjectLabels(ctx.gql, pagination));
           return;
+        }
+
+        if (scope === "team" && !options.team) {
+          throw invalidParameterError("--scope", "team scope requires --team");
+        }
+
+        if (scope === "workspace" && options.team) {
+          throw invalidParameterError(
+            "--team",
+            "cannot be used with --scope workspace",
+          );
         }
 
         const teamId = options.team

--- a/src/services/label-service.ts
+++ b/src/services/label-service.ts
@@ -5,9 +5,11 @@ import {
   type GetLabelsQuery,
   GetProjectLabelsDocument,
   type GetProjectLabelsQuery,
+  type IssueLabelFilter,
 } from "../gql/graphql.js";
 
 export type LabelType = "issue" | "project";
+export type LabelScope = "workspace" | "team";
 
 export interface Label {
   id: string;
@@ -17,13 +19,36 @@ export interface Label {
   type: LabelType;
 }
 
+export interface ListLabelOptions extends PaginationOptions {
+  scope?: LabelScope;
+}
+
+function buildIssueLabelFilter(
+  teamId?: string,
+  scope?: LabelScope,
+): IssueLabelFilter | undefined {
+  if (scope === "workspace") {
+    return { team: { null: true } };
+  }
+
+  if (scope === "team" && teamId) {
+    return { team: { id: { eq: teamId }, null: false } };
+  }
+
+  if (teamId) {
+    return { team: { id: { eq: teamId } } };
+  }
+
+  return undefined;
+}
+
 export async function listLabels(
   client: GraphQLClient,
   teamId?: string,
-  options: PaginationOptions = {},
+  options: ListLabelOptions = {},
 ): Promise<PaginatedResult<Label>> {
-  const { limit = 50, after } = options;
-  const filter = teamId ? { team: { id: { eq: teamId } } } : undefined;
+  const { limit = 50, after, scope } = options;
+  const filter = buildIssueLabelFilter(teamId, scope);
 
   const result = await client.request<GetLabelsQuery>(GetLabelsDocument, {
     first: limit,

--- a/tests/unit/commands/labels.test.ts
+++ b/tests/unit/commands/labels.test.ts
@@ -71,6 +71,7 @@ describe("labels list", () => {
     expect(listLabels).toHaveBeenCalledWith(expect.anything(), undefined, {
       limit: 50,
       after: undefined,
+      scope: undefined,
     });
     expect(listProjectLabels).not.toHaveBeenCalled();
     expect(resolveTeamId).not.toHaveBeenCalled();
@@ -103,6 +104,55 @@ describe("labels list", () => {
       {
         limit: 10,
         after: "cur1",
+        scope: undefined,
+      },
+    );
+    expect(listProjectLabels).not.toHaveBeenCalled();
+  });
+
+  it("passes workspace scope without team resolution", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "list",
+      "--scope",
+      "workspace",
+    ]);
+
+    expect(listLabels).toHaveBeenCalledWith(expect.anything(), undefined, {
+      limit: 50,
+      after: undefined,
+      scope: "workspace",
+    });
+    expect(resolveTeamId).not.toHaveBeenCalled();
+    expect(listProjectLabels).not.toHaveBeenCalled();
+  });
+
+  it("resolves team for explicit team scope", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "list",
+      "--scope",
+      "team",
+      "--team",
+      "ENG",
+    ]);
+
+    expect(resolveTeamId).toHaveBeenCalledWith(expect.anything(), "ENG");
+    expect(listLabels).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-team-uuid",
+      {
+        limit: 50,
+        after: undefined,
+        scope: "team",
       },
     );
     expect(listProjectLabels).not.toHaveBeenCalled();
@@ -123,6 +173,7 @@ describe("labels list", () => {
     expect(listLabels).toHaveBeenCalledWith(expect.anything(), undefined, {
       limit: 50,
       after: undefined,
+      scope: undefined,
     });
     expect(listProjectLabels).not.toHaveBeenCalled();
     expect(resolveTeamId).not.toHaveBeenCalled();
@@ -189,6 +240,80 @@ describe("labels list validation", () => {
     expect(resolveTeamId).not.toHaveBeenCalled();
   });
 
+  it("rejects unsupported scope values", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "list",
+      "--scope",
+      "org",
+    ]);
+
+    const errorOutput = JSON.parse(
+      vi.mocked(console.error).mock.calls[0][0] as string,
+    ) as { error: string };
+
+    expect(errorOutput.error).toBe(
+      'Invalid --scope: must be one of "workspace" or "team"',
+    );
+    expect(listLabels).not.toHaveBeenCalled();
+    expect(listProjectLabels).not.toHaveBeenCalled();
+    expect(resolveTeamId).not.toHaveBeenCalled();
+  });
+
+  it("rejects team scope without a team filter", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "list",
+      "--scope",
+      "team",
+    ]);
+
+    const errorOutput = JSON.parse(
+      vi.mocked(console.error).mock.calls[0][0] as string,
+    ) as { error: string };
+
+    expect(errorOutput.error).toBe(
+      "Invalid --scope: team scope requires --team",
+    );
+    expect(listLabels).not.toHaveBeenCalled();
+    expect(listProjectLabels).not.toHaveBeenCalled();
+    expect(resolveTeamId).not.toHaveBeenCalled();
+  });
+
+  it("rejects team filters for workspace scope", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "list",
+      "--scope",
+      "workspace",
+      "--team",
+      "ENG",
+    ]);
+
+    const errorOutput = JSON.parse(
+      vi.mocked(console.error).mock.calls[0][0] as string,
+    ) as { error: string };
+
+    expect(errorOutput.error).toBe(
+      "Invalid --team: cannot be used with --scope workspace",
+    );
+    expect(listLabels).not.toHaveBeenCalled();
+    expect(listProjectLabels).not.toHaveBeenCalled();
+    expect(resolveTeamId).not.toHaveBeenCalled();
+  });
+
   it("rejects team filters for project labels", async () => {
     const program = createProgram();
 
@@ -209,6 +334,32 @@ describe("labels list validation", () => {
 
     expect(errorOutput.error).toBe(
       "Invalid --team: cannot be used with --type project because project labels are workspace-scoped",
+    );
+    expect(listLabels).not.toHaveBeenCalled();
+    expect(listProjectLabels).not.toHaveBeenCalled();
+    expect(resolveTeamId).not.toHaveBeenCalled();
+  });
+
+  it("rejects scope filters for project labels", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "list",
+      "--type",
+      "project",
+      "--scope",
+      "workspace",
+    ]);
+
+    const errorOutput = JSON.parse(
+      vi.mocked(console.error).mock.calls[0][0] as string,
+    ) as { error: string };
+
+    expect(errorOutput.error).toBe(
+      "Invalid --scope: cannot be used with --type project because project labels are always workspace-scoped",
     );
     expect(listLabels).not.toHaveBeenCalled();
     expect(listProjectLabels).not.toHaveBeenCalled();

--- a/tests/unit/services/label-service.test.ts
+++ b/tests/unit/services/label-service.test.ts
@@ -101,6 +101,40 @@ describe("listLabels", () => {
     });
   });
 
+  it("filters workspace issue labels by null team", async () => {
+    const client = mockGqlClient({
+      issueLabels: {
+        nodes: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+
+    await listLabels(client, undefined, { scope: "workspace" });
+
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      first: 50,
+      after: undefined,
+      filter: { team: { null: true } },
+    });
+  });
+
+  it("keeps team scope on the resolved team filter", async () => {
+    const client = mockGqlClient({
+      issueLabels: {
+        nodes: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+
+    await listLabels(client, "team-1", { scope: "team" });
+
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      first: 50,
+      after: undefined,
+      filter: { team: { id: { eq: "team-1" }, null: false } },
+    });
+  });
+
   it("converts null description to undefined", async () => {
     const client = mockGqlClient({
       issueLabels: {


### PR DESCRIPTION
## Summary
- add `--scope workspace|team` to `labels list` for issue labels
- keep the existing default behavior when `--scope` is omitted
- validate `--scope team` requires `--team`, and reject `--scope` with project labels
- add command and service regression coverage for the new scope behavior

Closes #116

## Verification
- npm run check:ci
- npx tsc --noEmit
- npx tsc
- node dist/main.js usage --all
