### PR TITLE
feat: implement domain-centric discussion interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,7 @@ CLI tool for [Linear.app](https://linear.app) optimized for AI agents. JSON outp
 
 The official Linear MCP works fine, but it eats up ~13k tokens just by being connected -- before the agent does anything. Linearis takes a different approach: instead of exposing the full API surface upfront, agents discover what they need through a two-tier usage system. `linearis usage` gives an overview in ~200 tokens, then `linearis <domain> usage` provides the full reference for one area in ~300-500 tokens. A typical agent interaction costs ~500-700 tokens of context, not ~13k.
 
-The trade-off is coverage. An MCP exposes the entire Linear API; Linearis covers the operations that matter for day-to-day work with issues, comments, cycles, documents, and files. If you need to manage custom workflows, integrations, or workspace settings, the MCP is the better choice.
-
-**This project scratches my own itches,** and satisfies my own usage patterns of working with Linear: I **do** work with tickets/issues and comments on the command line; I **do not** manage projects or workspaces etc. there. YMMV.
+The trade-off is coverage. An MCP exposes the entire Linear API; Linearis covers the operations that matter for day-to-day work with issues, discussions, cycles, documents, and files. If you need to manage custom workflows, integrations, or workspace settings, the MCP is the better choice.
 
 ## Installation
 
@@ -68,8 +66,17 @@ linearis issues search "authentication bug"
 # Create an issue
 linearis issues create "Fix login flow" --team Platform --priority 2
 
-# Add a comment
-linearis comments create ENG-42 --body "Investigating this now"
+# Start a discussion thread on an issue
+linearis issues discuss ENG-42 --body "Investigating this now"
+
+# List root discussion threads for an issue
+linearis issues discussions ENG-42
+
+# List replies in one root thread
+linearis issues replies 6f4f28cd-4f53-4d76-ae95-80f1b6f6b87e
+
+# Reply to a thread (use a root discussion thread ID)
+linearis issues reply 6f4f28cd-4f53-4d76-ae95-80f1b6f6b87e --body "I found the root cause"
 ```
 
 For the full reference of every command and flag, run:
@@ -77,6 +84,24 @@ For the full reference of every command and flag, run:
 ```bash
 linearis <domain> usage
 ```
+
+### Migration: `comments` → issue discussion commands
+
+The `comments` domain remains available as a **deprecated compatibility facade**. For new automation and agent prompts, migrate to issue discussion commands in the `issues` domain:
+
+| Deprecated | Preferred |
+|---|---|
+| `linearis comments create <issue> --body <text>` | `linearis issues discuss <issue> --body <text>` |
+| `linearis comments list <issue>` | `linearis issues discussions <issue>` |
+| `linearis comments reply <thread> --body <text>` | `linearis issues reply <thread> --body <text>` |
+| `linearis comments edit <reply> --body <text>` | `linearis issues edit-reply <reply> --body <text>` |
+| `linearis comments delete <reply>` | `linearis issues delete-reply <reply>` |
+
+Notes:
+- `issues discussions <issue>` lists **root** threads.
+- Use `issues replies <thread>` to fetch replies in one thread, including nested replies.
+- Replying requires a **root discussion thread ID** (not a reply ID).
+- Compatibility `comments edit/delete` accepts root thread IDs and reply IDs.
 
 ## AI Agent Integration
 
@@ -95,7 +120,7 @@ This means the agent never loads the full API surface into context. It pays for 
 | | Linearis | Linear MCP |
 |---|---|---|
 | Context cost | ~500-700 tokens per interaction | ~13k tokens on connect |
-| Coverage | Common operations (issues, comments, cycles, docs, files) | Full Linear API |
+| Coverage | Common operations (issues, discussions, cycles, docs, files) | Full Linear API |
 | Output | JSON via stdout | Tool call responses |
 | Setup | `npm install -g linearis` + bash tool | MCP server connection |
 
@@ -116,9 +141,9 @@ Workflow rules:
 - When creating a ticket, ask the user which project to assign it to if unclear.
 - For subtasks, inherit the parent ticket's project by default.
 - When a task in a ticket description changes status, update the description.
-- For progress beyond simple checkbox changes, add a comment instead of editing the description.
+- For progress beyond simple checkbox changes, start or reply in a discussion thread instead of editing the description.
 
-File handling: `issues read` returns an `embeds` array with signed download URLs and expiration timestamps. Use `files download` to retrieve them. Use `files upload` to attach new files, then reference the returned URL in comments or descriptions.
+File handling: `issues read` returns an `embeds` array with signed download URLs and expiration timestamps. Use `files download` to retrieve them. Use `files upload` to attach new files, then reference the returned URL in discussions or descriptions.
 ```
 
 Add this (or a version adapted to your workflow) to your `AGENTS.md` or `CLAUDE.md` so every agent session has it in context automatically.

--- a/graphql/mutations/discussions.graphql
+++ b/graphql/mutations/discussions.graphql
@@ -1,0 +1,62 @@
+fragment DiscussionMutationCommentFields on Comment {
+  id
+  body
+  createdAt
+  editedAt
+  parentId
+  resolvedAt
+  resolvingComment {
+    id
+  }
+  resolvingUser {
+    id
+    displayName
+  }
+  user {
+    id
+    displayName
+  }
+}
+
+mutation StartDiscussion($input: CommentCreateInput!) {
+  commentCreate(input: $input) {
+    success
+    comment {
+      ...DiscussionMutationCommentFields
+    }
+  }
+}
+
+mutation EditDiscussionReply($id: String!, $input: CommentUpdateInput!) {
+  commentUpdate(id: $id, input: $input) {
+    success
+    comment {
+      ...DiscussionMutationCommentFields
+    }
+  }
+}
+
+mutation DeleteDiscussionReply($id: String!) {
+  commentDelete(id: $id) {
+    success
+    entityId
+  }
+}
+
+mutation ResolveDiscussion($id: String!, $resolvingCommentId: String) {
+  commentResolve(id: $id, resolvingCommentId: $resolvingCommentId) {
+    success
+    comment {
+      ...DiscussionMutationCommentFields
+    }
+  }
+}
+
+mutation UnresolveDiscussion($id: String!) {
+  commentUnresolve(id: $id) {
+    success
+    comment {
+      ...DiscussionMutationCommentFields
+    }
+  }
+}

--- a/graphql/queries/discussions.graphql
+++ b/graphql/queries/discussions.graphql
@@ -1,0 +1,159 @@
+fragment DiscussionCommentFields on Comment {
+  id
+  body
+  createdAt
+  editedAt
+  parentId
+  resolvedAt
+  resolvingComment {
+    id
+  }
+  resolvingUser {
+    id
+    displayName
+  }
+  user {
+    id
+    displayName
+  }
+}
+
+query GetDiscussionCommentContext($id: String!) {
+  comment(id: $id) {
+    ...DiscussionCommentFields
+    issueId
+    projectId
+    initiativeId
+  }
+}
+
+query ListIssueDiscussionRoots($issueId: String!, $first: Int, $after: String) {
+  issue(id: $issueId) {
+    comments(first: $first, after: $after, filter: { parent: { null: true } }) {
+      nodes {
+        ...DiscussionCommentFields
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}
+
+query ListProjectDiscussionRoots(
+  $projectId: String!
+  $first: Int
+  $after: String
+) {
+  project(id: $projectId) {
+    comments(first: $first, after: $after, filter: { parent: { null: true } }) {
+      nodes {
+        ...DiscussionCommentFields
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}
+
+query ListInitiativeDiscussionRoots(
+  $initiativeId: ID!
+  $initiativeLookupId: String!
+  $first: Int
+  $after: String
+) {
+  initiative: initiative(id: $initiativeLookupId) {
+    id
+  }
+  comments(
+    first: $first
+    after: $after
+    filter: {
+      initiative: { id: { eq: $initiativeId } }
+      parent: { null: true }
+    }
+  ) {
+    nodes {
+      ...DiscussionCommentFields
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+
+query ListIssueDiscussionReplyCandidates(
+  $issueId: ID!
+  $first: Int
+  $after: String
+) {
+  comments(
+    first: $first
+    after: $after
+    orderBy: createdAt
+    filter: { issue: { id: { eq: $issueId } }, parent: { null: false } }
+  ) {
+    nodes {
+      ...DiscussionCommentFields
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+
+query ListProjectDiscussionReplyCandidates(
+  $projectId: ID!
+  $first: Int
+  $after: String
+) {
+  comments(
+    first: $first
+    after: $after
+    orderBy: createdAt
+    filter: { project: { id: { eq: $projectId } }, parent: { null: false } }
+  ) {
+    nodes {
+      ...DiscussionCommentFields
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+
+query ListInitiativeDiscussionReplyCandidates(
+  $initiativeId: ID!
+  $first: Int
+  $after: String
+) {
+  comments(
+    first: $first
+    after: $after
+    orderBy: createdAt
+    filter: {
+      initiative: { id: { eq: $initiativeId } }
+      parent: { null: false }
+    }
+  ) {
+    nodes {
+      ...DiscussionCommentFields
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+
+query GetDiscussionComment($id: String!) {
+  comment(id: $id) {
+    ...DiscussionCommentFields
+  }
+}

--- a/src/commands/comments.ts
+++ b/src/commands/comments.ts
@@ -1,15 +1,16 @@
 import type { Command } from "commander";
 import { type CommandOptions, createContext } from "../common/context.js";
+import { invalidParameterError } from "../common/errors.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import { resolveIssueId } from "../resolvers/issue-resolver.js";
 import {
-  createComment,
-  deleteComment,
-  listComments,
-  replyToComment,
-  updateComment,
-} from "../services/comment-service.js";
+  deleteDiscussionComment,
+  editDiscussionComment,
+  listDiscussionsForIssue,
+  replyToDiscussion,
+  startIssueDiscussion,
+} from "../services/discussion-service.js";
 
 interface CreateCommentOptions extends CommandOptions {
   body?: string;
@@ -30,26 +31,43 @@ interface EditCommentOptions extends CommandOptions {
 
 export const COMMENTS_META: DomainMeta = {
   name: "comments",
-  summary: "discussion threads on issues (list, create, reply, edit, delete)",
+  summary:
+    "deprecated compatibility facade for issue discussions with root-thread-only reply support",
   context:
-    "a comment is a text entry on an issue. comments support markdown and threaded replies via parentId.",
+    "the comments domain remains operational as an intentionally narrowed compatibility layer. compatibility mode supports replying by root thread ID only, nested-reply targets are not supported in compatibility mode, and edit/delete accept either root thread IDs or reply IDs for backward compatibility. new workflows should migrate to domain-centric issues discussion commands (issues discuss/discussions/replies/reply/edit-reply/delete-reply).",
   arguments: {
     issue: "issue identifier (UUID or ABC-123)",
-    comment: "comment identifier (UUID only)",
+    comment: "thread/reply identifier (UUID only)",
   },
-  seeAlso: ["issues read <issue>"],
+  seeAlso: [
+    "issues discuss <issue>",
+    "issues discussions <issue>",
+    "issues replies <thread>",
+    "issues reply <thread>",
+    "issues edit-reply <reply>",
+    "issues delete-reply <reply>",
+  ],
 };
 
 export function setupCommentsCommands(program: Command): void {
   const comments = program
     .command("comments")
-    .description("Comment operations");
+    .description(
+      "Deprecated compatibility facade for issue discussions. Prefer the `issues` discussion commands.",
+    )
+    .addHelpText(
+      "after",
+      "\nDEPRECATED: kept for compatibility. Prefer `issues discuss`, `issues discussions`, `issues replies`, `issues reply`, `issues edit-reply`, and `issues delete-reply`.\nCompatibility mode only supports replying by root thread ID (nested-reply targets are not supported).\nCompatibility edit/delete accept root thread IDs and reply IDs.",
+    );
 
   comments.action(() => comments.help());
 
   comments
     .command("list <issue>")
-    .description("list comments on an issue")
+    .description(
+      "deprecated compatibility: list root issue discussions (migrate to `issues discussions <issue>`)",
+    )
+    .addHelpText("after", "\nPrefer: `issues discussions <issue>`")
     .addHelpText(
       "after",
       `\nWhen passing issue IDs, both UUID and identifiers like ABC-123 are supported.`,
@@ -67,7 +85,7 @@ export function setupCommentsCommands(program: Command): void {
 
         const limit = parseLimit(options.limit || "25");
         const resolvedIssueId = await resolveIssueId(ctx.sdk, issue);
-        const result = await listComments(ctx.gql, resolvedIssueId, {
+        const result = await listDiscussionsForIssue(ctx.gql, resolvedIssueId, {
           limit,
           after: options.after,
         });
@@ -78,7 +96,10 @@ export function setupCommentsCommands(program: Command): void {
 
   comments
     .command("create <issue>")
-    .description("create a comment on an issue")
+    .description(
+      "deprecated compatibility: start an issue discussion (migrate to `issues discuss <issue> --body <text>`)",
+    )
+    .addHelpText("after", "\nPrefer: `issues discuss <issue> --body <text>`")
     .addHelpText(
       "after",
       `\nWhen passing issue IDs, both UUID and identifiers like ABC-123 are supported.`,
@@ -94,11 +115,11 @@ export function setupCommentsCommands(program: Command): void {
         const ctx = createContext(command.parent!.parent!.opts());
 
         if (!options.body) {
-          throw new Error("--body is required");
+          throw invalidParameterError("--body", "is required");
         }
 
         const resolvedIssueId = await resolveIssueId(ctx.sdk, issue);
-        const result = await createComment(ctx.gql, {
+        const result = await startIssueDiscussion(ctx.gql, {
           issueId: resolvedIssueId,
           body: options.body,
         });
@@ -108,12 +129,23 @@ export function setupCommentsCommands(program: Command): void {
     );
 
   comments
-    .command("reply <comment>")
-    .description("reply to a comment")
+    .command("reply <thread>")
+    .description(
+      "deprecated compatibility: reply to a root discussion thread (requires root thread ID; nested-reply targets are not supported in compatibility mode; migrate to `issues reply <thread> --body <text>`)",
+    )
+    .addHelpText("after", "\nPrefer: `issues reply <thread> --body <text>`")
+    .addHelpText(
+      "after",
+      "\nImportant: `<thread>` must be the root discussion thread ID, not a reply ID.",
+    )
+    .addHelpText(
+      "after",
+      "\nNested-reply targets are not supported in compatibility mode.",
+    )
     .option("--body <text>", "reply body (required, markdown supported)")
     .action(
       handleCommand(async (...args: unknown[]) => {
-        const [comment, options, command] = args as [
+        const [thread, options, command] = args as [
           string,
           ReplyCommentOptions,
           Command,
@@ -121,11 +153,11 @@ export function setupCommentsCommands(program: Command): void {
         const ctx = createContext(command.parent!.parent!.opts());
 
         if (!options.body) {
-          throw new Error("--body is required");
+          throw invalidParameterError("--body", "is required");
         }
 
-        const result = await replyToComment(ctx.gql, {
-          parentId: comment,
+        const result = await replyToDiscussion(ctx.gql, {
+          threadId: thread,
           body: options.body,
         });
 
@@ -135,7 +167,10 @@ export function setupCommentsCommands(program: Command): void {
 
   comments
     .command("edit <comment>")
-    .description("edit a comment")
+    .description(
+      "deprecated compatibility: edit a discussion comment (accepts root thread ID or reply ID; migrate reply workflows to `issues edit-reply <reply> --body <text>`)",
+    )
+    .addHelpText("after", "\nPrefer: `issues edit-reply <reply> --body <text>`")
     .option("--body <text>", "new comment body (required, markdown supported)")
     .action(
       handleCommand(async (...args: unknown[]) => {
@@ -147,10 +182,10 @@ export function setupCommentsCommands(program: Command): void {
         const ctx = createContext(command.parent!.parent!.opts());
 
         if (!options.body) {
-          throw new Error("--body is required");
+          throw invalidParameterError("--body", "is required");
         }
 
-        const result = await updateComment(ctx.gql, comment, {
+        const result = await editDiscussionComment(ctx.gql, comment, {
           body: options.body,
         });
 
@@ -160,13 +195,16 @@ export function setupCommentsCommands(program: Command): void {
 
   comments
     .command("delete <comment>")
-    .description("delete a comment")
+    .description(
+      "deprecated compatibility: delete a discussion comment (accepts root thread ID or reply ID; migrate reply workflows to `issues delete-reply <reply>`)",
+    )
+    .addHelpText("after", "\nPrefer: `issues delete-reply <reply>`")
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [comment, , command] = args as [string, unknown, Command];
         const ctx = createContext(command.parent!.parent!.opts());
 
-        const result = await deleteComment(ctx.gql, comment);
+        const result = await deleteDiscussionComment(ctx.gql, comment);
 
         outputSuccess(result);
       }),

--- a/src/commands/initiatives/entity.ts
+++ b/src/commands/initiatives/entity.ts
@@ -21,6 +21,18 @@ import { resolveInitiativeId } from "../../resolvers/initiative-resolver.js";
 import { resolveTeamId } from "../../resolvers/team-resolver.js";
 import { resolveUserId } from "../../resolvers/user-resolver.js";
 import {
+  deleteDiscussionComment,
+  deleteDiscussionReply,
+  editDiscussionComment,
+  editDiscussionReply,
+  listDiscussionReplies,
+  listDiscussionsForInitiative,
+  replyToDiscussion,
+  resolveDiscussion,
+  startInitiativeDiscussion,
+  unresolveDiscussion,
+} from "../../services/discussion-service.js";
+import {
   archiveInitiative,
   createInitiative,
   deleteInitiative,
@@ -70,6 +82,19 @@ interface InitiativeListOptions extends InitiativeExpandOptions {
 }
 
 interface InitiativeReadOptions extends InitiativeExpandOptions {}
+
+interface DiscussionsOptions {
+  limit?: string;
+  after?: string;
+}
+
+interface DiscussionBodyOptions {
+  body?: string;
+}
+
+interface ResolveDiscussionOptions {
+  withComment?: string;
+}
 
 interface InitiativeCreateOptions {
   description?: string;
@@ -458,6 +483,253 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
         void getExpandFlags(options);
 
         const result = await getInitiative(ctx.gql, initiativeId);
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("discuss <initiative>")
+    .description("start a discussion thread on an initiative")
+    .option("--body <text>", "discussion body (required, markdown supported)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [initiative, options, command] = args as [
+          string,
+          DiscussionBodyOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+
+        if (!options.body) {
+          throw invalidParameterError("--body", "is required");
+        }
+
+        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+        const result = await startInitiativeDiscussion(ctx.gql, {
+          initiativeId,
+          body: options.body,
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("discussions <initiative>")
+    .description("list root discussion threads on an initiative")
+    .option("-l, --limit <n>", "max results", "25")
+    .option("--after <cursor>", "cursor for next page")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [initiative, options, command] = args as [
+          string,
+          DiscussionsOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+
+        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+        const result = await listDiscussionsForInitiative(
+          ctx.gql,
+          initiativeId,
+          {
+            limit: parseLimit(options.limit || "25"),
+            after: options.after,
+          },
+        );
+
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("replies <thread>")
+    .description("list replies in a root discussion thread")
+    .option("-l, --limit <n>", "max results", "50")
+    .option("--after <cursor>", "cursor for next page")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [thread, options, command] = args as [
+          string,
+          DiscussionsOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+
+        const result = await listDiscussionReplies(
+          ctx.gql,
+          thread,
+          {
+            limit: parseLimit(options.limit || "50"),
+            after: options.after,
+          },
+          "initiative",
+        );
+
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("reply <thread>")
+    .description("reply to a root discussion thread")
+    .addHelpText(
+      "after",
+      "\nImportant: `<thread>` must be a root discussion thread ID.",
+    )
+    .option("--body <text>", "reply body (required, markdown supported)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [thread, options, command] = args as [
+          string,
+          DiscussionBodyOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+
+        if (!options.body) {
+          throw invalidParameterError("--body", "is required");
+        }
+
+        const result = await replyToDiscussion(ctx.gql, {
+          threadId: thread,
+          body: options.body,
+          entityKind: "initiative",
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("edit <comment>")
+    .description("edit a root discussion or reply comment")
+    .option("--body <text>", "new comment body (required, markdown supported)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [comment, options, command] = args as [
+          string,
+          DiscussionBodyOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+
+        if (!options.body) {
+          throw invalidParameterError("--body", "is required");
+        }
+
+        const result = await editDiscussionComment(
+          ctx.gql,
+          comment,
+          {
+            body: options.body,
+          },
+          "initiative",
+        );
+
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("edit-reply <reply>")
+    .description("edit a discussion reply")
+    .option("--body <text>", "new reply body (required, markdown supported)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [reply, options, command] = args as [
+          string,
+          DiscussionBodyOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+
+        if (!options.body) {
+          throw invalidParameterError("--body", "is required");
+        }
+
+        const result = await editDiscussionReply(
+          ctx.gql,
+          reply,
+          {
+            body: options.body,
+          },
+          "initiative",
+        );
+
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("delete-comment <comment>")
+    .description("delete a root discussion or reply comment")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [comment, , command] = args as [string, unknown, Command];
+        const ctx = createContext(rootOptions(command));
+
+        const result = await deleteDiscussionComment(
+          ctx.gql,
+          comment,
+          "initiative",
+        );
+
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("delete-reply <reply>")
+    .description("delete a discussion reply")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [reply, , command] = args as [string, unknown, Command];
+        const ctx = createContext(rootOptions(command));
+
+        const result = await deleteDiscussionReply(
+          ctx.gql,
+          reply,
+          "initiative",
+        );
+
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("resolve <thread>")
+    .description("resolve a discussion thread")
+    .option("--with-comment <comment>", "comment to mark as resolving comment")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [thread, options, command] = args as [
+          string,
+          ResolveDiscussionOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+
+        const result = await resolveDiscussion(ctx.gql, {
+          threadId: thread,
+          resolvingCommentId: options.withComment,
+          entityKind: "initiative",
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  initiatives
+    .command("unresolve <thread>")
+    .description("unresolve a discussion thread")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [thread, , command] = args as [string, unknown, Command];
+        const ctx = createContext(rootOptions(command));
+
+        const result = await unresolveDiscussion(ctx.gql, thread, "initiative");
+
         outputSuccess(result);
       }),
     );

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import type { CommandContext } from "../common/context.js";
 import { createContext } from "../common/context.js";
+import { invalidParameterError } from "../common/errors.js";
 import { validateEstimateAgainstTeamConfig } from "../common/estimate-validation.js";
 import {
   isUuid,
@@ -34,6 +35,18 @@ import {
   resolveTeamId,
 } from "../resolvers/team-resolver.js";
 import { resolveUserId } from "../resolvers/user-resolver.js";
+import {
+  deleteDiscussionComment,
+  deleteDiscussionReply,
+  editDiscussionComment,
+  editDiscussionReply,
+  listDiscussionReplies,
+  listDiscussionsForIssue,
+  replyToDiscussion,
+  resolveDiscussion,
+  startIssueDiscussion,
+  unresolveDiscussion,
+} from "../services/discussion-service.js";
 import { buildIssueFilter } from "../services/issue-filter.js";
 import {
   createIssueRelation,
@@ -114,6 +127,19 @@ interface ReadOptions {
   withAttachments?: boolean;
   withComments?: boolean;
   withCommentThreads?: boolean;
+}
+
+interface DiscussionsOptions {
+  limit?: string;
+  after?: string;
+}
+
+interface DiscussionBodyOptions {
+  body?: string;
+}
+
+interface ResolveDiscussionOptions {
+  withComment?: string;
 }
 
 export const ISSUES_META: DomainMeta = {
@@ -463,6 +489,249 @@ export function setupIssuesCommands(program: Command): void {
           );
           outputSuccess(result);
         }
+      }),
+    );
+
+  issues
+    .command("discuss <issue>")
+    .description("start a discussion thread on an issue")
+    .addHelpText(
+      "after",
+      `\nWhen passing issue IDs, both UUID and identifiers like ABC-123 are supported.`,
+    )
+    .option("--body <text>", "discussion body (required, markdown supported)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [issue, options, command] = args as [
+          string,
+          DiscussionBodyOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        if (!options.body) {
+          throw invalidParameterError("--body", "is required");
+        }
+
+        const issueId = await resolveIssueId(ctx.sdk, issue);
+        const result = await startIssueDiscussion(ctx.gql, {
+          issueId,
+          body: options.body,
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  issues
+    .command("discussions <issue>")
+    .description("list root discussion threads on an issue")
+    .addHelpText(
+      "after",
+      `\nWhen passing issue IDs, both UUID and identifiers like ABC-123 are supported.`,
+    )
+    .option("-l, --limit <n>", "max results", "25")
+    .option("--after <cursor>", "cursor for next page")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [issue, options, command] = args as [
+          string,
+          DiscussionsOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        const issueId = await resolveIssueId(ctx.sdk, issue);
+        const result = await listDiscussionsForIssue(ctx.gql, issueId, {
+          limit: parseLimit(options.limit || "25"),
+          after: options.after,
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  issues
+    .command("replies <thread>")
+    .description("list replies in a root discussion thread")
+    .option("-l, --limit <n>", "max results", "50")
+    .option("--after <cursor>", "cursor for next page")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [thread, options, command] = args as [
+          string,
+          DiscussionsOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        const result = await listDiscussionReplies(
+          ctx.gql,
+          thread,
+          {
+            limit: parseLimit(options.limit || "50"),
+            after: options.after,
+          },
+          "issue",
+        );
+
+        outputSuccess(result);
+      }),
+    );
+
+  issues
+    .command("reply <thread>")
+    .description("reply to a root discussion thread")
+    .addHelpText(
+      "after",
+      "\nImportant: `<thread>` must be a root discussion thread ID.",
+    )
+    .option("--body <text>", "reply body (required, markdown supported)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [thread, options, command] = args as [
+          string,
+          DiscussionBodyOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        if (!options.body) {
+          throw invalidParameterError("--body", "is required");
+        }
+
+        const result = await replyToDiscussion(ctx.gql, {
+          threadId: thread,
+          body: options.body,
+          entityKind: "issue",
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  issues
+    .command("edit <comment>")
+    .description("edit a root discussion or reply comment")
+    .option("--body <text>", "new comment body (required, markdown supported)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [comment, options, command] = args as [
+          string,
+          DiscussionBodyOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        if (!options.body) {
+          throw invalidParameterError("--body", "is required");
+        }
+
+        const result = await editDiscussionComment(
+          ctx.gql,
+          comment,
+          {
+            body: options.body,
+          },
+          "issue",
+        );
+
+        outputSuccess(result);
+      }),
+    );
+
+  issues
+    .command("edit-reply <reply>")
+    .description("edit a discussion reply")
+    .option("--body <text>", "new reply body (required, markdown supported)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [reply, options, command] = args as [
+          string,
+          DiscussionBodyOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        if (!options.body) {
+          throw invalidParameterError("--body", "is required");
+        }
+
+        const result = await editDiscussionReply(
+          ctx.gql,
+          reply,
+          {
+            body: options.body,
+          },
+          "issue",
+        );
+
+        outputSuccess(result);
+      }),
+    );
+
+  issues
+    .command("delete-comment <comment>")
+    .description("delete a root discussion or reply comment")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [comment, , command] = args as [string, unknown, Command];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        const result = await deleteDiscussionComment(ctx.gql, comment, "issue");
+
+        outputSuccess(result);
+      }),
+    );
+
+  issues
+    .command("delete-reply <reply>")
+    .description("delete a discussion reply")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [reply, , command] = args as [string, unknown, Command];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        const result = await deleteDiscussionReply(ctx.gql, reply, "issue");
+
+        outputSuccess(result);
+      }),
+    );
+
+  issues
+    .command("resolve <thread>")
+    .description("resolve a discussion thread")
+    .option("--with-comment <comment>", "comment to mark as resolving comment")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [thread, options, command] = args as [
+          string,
+          ResolveDiscussionOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        const result = await resolveDiscussion(ctx.gql, {
+          threadId: thread,
+          resolvingCommentId: options.withComment,
+          entityKind: "issue",
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  issues
+    .command("unresolve <thread>")
+    .description("unresolve a discussion thread")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [thread, , command] = args as [string, unknown, Command];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        const result = await unresolveDiscussion(ctx.gql, thread, "issue");
+
+        outputSuccess(result);
       }),
     );
 

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -12,6 +12,18 @@ import { resolveProjectStatusId } from "../resolvers/project-status-resolver.js"
 import { resolveTeamId } from "../resolvers/team-resolver.js";
 import { resolveUserId } from "../resolvers/user-resolver.js";
 import {
+  deleteDiscussionComment,
+  deleteDiscussionReply,
+  editDiscussionComment,
+  editDiscussionReply,
+  listDiscussionReplies,
+  listDiscussionsForProject,
+  replyToDiscussion,
+  resolveDiscussion,
+  startProjectDiscussion,
+  unresolveDiscussion,
+} from "../services/discussion-service.js";
+import {
   archiveProject,
   createProject,
   deleteProject,
@@ -24,6 +36,19 @@ import {
 interface ListOptions {
   limit: string;
   after?: string;
+}
+
+interface DiscussionsOptions {
+  limit?: string;
+  after?: string;
+}
+
+interface DiscussionBodyOptions {
+  body?: string;
+}
+
+interface ResolveDiscussionOptions {
+  withComment?: string;
 }
 
 interface CreateOptions {
@@ -115,6 +140,245 @@ export function setupProjectsCommands(program: Command): void {
         const ctx = createContext(command.parent!.parent!.opts());
         const projectId = await resolveProjectId(ctx.sdk, project);
         const result = await getProject(ctx.gql, projectId);
+        outputSuccess(result);
+      }),
+    );
+
+  projects
+    .command("discuss <project>")
+    .description("start a discussion thread on a project")
+    .option("--body <text>", "discussion body (required, markdown supported)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [project, options, command] = args as [
+          string,
+          DiscussionBodyOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        if (!options.body) {
+          throw invalidParameterError("--body", "is required");
+        }
+
+        const projectId = await resolveProjectId(ctx.sdk, project);
+        const result = await startProjectDiscussion(ctx.gql, {
+          projectId,
+          body: options.body,
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  projects
+    .command("discussions <project>")
+    .description("list root discussion threads on a project")
+    .option("-l, --limit <n>", "max results", "25")
+    .option("--after <cursor>", "cursor for next page")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [project, options, command] = args as [
+          string,
+          DiscussionsOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        const projectId = await resolveProjectId(ctx.sdk, project);
+        const result = await listDiscussionsForProject(ctx.gql, projectId, {
+          limit: parseLimit(options.limit || "25"),
+          after: options.after,
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  projects
+    .command("replies <thread>")
+    .description("list replies in a root discussion thread")
+    .option("-l, --limit <n>", "max results", "50")
+    .option("--after <cursor>", "cursor for next page")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [thread, options, command] = args as [
+          string,
+          DiscussionsOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        const result = await listDiscussionReplies(
+          ctx.gql,
+          thread,
+          {
+            limit: parseLimit(options.limit || "50"),
+            after: options.after,
+          },
+          "project",
+        );
+
+        outputSuccess(result);
+      }),
+    );
+
+  projects
+    .command("reply <thread>")
+    .description("reply to a root discussion thread")
+    .addHelpText(
+      "after",
+      "\nImportant: `<thread>` must be a root discussion thread ID.",
+    )
+    .option("--body <text>", "reply body (required, markdown supported)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [thread, options, command] = args as [
+          string,
+          DiscussionBodyOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        if (!options.body) {
+          throw invalidParameterError("--body", "is required");
+        }
+
+        const result = await replyToDiscussion(ctx.gql, {
+          threadId: thread,
+          body: options.body,
+          entityKind: "project",
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  projects
+    .command("edit <comment>")
+    .description("edit a root discussion or reply comment")
+    .option("--body <text>", "new comment body (required, markdown supported)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [comment, options, command] = args as [
+          string,
+          DiscussionBodyOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        if (!options.body) {
+          throw invalidParameterError("--body", "is required");
+        }
+
+        const result = await editDiscussionComment(
+          ctx.gql,
+          comment,
+          {
+            body: options.body,
+          },
+          "project",
+        );
+
+        outputSuccess(result);
+      }),
+    );
+
+  projects
+    .command("edit-reply <reply>")
+    .description("edit a discussion reply")
+    .option("--body <text>", "new reply body (required, markdown supported)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [reply, options, command] = args as [
+          string,
+          DiscussionBodyOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        if (!options.body) {
+          throw invalidParameterError("--body", "is required");
+        }
+
+        const result = await editDiscussionReply(
+          ctx.gql,
+          reply,
+          {
+            body: options.body,
+          },
+          "project",
+        );
+
+        outputSuccess(result);
+      }),
+    );
+
+  projects
+    .command("delete-comment <comment>")
+    .description("delete a root discussion or reply comment")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [comment, , command] = args as [string, unknown, Command];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        const result = await deleteDiscussionComment(
+          ctx.gql,
+          comment,
+          "project",
+        );
+
+        outputSuccess(result);
+      }),
+    );
+
+  projects
+    .command("delete-reply <reply>")
+    .description("delete a discussion reply")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [reply, , command] = args as [string, unknown, Command];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        const result = await deleteDiscussionReply(ctx.gql, reply, "project");
+
+        outputSuccess(result);
+      }),
+    );
+
+  projects
+    .command("resolve <thread>")
+    .description("resolve a discussion thread")
+    .option("--with-comment <comment>", "comment to mark as resolving comment")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [thread, options, command] = args as [
+          string,
+          ResolveDiscussionOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        const result = await resolveDiscussion(ctx.gql, {
+          threadId: thread,
+          resolvingCommentId: options.withComment,
+          entityKind: "project",
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  projects
+    .command("unresolve <thread>")
+    .description("unresolve a discussion thread")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [thread, , command] = args as [string, unknown, Command];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        const result = await unresolveDiscussion(ctx.gql, thread, "project");
+
         outputSuccess(result);
       }),
     );

--- a/src/services/discussion-service.ts
+++ b/src/services/discussion-service.ts
@@ -1,0 +1,615 @@
+import type { GraphQLClient } from "../client/graphql-client.js";
+import type { PaginatedResult, PaginationOptions } from "../common/types.js";
+import {
+  type CommentCreateInput,
+  type CommentUpdateInput,
+  DeleteDiscussionReplyDocument,
+  type DeleteDiscussionReplyMutation,
+  type DiscussionCommentFieldsFragment,
+  EditDiscussionReplyDocument,
+  type EditDiscussionReplyMutation,
+  GetDiscussionCommentContextDocument,
+  type GetDiscussionCommentContextQuery,
+  ListInitiativeDiscussionReplyCandidatesDocument,
+  type ListInitiativeDiscussionReplyCandidatesQuery,
+  ListInitiativeDiscussionRootsDocument,
+  type ListInitiativeDiscussionRootsQuery,
+  ListIssueDiscussionReplyCandidatesDocument,
+  type ListIssueDiscussionReplyCandidatesQuery,
+  ListIssueDiscussionRootsDocument,
+  type ListIssueDiscussionRootsQuery,
+  ListProjectDiscussionReplyCandidatesDocument,
+  type ListProjectDiscussionReplyCandidatesQuery,
+  ListProjectDiscussionRootsDocument,
+  type ListProjectDiscussionRootsQuery,
+  ResolveDiscussionDocument,
+  type ResolveDiscussionMutation,
+  StartDiscussionDocument,
+  type StartDiscussionMutation,
+  UnresolveDiscussionDocument,
+  type UnresolveDiscussionMutation,
+} from "../gql/graphql.js";
+
+export type DiscussionThread = DiscussionCommentFieldsFragment;
+export type DiscussionEntityKind = "issue" | "project" | "initiative";
+
+const DEFAULT_ROOT_LIMIT = 25;
+const DEFAULT_REPLY_LIMIT = 50;
+const DISCUSSION_REPLY_FETCH_LIMIT = 250;
+
+type DiscussionThreadContext = NonNullable<
+  GetDiscussionCommentContextQuery["comment"]
+>;
+
+type DiscussionCommentContext = DiscussionThreadContext;
+
+type DiscussionReplyCandidateQuery =
+  | ListIssueDiscussionReplyCandidatesQuery
+  | ListProjectDiscussionReplyCandidatesQuery
+  | ListInitiativeDiscussionReplyCandidatesQuery;
+
+function getDiscussionEntityKind(
+  comment: Pick<
+    DiscussionCommentContext,
+    "issueId" | "projectId" | "initiativeId"
+  >,
+): DiscussionEntityKind {
+  if (comment.issueId) {
+    return "issue";
+  }
+
+  if (comment.projectId) {
+    return "project";
+  }
+
+  if (comment.initiativeId) {
+    return "initiative";
+  }
+
+  throw new Error("Discussion comment has no supported parent entity");
+}
+
+function assertExpectedDiscussionEntityKind(
+  comment: DiscussionCommentContext,
+  expectedEntityKind: DiscussionEntityKind | undefined,
+  label: "thread" | "reply" | "comment",
+): void {
+  if (!expectedEntityKind) {
+    return;
+  }
+
+  const actualEntityKind = getDiscussionEntityKind(comment);
+
+  if (actualEntityKind !== expectedEntityKind) {
+    throw new Error(
+      `Discussion ${label} ID "${comment.id}" belongs to ${actualEntityKind}, not ${expectedEntityKind}`,
+    );
+  }
+}
+
+async function assertDiscussionCommentExists(
+  client: GraphQLClient,
+  id: string,
+  expectedEntityKind?: DiscussionEntityKind,
+  label: "comment" | "reply" = "comment",
+): Promise<DiscussionCommentContext> {
+  const result = await client.request<GetDiscussionCommentContextQuery>(
+    GetDiscussionCommentContextDocument,
+    { id },
+  );
+
+  if (!result.comment) {
+    throw new Error(`Discussion comment ID "${id}" not found`);
+  }
+
+  assertExpectedDiscussionEntityKind(result.comment, expectedEntityKind, label);
+
+  return result.comment;
+}
+
+async function assertRootDiscussionThread(
+  client: GraphQLClient,
+  threadId: string,
+  expectedEntityKind?: DiscussionEntityKind,
+): Promise<DiscussionThreadContext> {
+  const result = await client.request<GetDiscussionCommentContextQuery>(
+    GetDiscussionCommentContextDocument,
+    { id: threadId },
+  );
+
+  if (!result.comment) {
+    throw new Error(`Discussion thread ID "${threadId}" not found`);
+  }
+
+  if (result.comment.parentId) {
+    throw new Error(
+      `Discussion thread ID "${threadId}" must reference a root comment`,
+    );
+  }
+
+  assertExpectedDiscussionEntityKind(
+    result.comment,
+    expectedEntityKind,
+    "thread",
+  );
+
+  return result.comment;
+}
+
+async function assertReplyComment(
+  client: GraphQLClient,
+  commentId: string,
+  expectedEntityKind?: DiscussionEntityKind,
+): Promise<DiscussionCommentContext> {
+  const comment = await assertDiscussionCommentExists(
+    client,
+    commentId,
+    expectedEntityKind,
+    "reply",
+  );
+
+  if (!comment.parentId) {
+    throw new Error(
+      `Discussion reply ID "${commentId}" must reference a reply comment`,
+    );
+  }
+
+  return comment;
+}
+
+function compareDiscussionCommentsChronologically(
+  a: Pick<DiscussionCommentFieldsFragment, "createdAt" | "editedAt" | "id">,
+  b: Pick<DiscussionCommentFieldsFragment, "createdAt" | "editedAt" | "id">,
+): number {
+  const createdAtComparison = a.createdAt.localeCompare(b.createdAt);
+
+  if (createdAtComparison !== 0) {
+    return createdAtComparison;
+  }
+
+  const editedAtComparison = (a.editedAt ?? "").localeCompare(b.editedAt ?? "");
+
+  if (editedAtComparison !== 0) {
+    return editedAtComparison;
+  }
+
+  return a.id.localeCompare(b.id);
+}
+
+function getDiscussionThreadEntity(
+  thread: DiscussionThreadContext,
+):
+  | { kind: "issue"; id: string }
+  | { kind: "project"; id: string }
+  | { kind: "initiative"; id: string } {
+  if (thread.issueId) {
+    return { kind: "issue", id: thread.issueId };
+  }
+
+  if (thread.projectId) {
+    return { kind: "project", id: thread.projectId };
+  }
+
+  if (thread.initiativeId) {
+    return { kind: "initiative", id: thread.initiativeId };
+  }
+
+  throw new Error(
+    `Discussion thread ID "${thread.id}" has no supported parent entity`,
+  );
+}
+
+async function listDiscussionReplyCandidates(
+  client: GraphQLClient,
+  thread: DiscussionThreadContext,
+): Promise<DiscussionCommentFieldsFragment[]> {
+  const entity = getDiscussionThreadEntity(thread);
+  const nodes: DiscussionCommentFieldsFragment[] = [];
+  let after: string | undefined;
+
+  while (true) {
+    let result: DiscussionReplyCandidateQuery;
+
+    if (entity.kind === "issue") {
+      result = await client.request<ListIssueDiscussionReplyCandidatesQuery>(
+        ListIssueDiscussionReplyCandidatesDocument,
+        {
+          issueId: entity.id,
+          first: DISCUSSION_REPLY_FETCH_LIMIT,
+          after,
+        },
+      );
+    } else if (entity.kind === "project") {
+      result = await client.request<ListProjectDiscussionReplyCandidatesQuery>(
+        ListProjectDiscussionReplyCandidatesDocument,
+        {
+          projectId: entity.id,
+          first: DISCUSSION_REPLY_FETCH_LIMIT,
+          after,
+        },
+      );
+    } else {
+      result =
+        await client.request<ListInitiativeDiscussionReplyCandidatesQuery>(
+          ListInitiativeDiscussionReplyCandidatesDocument,
+          {
+            initiativeId: entity.id,
+            first: DISCUSSION_REPLY_FETCH_LIMIT,
+            after,
+          },
+        );
+    }
+
+    nodes.push(...result.comments.nodes);
+
+    if (
+      !result.comments.pageInfo.hasNextPage ||
+      !result.comments.pageInfo.endCursor
+    ) {
+      break;
+    }
+
+    after = result.comments.pageInfo.endCursor;
+  }
+
+  return nodes.sort(compareDiscussionCommentsChronologically);
+}
+
+function filterThreadReplies(
+  comments: readonly DiscussionCommentFieldsFragment[],
+  threadId: string,
+): DiscussionCommentFieldsFragment[] {
+  const childrenByParentId = new Map<
+    string,
+    DiscussionCommentFieldsFragment[]
+  >();
+
+  for (const comment of comments) {
+    if (!comment.parentId) {
+      continue;
+    }
+
+    const siblings = childrenByParentId.get(comment.parentId) ?? [];
+    siblings.push(comment);
+    siblings.sort(compareDiscussionCommentsChronologically);
+    childrenByParentId.set(comment.parentId, siblings);
+  }
+
+  const replies: DiscussionCommentFieldsFragment[] = [];
+  const stack = [...(childrenByParentId.get(threadId) ?? [])].reverse();
+
+  while (stack.length > 0) {
+    const current = stack.pop();
+
+    if (!current) {
+      continue;
+    }
+
+    replies.push(current);
+
+    const children = childrenByParentId.get(current.id);
+
+    if (!children) {
+      continue;
+    }
+
+    for (let i = children.length - 1; i >= 0; i -= 1) {
+      stack.push(children[i]);
+    }
+  }
+
+  return replies;
+}
+
+function paginateDiscussionReplies(
+  replies: readonly DiscussionCommentFieldsFragment[],
+  limit: number,
+  after?: string,
+): PaginatedResult<DiscussionCommentFieldsFragment> {
+  const startIndex =
+    after === undefined
+      ? 0
+      : replies.findIndex((reply) => reply.id === after) + 1;
+
+  if (after !== undefined && startIndex === 0) {
+    throw new Error(`Discussion reply cursor "${after}" not found`);
+  }
+
+  const nodes = replies.slice(startIndex, startIndex + limit);
+
+  return {
+    nodes,
+    pageInfo: {
+      hasNextPage: startIndex + limit < replies.length,
+      endCursor: nodes.at(-1)?.id ?? null,
+    },
+  };
+}
+
+async function startDiscussion(
+  client: GraphQLClient,
+  input: CommentCreateInput,
+): Promise<StartDiscussionMutation["commentCreate"]["comment"]> {
+  const result = await client.request<StartDiscussionMutation>(
+    StartDiscussionDocument,
+    { input },
+  );
+
+  if (!result.commentCreate.success || !result.commentCreate.comment) {
+    throw new Error("Failed to start discussion");
+  }
+
+  return result.commentCreate.comment;
+}
+
+export async function listDiscussionsForIssue(
+  client: GraphQLClient,
+  issueId: string,
+  options: PaginationOptions = {},
+): Promise<PaginatedResult<DiscussionThread>> {
+  const { limit = DEFAULT_ROOT_LIMIT, after } = options;
+  const result = await client.request<ListIssueDiscussionRootsQuery>(
+    ListIssueDiscussionRootsDocument,
+    {
+      issueId,
+      first: limit,
+      after,
+    },
+  );
+
+  if (!result.issue) {
+    throw new Error(`Issue with ID "${issueId}" not found`);
+  }
+
+  return {
+    nodes: result.issue.comments.nodes,
+    pageInfo: result.issue.comments.pageInfo,
+  };
+}
+
+export async function listDiscussionsForProject(
+  client: GraphQLClient,
+  projectId: string,
+  options: PaginationOptions = {},
+): Promise<PaginatedResult<DiscussionThread>> {
+  const { limit = DEFAULT_ROOT_LIMIT, after } = options;
+  const result = await client.request<ListProjectDiscussionRootsQuery>(
+    ListProjectDiscussionRootsDocument,
+    {
+      projectId,
+      first: limit,
+      after,
+    },
+  );
+
+  if (!result.project) {
+    throw new Error(`Project with ID "${projectId}" not found`);
+  }
+
+  return {
+    nodes: result.project.comments.nodes,
+    pageInfo: result.project.comments.pageInfo,
+  };
+}
+
+export async function listDiscussionsForInitiative(
+  client: GraphQLClient,
+  initiativeId: string,
+  options: PaginationOptions = {},
+): Promise<PaginatedResult<DiscussionThread>> {
+  const { limit = DEFAULT_ROOT_LIMIT, after } = options;
+  const result = await client.request<ListInitiativeDiscussionRootsQuery>(
+    ListInitiativeDiscussionRootsDocument,
+    {
+      initiativeId,
+      initiativeLookupId: initiativeId,
+      first: limit,
+      after,
+    },
+  );
+
+  if (!result.initiative) {
+    throw new Error(`Initiative with ID "${initiativeId}" not found`);
+  }
+
+  return {
+    nodes: result.comments.nodes,
+    pageInfo: result.comments.pageInfo,
+  };
+}
+
+export async function listDiscussionReplies(
+  client: GraphQLClient,
+  threadId: string,
+  options: PaginationOptions = {},
+  expectedEntityKind?: DiscussionEntityKind,
+): Promise<PaginatedResult<DiscussionCommentFieldsFragment>> {
+  const thread = await assertRootDiscussionThread(
+    client,
+    threadId,
+    expectedEntityKind,
+  );
+  const candidates = await listDiscussionReplyCandidates(client, thread);
+  const replies = filterThreadReplies(candidates, threadId);
+  const { limit = DEFAULT_REPLY_LIMIT, after } = options;
+
+  return paginateDiscussionReplies(replies, limit, after);
+}
+
+export async function startIssueDiscussion(
+  client: GraphQLClient,
+  input: { issueId: string; body: string },
+): Promise<StartDiscussionMutation["commentCreate"]["comment"]> {
+  return startDiscussion(client, { issueId: input.issueId, body: input.body });
+}
+
+export async function startProjectDiscussion(
+  client: GraphQLClient,
+  input: { projectId: string; body: string },
+): Promise<StartDiscussionMutation["commentCreate"]["comment"]> {
+  return startDiscussion(client, {
+    projectId: input.projectId,
+    body: input.body,
+  });
+}
+
+export async function startInitiativeDiscussion(
+  client: GraphQLClient,
+  input: { initiativeId: string; body: string },
+): Promise<StartDiscussionMutation["commentCreate"]["comment"]> {
+  return startDiscussion(client, {
+    initiativeId: input.initiativeId,
+    body: input.body,
+  });
+}
+
+export async function replyToDiscussion(
+  client: GraphQLClient,
+  input: { threadId: string; body: string; entityKind?: DiscussionEntityKind },
+): Promise<StartDiscussionMutation["commentCreate"]["comment"]> {
+  await assertRootDiscussionThread(client, input.threadId, input.entityKind);
+
+  const result = await client.request<StartDiscussionMutation>(
+    StartDiscussionDocument,
+    {
+      input: {
+        parentId: input.threadId,
+        body: input.body,
+      },
+    },
+  );
+
+  if (!result.commentCreate.success || !result.commentCreate.comment) {
+    throw new Error("Failed to create discussion reply");
+  }
+
+  return result.commentCreate.comment;
+}
+
+export async function editDiscussionReply(
+  client: GraphQLClient,
+  id: string,
+  input: CommentUpdateInput,
+  expectedEntityKind?: DiscussionEntityKind,
+): Promise<EditDiscussionReplyMutation["commentUpdate"]["comment"]> {
+  await assertReplyComment(client, id, expectedEntityKind);
+
+  const result = await client.request<EditDiscussionReplyMutation>(
+    EditDiscussionReplyDocument,
+    { id, input },
+  );
+
+  if (!result.commentUpdate.success || !result.commentUpdate.comment) {
+    throw new Error("Failed to edit discussion reply");
+  }
+
+  return result.commentUpdate.comment;
+}
+
+export async function deleteDiscussionReply(
+  client: GraphQLClient,
+  id: string,
+  expectedEntityKind?: DiscussionEntityKind,
+): Promise<{ id: string; success: true }> {
+  await assertReplyComment(client, id, expectedEntityKind);
+
+  const result = await client.request<DeleteDiscussionReplyMutation>(
+    DeleteDiscussionReplyDocument,
+    { id },
+  );
+
+  if (!result.commentDelete.success) {
+    throw new Error("Failed to delete discussion reply");
+  }
+
+  return {
+    id: result.commentDelete.entityId,
+    success: true,
+  };
+}
+
+export async function editDiscussionComment(
+  client: GraphQLClient,
+  id: string,
+  input: CommentUpdateInput,
+  expectedEntityKind?: DiscussionEntityKind,
+): Promise<EditDiscussionReplyMutation["commentUpdate"]["comment"]> {
+  await assertDiscussionCommentExists(client, id, expectedEntityKind);
+
+  const result = await client.request<EditDiscussionReplyMutation>(
+    EditDiscussionReplyDocument,
+    { id, input },
+  );
+
+  if (!result.commentUpdate.success || !result.commentUpdate.comment) {
+    throw new Error("Failed to edit discussion comment");
+  }
+
+  return result.commentUpdate.comment;
+}
+
+export async function deleteDiscussionComment(
+  client: GraphQLClient,
+  id: string,
+  expectedEntityKind?: DiscussionEntityKind,
+): Promise<{ id: string; success: true }> {
+  await assertDiscussionCommentExists(client, id, expectedEntityKind);
+
+  const result = await client.request<DeleteDiscussionReplyMutation>(
+    DeleteDiscussionReplyDocument,
+    { id },
+  );
+
+  if (!result.commentDelete.success) {
+    throw new Error("Failed to delete discussion comment");
+  }
+
+  return {
+    id: result.commentDelete.entityId,
+    success: true,
+  };
+}
+
+export async function resolveDiscussion(
+  client: GraphQLClient,
+  input: {
+    threadId: string;
+    resolvingCommentId?: string;
+    entityKind?: DiscussionEntityKind;
+  },
+): Promise<ResolveDiscussionMutation["commentResolve"]["comment"]> {
+  await assertRootDiscussionThread(client, input.threadId, input.entityKind);
+
+  const result = await client.request<ResolveDiscussionMutation>(
+    ResolveDiscussionDocument,
+    {
+      id: input.threadId,
+      resolvingCommentId: input.resolvingCommentId,
+    },
+  );
+
+  if (!result.commentResolve.success || !result.commentResolve.comment) {
+    throw new Error("Failed to resolve discussion");
+  }
+
+  return result.commentResolve.comment;
+}
+
+export async function unresolveDiscussion(
+  client: GraphQLClient,
+  threadId: string,
+  expectedEntityKind?: DiscussionEntityKind,
+): Promise<UnresolveDiscussionMutation["commentUnresolve"]["comment"]> {
+  await assertRootDiscussionThread(client, threadId, expectedEntityKind);
+
+  const result = await client.request<UnresolveDiscussionMutation>(
+    UnresolveDiscussionDocument,
+    { id: threadId },
+  );
+
+  if (!result.commentUnresolve.success || !result.commentUnresolve.comment) {
+    throw new Error("Failed to unresolve discussion");
+  }
+
+  return result.commentUnresolve.comment;
+}

--- a/tests/unit/commands/comments.test.ts
+++ b/tests/unit/commands/comments.test.ts
@@ -1,0 +1,274 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/common/context.js", () => ({
+  createContext: vi.fn(() => ({
+    gql: { request: vi.fn() },
+    sdk: { sdk: {} },
+  })),
+}));
+
+vi.mock("../../../src/common/output.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../src/common/output.js")>();
+  return {
+    ...actual,
+    outputSuccess: vi.fn(),
+  };
+});
+
+vi.mock("../../../src/resolvers/issue-resolver.js", () => ({
+  resolveIssueId: vi.fn().mockResolvedValue("resolved-issue-uuid"),
+}));
+
+vi.mock("../../../src/services/discussion-service.js", () => ({
+  listDiscussionsForIssue: vi.fn().mockResolvedValue({
+    nodes: [],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+  }),
+  startIssueDiscussion: vi.fn().mockResolvedValue({ id: "discussion-root-1" }),
+  replyToDiscussion: vi.fn().mockResolvedValue({ id: "discussion-reply-1" }),
+  editDiscussionComment: vi
+    .fn()
+    .mockResolvedValue({ id: "discussion-comment-1" }),
+  deleteDiscussionComment: vi
+    .fn()
+    .mockResolvedValue({ id: "discussion-comment-1", success: true }),
+}));
+
+import { setupCommentsCommands } from "../../../src/commands/comments.js";
+import { resolveIssueId } from "../../../src/resolvers/issue-resolver.js";
+import {
+  deleteDiscussionComment,
+  editDiscussionComment,
+  listDiscussionsForIssue,
+  replyToDiscussion,
+  startIssueDiscussion,
+} from "../../../src/services/discussion-service.js";
+
+function createProgram(): Command {
+  const program = new Command();
+  program.option("--api-token <token>");
+  setupCommentsCommands(program);
+  return program;
+}
+
+describe("comments compatibility delegation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("comments help includes deprecation status and migration hints", () => {
+    const program = createProgram();
+    const comments = program.commands.find(
+      (command) => command.name() === "comments",
+    );
+
+    expect(comments).toBeDefined();
+
+    const commentsHelp = comments!.helpInformation();
+
+    expect(commentsHelp).toContain(
+      "Deprecated compatibility facade for issue discussions",
+    );
+    expect(commentsHelp).toMatch(/Prefer the `issues`\s+discussion commands/i);
+    expect(commentsHelp).toMatch(/migrate to `issues discussions\s+<issue>`/i);
+    expect(commentsHelp).toMatch(
+      /nested-reply\s+targets are not\s+supported in compatibility mode/i,
+    );
+  });
+
+  it("comments reply help clarifies root discussion thread ID semantics", () => {
+    const program = createProgram();
+    const comments = program.commands.find(
+      (command) => command.name() === "comments",
+    );
+
+    expect(comments).toBeDefined();
+
+    const reply = comments!.commands.find(
+      (command) => command.name() === "reply",
+    );
+
+    expect(reply).toBeDefined();
+
+    const replyHelp = reply!.helpInformation();
+
+    expect(replyHelp).toContain(
+      "deprecated compatibility: reply to a root discussion thread",
+    );
+    expect(replyHelp).toMatch(
+      /migrate\s+to `issues reply <thread> --body <text>`/,
+    );
+    expect(replyHelp).toMatch(/requires root\s+thread ID/);
+    expect(replyHelp).toMatch(
+      /Nested-reply targets are not\s+supported in compatibility mode/i,
+    );
+    expect(replyHelp).toContain("reply [options] <thread>");
+  });
+
+  it("comments list resolves issue and delegates to listDiscussionsForIssue", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "comments",
+      "list",
+      "ENG-42",
+      "--limit",
+      "10",
+      "--after",
+      "cursor-1",
+    ]);
+
+    expect(resolveIssueId).toHaveBeenCalledWith(expect.anything(), "ENG-42");
+    expect(listDiscussionsForIssue).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+      { limit: 10, after: "cursor-1" },
+    );
+  });
+
+  it("comments create resolves issue and delegates to startIssueDiscussion", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "comments",
+      "create",
+      "ENG-42",
+      "--body",
+      "Kickoff discussion",
+    ]);
+
+    expect(resolveIssueId).toHaveBeenCalledWith(expect.anything(), "ENG-42");
+    expect(startIssueDiscussion).toHaveBeenCalledWith(expect.anything(), {
+      issueId: "resolved-issue-uuid",
+      body: "Kickoff discussion",
+    });
+  });
+
+  it("comments create requires --body", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "test", "comments", "create", "ENG-42"]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid --body: is required"),
+    );
+    expect(startIssueDiscussion).not.toHaveBeenCalled();
+  });
+
+  it("comments reply delegates to replyToDiscussion", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "comments",
+      "reply",
+      "thread-1",
+      "--body",
+      "Reply body",
+    ]);
+
+    expect(replyToDiscussion).toHaveBeenCalledWith(expect.anything(), {
+      threadId: "thread-1",
+      body: "Reply body",
+    });
+  });
+
+  it("comments edit delegates to editDiscussionComment", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "comments",
+      "edit",
+      "reply-1",
+      "--body",
+      "Edited body",
+    ]);
+
+    expect(editDiscussionComment).toHaveBeenCalledWith(
+      expect.anything(),
+      "reply-1",
+      { body: "Edited body" },
+    );
+  });
+
+  it("comments reply requires --body", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "test", "comments", "reply", "thread-1"]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid --body: is required"),
+    );
+    expect(replyToDiscussion).not.toHaveBeenCalled();
+  });
+
+  it("comments edit requires --body", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "test", "comments", "edit", "reply-1"]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid --body: is required"),
+    );
+    expect(editDiscussionComment).not.toHaveBeenCalled();
+  });
+
+  it("comments edit accepts root thread IDs for compatibility", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "comments",
+      "edit",
+      "root-1",
+      "--body",
+      "Edited root",
+    ]);
+
+    expect(editDiscussionComment).toHaveBeenCalledWith(
+      expect.anything(),
+      "root-1",
+      { body: "Edited root" },
+    );
+  });
+
+  it("comments delete delegates to deleteDiscussionComment", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "test", "comments", "delete", "reply-1"]);
+
+    expect(deleteDiscussionComment).toHaveBeenCalledWith(
+      expect.anything(),
+      "reply-1",
+    );
+  });
+
+  it("comments delete accepts root thread IDs for compatibility", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "test", "comments", "delete", "root-1"]);
+
+    expect(deleteDiscussionComment).toHaveBeenCalledWith(
+      expect.anything(),
+      "root-1",
+    );
+  });
+});

--- a/tests/unit/commands/initiatives.test.ts
+++ b/tests/unit/commands/initiatives.test.ts
@@ -102,11 +102,60 @@ vi.mock("../../../src/services/initiative-update-service.js", () => ({
     .mockResolvedValue({ id: "resolved-update-uuid" }),
 }));
 
+vi.mock("../../../src/services/discussion-service.js", () => ({
+  startInitiativeDiscussion: vi
+    .fn()
+    .mockResolvedValue({ id: "discussion-root-1" }),
+  listDiscussionsForInitiative: vi.fn().mockResolvedValue({
+    nodes: [],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+  }),
+  listDiscussionReplies: vi.fn().mockResolvedValue({
+    nodes: [],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+  }),
+  replyToDiscussion: vi.fn().mockResolvedValue({ id: "discussion-reply-1" }),
+  editDiscussionReply: vi.fn().mockResolvedValue({ id: "discussion-reply-1" }),
+  deleteDiscussionReply: vi
+    .fn()
+    .mockResolvedValue({ id: "discussion-reply-1", success: true }),
+  editDiscussionComment: vi
+    .fn()
+    .mockResolvedValue({ id: "discussion-comment-1" }),
+  deleteDiscussionComment: vi
+    .fn()
+    .mockResolvedValue({ id: "discussion-comment-1", success: true }),
+  resolveDiscussion: vi.fn().mockResolvedValue({ id: "discussion-root-1" }),
+  unresolveDiscussion: vi.fn().mockResolvedValue({ id: "discussion-root-1" }),
+}));
+
 import { setupInitiativesCommands } from "../../../src/commands/initiatives/index.js";
 import { outputSuccess } from "../../../src/common/output.js";
 import { resolveInitiativeId } from "../../../src/resolvers/initiative-resolver.js";
 import { resolveProjectId } from "../../../src/resolvers/project-resolver.js";
 import { resolveUserId } from "../../../src/resolvers/user-resolver.js";
+import {
+  deleteDiscussionComment,
+  deleteDiscussionReply,
+  editDiscussionComment,
+  editDiscussionReply,
+  listDiscussionReplies,
+  listDiscussionsForInitiative,
+  replyToDiscussion,
+  resolveDiscussion,
+  startInitiativeDiscussion,
+  unresolveDiscussion,
+} from "../../../src/services/discussion-service.js";
 import {
   createInitiativeProjectLink,
   deleteInitiativeProjectLink,
@@ -440,5 +489,335 @@ describe("initiative updates wiring", () => {
         body: "Steady progress",
       }),
     );
+  });
+});
+
+describe("initiative discussion commands", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("wires discuss with initiative resolver and discussion service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "discuss",
+      "Growth",
+      "--body",
+      "Kickoff thread",
+    ]);
+
+    expect(resolveInitiativeId).toHaveBeenCalledWith(
+      expect.anything(),
+      "Growth",
+    );
+    expect(startInitiativeDiscussion).toHaveBeenCalledWith(expect.anything(), {
+      initiativeId: "resolved-initiative-uuid",
+      body: "Kickoff thread",
+    });
+    expect(outputSuccess).toHaveBeenCalledWith({ id: "discussion-root-1" });
+  });
+
+  it("validates discuss requires --body", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "discuss",
+      "Growth",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid --body: is required"),
+    );
+    expect(startInitiativeDiscussion).not.toHaveBeenCalled();
+  });
+
+  it("wires discussions with pagination", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "discussions",
+      "Growth",
+      "--limit",
+      "10",
+      "--after",
+      "cursor-1",
+    ]);
+
+    expect(resolveInitiativeId).toHaveBeenCalledWith(
+      expect.anything(),
+      "Growth",
+    );
+    expect(listDiscussionsForInitiative).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-initiative-uuid",
+      { limit: 10, after: "cursor-1" },
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({
+      nodes: [],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: null,
+        endCursor: null,
+      },
+    });
+  });
+
+  it("wires replies with pagination", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "replies",
+      "thread-1",
+      "--limit",
+      "15",
+      "--after",
+      "cursor-2",
+    ]);
+
+    expect(listDiscussionReplies).toHaveBeenCalledWith(
+      expect.anything(),
+      "thread-1",
+      {
+        limit: 15,
+        after: "cursor-2",
+      },
+      "initiative",
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({
+      nodes: [],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: null,
+        endCursor: null,
+      },
+    });
+  });
+
+  it("wires reply", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "reply",
+      "thread-1",
+      "--body",
+      "Nested reply",
+    ]);
+
+    expect(replyToDiscussion).toHaveBeenCalledWith(expect.anything(), {
+      threadId: "thread-1",
+      body: "Nested reply",
+      entityKind: "initiative",
+    });
+    expect(outputSuccess).toHaveBeenCalledWith({ id: "discussion-reply-1" });
+  });
+
+  it("validates reply requires --body", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "reply",
+      "thread-1",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid --body: is required"),
+    );
+    expect(replyToDiscussion).not.toHaveBeenCalled();
+  });
+
+  it("documents generic edit/delete as root-or-reply while strict reply commands stay reply-only", () => {
+    const program = createProgram();
+    const initiatives = program.commands.find(
+      (command) => command.name() === "initiatives",
+    );
+
+    const edit = initiatives?.commands.find(
+      (command) => command.name() === "edit",
+    );
+    const del = initiatives?.commands.find(
+      (command) => command.name() === "delete-comment",
+    );
+    const editReply = initiatives?.commands.find(
+      (command) => command.name() === "edit-reply",
+    );
+    const deleteReply = initiatives?.commands.find(
+      (command) => command.name() === "delete-reply",
+    );
+
+    expect(edit?.description()).toContain("root discussion or reply");
+    expect(del?.description()).toContain("root discussion or reply");
+    expect(editReply?.description()).toBe("edit a discussion reply");
+    expect(deleteReply?.description()).toBe("delete a discussion reply");
+  });
+
+  it("wires generic edit to discussion comment service", async () => {
+    const program = createProgram();
+    const commentId = "11111111-1111-4111-8111-111111111111";
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "edit",
+      commentId,
+      "--body",
+      "Edited",
+    ]);
+
+    expect(editDiscussionComment).toHaveBeenCalledWith(
+      expect.anything(),
+      commentId,
+      { body: "Edited" },
+      "initiative",
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({ id: "discussion-comment-1" });
+  });
+
+  it("wires edit-reply", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "edit-reply",
+      "reply-1",
+      "--body",
+      "Edited",
+    ]);
+
+    expect(editDiscussionReply).toHaveBeenCalledWith(
+      expect.anything(),
+      "reply-1",
+      { body: "Edited" },
+      "initiative",
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({ id: "discussion-reply-1" });
+  });
+
+  it("validates edit-reply requires --body", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "edit-reply",
+      "reply-1",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid --body: is required"),
+    );
+    expect(editDiscussionReply).not.toHaveBeenCalled();
+  });
+
+  it("wires generic delete-comment to discussion comment service", async () => {
+    const program = createProgram();
+    const commentId = "11111111-1111-4111-8111-111111111111";
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "delete-comment",
+      commentId,
+    ]);
+
+    expect(deleteDiscussionComment).toHaveBeenCalledWith(
+      expect.anything(),
+      commentId,
+      "initiative",
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({
+      id: "discussion-comment-1",
+      success: true,
+    });
+  });
+
+  it("wires delete-reply", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "delete-reply",
+      "reply-1",
+    ]);
+
+    expect(deleteDiscussionReply).toHaveBeenCalledWith(
+      expect.anything(),
+      "reply-1",
+      "initiative",
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({
+      id: "discussion-reply-1",
+      success: true,
+    });
+  });
+
+  it("wires resolve and forwards --with-comment", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "resolve",
+      "thread-1",
+      "--with-comment",
+      "comment-123",
+    ]);
+
+    expect(resolveDiscussion).toHaveBeenCalledWith(expect.anything(), {
+      threadId: "thread-1",
+      resolvingCommentId: "comment-123",
+      entityKind: "initiative",
+    });
+    expect(outputSuccess).toHaveBeenCalledWith({ id: "discussion-root-1" });
+  });
+
+  it("wires unresolve", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "unresolve",
+      "thread-1",
+    ]);
+
+    expect(unresolveDiscussion).toHaveBeenCalledWith(
+      expect.anything(),
+      "thread-1",
+      "initiative",
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({ id: "discussion-root-1" });
   });
 });

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -112,6 +112,43 @@ vi.mock("../../../src/services/issue-relation-service.js", () => ({
   findIssueRelation: vi.fn(),
 }));
 
+vi.mock("../../../src/services/discussion-service.js", () => ({
+  startIssueDiscussion: vi.fn().mockResolvedValue({ id: "discussion-root-1" }),
+  listDiscussionsForIssue: vi.fn().mockResolvedValue({
+    nodes: [],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+  }),
+  listDiscussionReplies: vi.fn().mockResolvedValue({
+    nodes: [],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+  }),
+  replyToDiscussion: vi.fn().mockResolvedValue({ id: "discussion-reply-1" }),
+  editDiscussionReply: vi.fn().mockResolvedValue({ id: "discussion-reply-1" }),
+  deleteDiscussionReply: vi.fn().mockResolvedValue({
+    id: "discussion-reply-1",
+    success: true,
+  }),
+  editDiscussionComment: vi
+    .fn()
+    .mockResolvedValue({ id: "discussion-comment-1" }),
+  deleteDiscussionComment: vi.fn().mockResolvedValue({
+    id: "discussion-comment-1",
+    success: true,
+  }),
+  resolveDiscussion: vi.fn().mockResolvedValue({ id: "discussion-root-1" }),
+  unresolveDiscussion: vi.fn().mockResolvedValue({ id: "discussion-root-1" }),
+}));
+
 import { setupIssuesCommands } from "../../../src/commands/issues.js";
 import {
   resolveIssueEstimateContext,
@@ -122,6 +159,18 @@ import {
   resolveTeamId,
 } from "../../../src/resolvers/team-resolver.js";
 import { resolveUserId } from "../../../src/resolvers/user-resolver.js";
+import {
+  deleteDiscussionComment,
+  deleteDiscussionReply,
+  editDiscussionComment,
+  editDiscussionReply,
+  listDiscussionReplies,
+  listDiscussionsForIssue,
+  replyToDiscussion,
+  resolveDiscussion,
+  startIssueDiscussion,
+  unresolveDiscussion,
+} from "../../../src/services/discussion-service.js";
 import {
   archiveIssue,
   createIssue,
@@ -1141,6 +1190,313 @@ describe("issues lifecycle commands", () => {
     expect(deleteIssue).toHaveBeenCalledWith(
       expect.anything(),
       "resolved-issue-uuid",
+    );
+  });
+});
+
+describe("issues discussion commands", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("issues discuss resolves issue and starts thread", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "discuss",
+      "ENG-42",
+      "--body",
+      "Need decision",
+    ]);
+
+    expect(resolveIssueId).toHaveBeenCalledWith(expect.anything(), "ENG-42");
+    expect(startIssueDiscussion).toHaveBeenCalledWith(expect.anything(), {
+      issueId: "resolved-issue-uuid",
+      body: "Need decision",
+    });
+  });
+
+  it("issues discuss requires --body", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "test", "issues", "discuss", "ENG-42"]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid --body: is required"),
+    );
+    expect(startIssueDiscussion).not.toHaveBeenCalled();
+  });
+
+  it("issues discussions resolves issue and forwards pagination", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "discussions",
+      "ENG-42",
+      "--limit",
+      "10",
+      "--after",
+      "cursor-1",
+    ]);
+
+    expect(resolveIssueId).toHaveBeenCalledWith(expect.anything(), "ENG-42");
+    expect(listDiscussionsForIssue).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+      { limit: 10, after: "cursor-1" },
+    );
+  });
+
+  it("issues replies forwards pagination", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "replies",
+      "thread-1",
+      "--limit",
+      "15",
+      "--after",
+      "cursor-2",
+    ]);
+
+    expect(listDiscussionReplies).toHaveBeenCalledWith(
+      expect.anything(),
+      "thread-1",
+      {
+        limit: 15,
+        after: "cursor-2",
+      },
+      "issue",
+    );
+  });
+
+  it("issues reply requires --body", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "test", "issues", "reply", "thread-1"]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid --body: is required"),
+    );
+    expect(replyToDiscussion).not.toHaveBeenCalled();
+  });
+
+  it("issues reply delegates to discussion service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "reply",
+      "thread-1",
+      "--body",
+      "Nested reply",
+    ]);
+
+    expect(replyToDiscussion).toHaveBeenCalledWith(expect.anything(), {
+      threadId: "thread-1",
+      body: "Nested reply",
+      entityKind: "issue",
+    });
+  });
+
+  it("issues delete-comment deletes root or reply discussion comments", async () => {
+    const program = createProgram();
+    const commentId = "11111111-1111-4111-8111-111111111111";
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "delete-comment",
+      commentId,
+    ]);
+
+    expect(deleteDiscussionComment).toHaveBeenCalledWith(
+      expect.anything(),
+      commentId,
+      "issue",
+    );
+    expect(deleteIssue).not.toHaveBeenCalled();
+  });
+
+  it("issues generic edit/delete help documents root or reply IDs while strict reply commands stay reply-only", () => {
+    const program = createProgram();
+    const issues = program.commands.find(
+      (command) => command.name() === "issues",
+    );
+
+    const edit = issues?.commands.find((command) => command.name() === "edit");
+    const del = issues?.commands.find(
+      (command) => command.name() === "delete-comment",
+    );
+    const editReply = issues?.commands.find(
+      (command) => command.name() === "edit-reply",
+    );
+    const deleteReply = issues?.commands.find(
+      (command) => command.name() === "delete-reply",
+    );
+
+    expect(edit?.description()).toContain("root discussion or reply");
+    expect(del?.description()).toContain("root discussion or reply");
+    expect(editReply?.description()).toBe("edit a discussion reply");
+    expect(deleteReply?.description()).toBe("delete a discussion reply");
+  });
+
+  it("issues edit delegates to generic discussion comment service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "edit",
+      "11111111-1111-4111-8111-111111111111",
+      "--body",
+      "Edited",
+    ]);
+
+    expect(editDiscussionComment).toHaveBeenCalledWith(
+      expect.anything(),
+      "11111111-1111-4111-8111-111111111111",
+      { body: "Edited" },
+      "issue",
+    );
+  });
+
+  it("issues edit-reply delegates to discussion service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "edit-reply",
+      "reply-1",
+      "--body",
+      "Edited",
+    ]);
+
+    expect(editDiscussionReply).toHaveBeenCalledWith(
+      expect.anything(),
+      "reply-1",
+      { body: "Edited" },
+      "issue",
+    );
+  });
+
+  it("issues edit-reply requires --body", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "edit-reply",
+      "reply-1",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid --body: is required"),
+    );
+    expect(editDiscussionReply).not.toHaveBeenCalled();
+  });
+
+  it("issues delete-comment delegates to generic discussion comment service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "delete-comment",
+      "11111111-1111-4111-8111-111111111111",
+    ]);
+
+    expect(deleteDiscussionComment).toHaveBeenCalledWith(
+      expect.anything(),
+      "11111111-1111-4111-8111-111111111111",
+      "issue",
+    );
+  });
+
+  it("issues delete-reply delegates to discussion service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "delete-reply",
+      "reply-1",
+    ]);
+
+    expect(deleteDiscussionReply).toHaveBeenCalledWith(
+      expect.anything(),
+      "reply-1",
+      "issue",
+    );
+  });
+
+  it("issues resolve delegates to discussion service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "test", "issues", "resolve", "thread-1"]);
+
+    expect(resolveDiscussion).toHaveBeenCalledWith(expect.anything(), {
+      threadId: "thread-1",
+      entityKind: "issue",
+    });
+  });
+
+  it("issues resolve forwards --with-comment as resolvingCommentId", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "resolve",
+      "thread-1",
+      "--with-comment",
+      "comment-123",
+    ]);
+
+    expect(resolveDiscussion).toHaveBeenCalledWith(expect.anything(), {
+      threadId: "thread-1",
+      resolvingCommentId: "comment-123",
+      entityKind: "issue",
+    });
+  });
+
+  it("issues unresolve delegates to discussion service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "unresolve",
+      "thread-1",
+    ]);
+
+    expect(unresolveDiscussion).toHaveBeenCalledWith(
+      expect.anything(),
+      "thread-1",
+      "issue",
     );
   });
 });

--- a/tests/unit/commands/projects.test.ts
+++ b/tests/unit/commands/projects.test.ts
@@ -44,9 +44,60 @@ vi.mock("../../../src/services/project-service.js", () => ({
   updateProject: vi.fn().mockResolvedValue({ id: "proj-1" }),
 }));
 
+vi.mock("../../../src/services/discussion-service.js", () => ({
+  startProjectDiscussion: vi
+    .fn()
+    .mockResolvedValue({ id: "discussion-root-1" }),
+  listDiscussionsForProject: vi.fn().mockResolvedValue({
+    nodes: [],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+  }),
+  listDiscussionReplies: vi.fn().mockResolvedValue({
+    nodes: [],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+  }),
+  replyToDiscussion: vi.fn().mockResolvedValue({ id: "discussion-reply-1" }),
+  editDiscussionReply: vi.fn().mockResolvedValue({ id: "discussion-reply-1" }),
+  deleteDiscussionReply: vi.fn().mockResolvedValue({
+    id: "discussion-reply-1",
+    success: true,
+  }),
+  editDiscussionComment: vi
+    .fn()
+    .mockResolvedValue({ id: "discussion-comment-1" }),
+  deleteDiscussionComment: vi.fn().mockResolvedValue({
+    id: "discussion-comment-1",
+    success: true,
+  }),
+  resolveDiscussion: vi.fn().mockResolvedValue({ id: "discussion-root-1" }),
+  unresolveDiscussion: vi.fn().mockResolvedValue({ id: "discussion-root-1" }),
+}));
+
 import { setupProjectsCommands } from "../../../src/commands/projects.js";
 import { outputSuccess } from "../../../src/common/output.js";
 import { resolveProjectId } from "../../../src/resolvers/project-resolver.js";
+import {
+  deleteDiscussionComment,
+  deleteDiscussionReply,
+  editDiscussionComment,
+  editDiscussionReply,
+  listDiscussionReplies,
+  listDiscussionsForProject,
+  replyToDiscussion,
+  resolveDiscussion,
+  startProjectDiscussion,
+  unresolveDiscussion,
+} from "../../../src/services/discussion-service.js";
 import {
   archiveProject,
   createProject,
@@ -262,6 +313,348 @@ describe("projects create --priority", () => {
       expect.stringContaining("must be 0-4"),
     );
     expect(createProject).not.toHaveBeenCalled();
+  });
+});
+
+describe("projects discussion commands", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("projects discuss resolves project and delegates to discussion service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "discuss",
+      "My Project",
+      "--body",
+      "Kickoff thread",
+    ]);
+
+    expect(resolveProjectId).toHaveBeenCalledWith(
+      expect.anything(),
+      "My Project",
+    );
+    expect(startProjectDiscussion).toHaveBeenCalledWith(expect.anything(), {
+      projectId: "resolved-project-uuid",
+      body: "Kickoff thread",
+    });
+    expect(outputSuccess).toHaveBeenCalledWith({ id: "discussion-root-1" });
+  });
+
+  it("projects discuss requires --body", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "discuss",
+      "My Project",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid --body: is required"),
+    );
+    expect(startProjectDiscussion).not.toHaveBeenCalled();
+  });
+
+  it("projects discussions resolves project and forwards pagination", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "discussions",
+      "My Project",
+      "--limit",
+      "10",
+      "--after",
+      "cursor-1",
+    ]);
+
+    expect(resolveProjectId).toHaveBeenCalledWith(
+      expect.anything(),
+      "My Project",
+    );
+    expect(listDiscussionsForProject).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-project-uuid",
+      { limit: 10, after: "cursor-1" },
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({
+      nodes: [],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: null,
+        endCursor: null,
+      },
+    });
+  });
+
+  it("projects replies forwards pagination", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "replies",
+      "thread-1",
+      "--limit",
+      "15",
+      "--after",
+      "cursor-2",
+    ]);
+
+    expect(listDiscussionReplies).toHaveBeenCalledWith(
+      expect.anything(),
+      "thread-1",
+      {
+        limit: 15,
+        after: "cursor-2",
+      },
+      "project",
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({
+      nodes: [],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: false,
+        startCursor: null,
+        endCursor: null,
+      },
+    });
+  });
+
+  it("projects reply delegates to discussion service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "reply",
+      "thread-1",
+      "--body",
+      "Nested reply",
+    ]);
+
+    expect(replyToDiscussion).toHaveBeenCalledWith(expect.anything(), {
+      threadId: "thread-1",
+      body: "Nested reply",
+      entityKind: "project",
+    });
+    expect(outputSuccess).toHaveBeenCalledWith({ id: "discussion-reply-1" });
+  });
+
+  it("projects reply requires --body", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "test", "projects", "reply", "thread-1"]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid --body: is required"),
+    );
+    expect(replyToDiscussion).not.toHaveBeenCalled();
+  });
+
+  it("projects generic edit/delete help documents root or reply IDs while strict reply commands stay reply-only", () => {
+    const program = createProgram();
+    const projects = program.commands.find(
+      (command) => command.name() === "projects",
+    );
+
+    const edit = projects?.commands.find(
+      (command) => command.name() === "edit",
+    );
+    const del = projects?.commands.find(
+      (command) => command.name() === "delete-comment",
+    );
+    const editReply = projects?.commands.find(
+      (command) => command.name() === "edit-reply",
+    );
+    const deleteReply = projects?.commands.find(
+      (command) => command.name() === "delete-reply",
+    );
+
+    expect(edit?.description()).toContain("root discussion or reply");
+    expect(del?.description()).toContain("root discussion or reply");
+    expect(editReply?.description()).toBe("edit a discussion reply");
+    expect(deleteReply?.description()).toBe("delete a discussion reply");
+  });
+
+  it("projects edit delegates to generic discussion comment service", async () => {
+    const program = createProgram();
+    const commentId = "11111111-1111-4111-8111-111111111111";
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "edit",
+      commentId,
+      "--body",
+      "Edited",
+    ]);
+
+    expect(editDiscussionComment).toHaveBeenCalledWith(
+      expect.anything(),
+      commentId,
+      { body: "Edited" },
+      "project",
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({ id: "discussion-comment-1" });
+  });
+
+  it("projects edit-reply delegates to discussion service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "edit-reply",
+      "reply-1",
+      "--body",
+      "Edited",
+    ]);
+
+    expect(editDiscussionReply).toHaveBeenCalledWith(
+      expect.anything(),
+      "reply-1",
+      { body: "Edited" },
+      "project",
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({ id: "discussion-reply-1" });
+  });
+
+  it("projects edit-reply requires --body", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "edit-reply",
+      "reply-1",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid --body: is required"),
+    );
+    expect(editDiscussionReply).not.toHaveBeenCalled();
+  });
+
+  it("projects delete-comment delegates to generic discussion comment service", async () => {
+    const program = createProgram();
+    const commentId = "11111111-1111-4111-8111-111111111111";
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "delete-comment",
+      commentId,
+    ]);
+
+    expect(deleteDiscussionComment).toHaveBeenCalledWith(
+      expect.anything(),
+      commentId,
+      "project",
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({
+      id: "discussion-comment-1",
+      success: true,
+    });
+  });
+
+  it("projects delete-reply delegates to discussion service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "delete-reply",
+      "reply-1",
+    ]);
+
+    expect(deleteDiscussionReply).toHaveBeenCalledWith(
+      expect.anything(),
+      "reply-1",
+      "project",
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({
+      id: "discussion-reply-1",
+      success: true,
+    });
+  });
+
+  it("projects resolve delegates to discussion service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "resolve",
+      "thread-1",
+    ]);
+
+    expect(resolveDiscussion).toHaveBeenCalledWith(expect.anything(), {
+      threadId: "thread-1",
+      entityKind: "project",
+    });
+    expect(outputSuccess).toHaveBeenCalledWith({ id: "discussion-root-1" });
+  });
+
+  it("projects resolve forwards --with-comment as resolvingCommentId", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "resolve",
+      "thread-1",
+      "--with-comment",
+      "comment-123",
+    ]);
+
+    expect(resolveDiscussion).toHaveBeenCalledWith(expect.anything(), {
+      threadId: "thread-1",
+      resolvingCommentId: "comment-123",
+      entityKind: "project",
+    });
+    expect(outputSuccess).toHaveBeenCalledWith({ id: "discussion-root-1" });
+  });
+
+  it("projects unresolve delegates to discussion service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "unresolve",
+      "thread-1",
+    ]);
+
+    expect(unresolveDiscussion).toHaveBeenCalledWith(
+      expect.anything(),
+      "thread-1",
+      "project",
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({ id: "discussion-root-1" });
   });
 });
 

--- a/tests/unit/services/discussion-service.test.ts
+++ b/tests/unit/services/discussion-service.test.ts
@@ -1,0 +1,587 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import {
+  GetDiscussionCommentContextDocument,
+  type ListIssueDiscussionRootsQuery,
+} from "../../../src/gql/graphql.js";
+import {
+  deleteDiscussionComment,
+  deleteDiscussionReply,
+  editDiscussionComment,
+  editDiscussionReply,
+  listDiscussionReplies,
+  listDiscussionsForInitiative,
+  listDiscussionsForIssue,
+  listDiscussionsForProject,
+  replyToDiscussion,
+  resolveDiscussion,
+  startInitiativeDiscussion,
+  startIssueDiscussion,
+  startProjectDiscussion,
+  unresolveDiscussion,
+} from "../../../src/services/discussion-service.js";
+
+function createClientMock(): GraphQLClient {
+  return {
+    request: vi.fn(),
+  } as unknown as GraphQLClient;
+}
+
+const MOCK_USER = { id: "user-1", displayName: "Test User" };
+
+function comment(id: string, parentId: string | null = null) {
+  return {
+    id,
+    body: `comment-${id}`,
+    createdAt: "2025-01-15T10:00:00.000Z",
+    editedAt: null,
+    parentId,
+    resolvedAt: null,
+    resolvingComment: null,
+    resolvingUser: null,
+    user: MOCK_USER,
+  };
+}
+
+describe("listDiscussionsForIssue", () => {
+  it("returns root threads only", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValue({
+      issue: {
+        comments: {
+          nodes: [comment("root-1"), comment("root-2")],
+          pageInfo: { hasNextPage: true, endCursor: "root-cursor-1" },
+        },
+      },
+    } satisfies ListIssueDiscussionRootsQuery);
+
+    const result = await listDiscussionsForIssue(client, "issue-1", {
+      limit: 2,
+      after: "root-cursor-0",
+    });
+
+    expect(result.nodes.map((node) => node.id)).toEqual(["root-1", "root-2"]);
+    expect(result.pageInfo).toEqual({
+      hasNextPage: true,
+      endCursor: "root-cursor-1",
+    });
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      issueId: "issue-1",
+      first: 2,
+      after: "root-cursor-0",
+    });
+  });
+
+  it("throws when issue is missing", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValue({ issue: null });
+
+    await expect(
+      listDiscussionsForIssue(client, "issue-missing"),
+    ).rejects.toThrow('Issue with ID "issue-missing" not found');
+  });
+});
+
+describe("listDiscussionsForProject", () => {
+  it("returns root threads only", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValue({
+      project: {
+        comments: {
+          nodes: [comment("root-1")],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+    });
+
+    const result = await listDiscussionsForProject(client, "project-1", {
+      limit: 10,
+      after: "cur-0",
+    });
+
+    expect(result.nodes).toHaveLength(1);
+    expect(result.pageInfo).toEqual({ hasNextPage: false, endCursor: null });
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      projectId: "project-1",
+      first: 10,
+      after: "cur-0",
+    });
+  });
+
+  it("throws when project is missing", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValue({ project: null });
+
+    await expect(
+      listDiscussionsForProject(client, "project-missing"),
+    ).rejects.toThrow('Project with ID "project-missing" not found');
+  });
+});
+
+describe("listDiscussionsForInitiative", () => {
+  it("returns root threads only", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValue({
+      initiative: { id: "initiative-1" },
+      comments: {
+        nodes: [comment("root-1")],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+
+    const result = await listDiscussionsForInitiative(client, "initiative-1");
+
+    expect(result.nodes).toHaveLength(1);
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      initiativeId: "initiative-1",
+      initiativeLookupId: "initiative-1",
+      first: 25,
+      after: undefined,
+    });
+  });
+
+  it("throws when initiative is missing", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValue({ initiative: null });
+
+    await expect(
+      listDiscussionsForInitiative(client, "initiative-missing"),
+    ).rejects.toThrow('Initiative with ID "initiative-missing" not found');
+  });
+});
+
+describe("listDiscussionReplies", () => {
+  it("returns deeply nested replies beyond fixed query depth", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        comment: {
+          ...comment("root-1"),
+          issueId: "issue-1",
+          projectId: null,
+          initiativeId: null,
+        },
+      })
+      .mockResolvedValueOnce({
+        comments: {
+          nodes: [
+            comment("reply-1", "root-1"),
+            comment("reply-2", "reply-1"),
+            comment("reply-3", "reply-2"),
+            comment("reply-4", "reply-3"),
+            comment("reply-5", "reply-4"),
+          ],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      });
+
+    const result = await listDiscussionReplies(client, "root-1", {
+      limit: 5,
+    });
+
+    expect(result.nodes.map((node) => node.id)).toEqual([
+      "reply-1",
+      "reply-2",
+      "reply-3",
+      "reply-4",
+      "reply-5",
+    ]);
+    expect(result.pageInfo).toEqual({
+      hasNextPage: false,
+      endCursor: "reply-5",
+    });
+  });
+
+  it("paginates thread replies with reply id cursors", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        comment: {
+          ...comment("root-1"),
+          issueId: "issue-1",
+          projectId: null,
+          initiativeId: null,
+        },
+      })
+      .mockResolvedValueOnce({
+        comments: {
+          nodes: [
+            comment("reply-1", "root-1"),
+            comment("other-1", "other-root"),
+            comment("reply-2", "reply-1"),
+            comment("reply-3", "reply-2"),
+          ],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      });
+
+    const result = await listDiscussionReplies(client, "root-1", {
+      limit: 1,
+      after: "reply-1",
+    });
+
+    expect(result.nodes.map((node) => node.id)).toEqual(["reply-2"]);
+    expect(result.pageInfo).toEqual({
+      hasNextPage: true,
+      endCursor: "reply-2",
+    });
+  });
+
+  it("keeps descendants when candidates arrive before their parent", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        comment: {
+          ...comment("root-1"),
+          issueId: "issue-1",
+          projectId: null,
+          initiativeId: null,
+        },
+      })
+      .mockResolvedValueOnce({
+        comments: {
+          nodes: [
+            {
+              ...comment("a-child", "z-parent"),
+              createdAt: "2025-01-15T10:00:00.000Z",
+            },
+            {
+              ...comment("z-parent", "root-1"),
+              createdAt: "2025-01-15T10:00:00.000Z",
+            },
+          ],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      });
+
+    const result = await listDiscussionReplies(client, "root-1", { limit: 10 });
+
+    expect(result.nodes.map((node) => node.id)).toEqual([
+      "z-parent",
+      "a-child",
+    ]);
+  });
+
+  it("throws when thread id does not exist", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValueOnce({ comment: null });
+
+    await expect(
+      listDiscussionReplies(client, "missing-thread"),
+    ).rejects.toThrow('Discussion thread ID "missing-thread" not found');
+  });
+
+  it("rejects non-root thread id", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValueOnce({
+      comment: comment("reply-1", "root-1"),
+    });
+
+    await expect(listDiscussionReplies(client, "reply-1")).rejects.toThrow(
+      'Discussion thread ID "reply-1" must reference a root comment',
+    );
+  });
+});
+
+describe("replyToDiscussion", () => {
+  it("throws when thread id does not exist", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValueOnce({ comment: null });
+
+    await expect(
+      replyToDiscussion(client, { threadId: "missing-thread", body: "nested" }),
+    ).rejects.toThrow('Discussion thread ID "missing-thread" not found');
+  });
+
+  it("rejects non-root parent thread id", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValueOnce({
+      comment: {
+        ...comment("reply-2", "root-1"),
+        issueId: "issue-1",
+        projectId: null,
+        initiativeId: null,
+      },
+    });
+
+    await expect(
+      replyToDiscussion(client, { threadId: "reply-2", body: "nested reply" }),
+    ).rejects.toThrow(
+      'Discussion thread ID "reply-2" must reference a root comment',
+    );
+
+    expect(client.request).toHaveBeenCalledTimes(1);
+    expect(client.request).toHaveBeenCalledWith(
+      GetDiscussionCommentContextDocument,
+      {
+        id: "reply-2",
+      },
+    );
+  });
+
+  it("rejects root thread from different entity kind", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValueOnce({
+      comment: {
+        ...comment("root-1"),
+        issueId: null,
+        projectId: "project-1",
+        initiativeId: null,
+      },
+    });
+
+    await expect(
+      replyToDiscussion(client, {
+        threadId: "root-1",
+        body: "nested reply",
+        entityKind: "issue",
+      }),
+    ).rejects.toThrow(
+      'Discussion thread ID "root-1" belongs to project, not issue',
+    );
+  });
+
+  it("creates a reply for root thread", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({ comment: comment("root-1") })
+      .mockResolvedValueOnce({
+        commentCreate: {
+          success: true,
+          comment: comment("reply-1", "root-1"),
+        },
+      });
+
+    const result = await replyToDiscussion(client, {
+      threadId: "root-1",
+      body: "hello",
+    });
+
+    expect(result.id).toBe("reply-1");
+    expect(result.parentId).toBe("root-1");
+  });
+});
+
+describe("discussion mutation flows", () => {
+  it("starts issue/project/initiative discussions", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        commentCreate: { success: true, comment: comment("c-issue") },
+      })
+      .mockResolvedValueOnce({
+        commentCreate: { success: true, comment: comment("c-project") },
+      })
+      .mockResolvedValueOnce({
+        commentCreate: { success: true, comment: comment("c-initiative") },
+      });
+
+    await expect(
+      startIssueDiscussion(client, { issueId: "issue-1", body: "issue body" }),
+    ).resolves.toMatchObject({ id: "c-issue" });
+    await expect(
+      startProjectDiscussion(client, {
+        projectId: "project-1",
+        body: "project body",
+      }),
+    ).resolves.toMatchObject({ id: "c-project" });
+    await expect(
+      startInitiativeDiscussion(client, {
+        initiativeId: "initiative-1",
+        body: "initiative body",
+      }),
+    ).resolves.toMatchObject({ id: "c-initiative" });
+  });
+
+  it("fails to start issue discussion when create fails", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValueOnce({
+      commentCreate: { success: false, comment: null },
+    });
+
+    await expect(
+      startIssueDiscussion(client, { issueId: "issue-1", body: "issue body" }),
+    ).rejects.toThrow("Failed to start discussion");
+  });
+
+  it("edits and deletes replies", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({ comment: comment("reply-1", "root-1") })
+      .mockResolvedValueOnce({
+        commentUpdate: {
+          success: true,
+          comment: { ...comment("reply-1", "root-1"), body: "updated" },
+        },
+      })
+      .mockResolvedValueOnce({ comment: comment("reply-1", "root-1") })
+      .mockResolvedValueOnce({
+        commentDelete: { success: true, entityId: "reply-1" },
+      });
+
+    await expect(
+      editDiscussionReply(client, "reply-1", { body: "updated" }),
+    ).resolves.toMatchObject({ id: "reply-1", body: "updated" });
+    await expect(deleteDiscussionReply(client, "reply-1")).resolves.toEqual({
+      id: "reply-1",
+      success: true,
+    });
+  });
+
+  it("rejects editing a root comment via editDiscussionReply", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValueOnce({
+      comment: comment("root-1"),
+    });
+
+    await expect(
+      editDiscussionReply(client, "root-1", { body: "updated" }),
+    ).rejects.toThrow(
+      'Discussion reply ID "root-1" must reference a reply comment',
+    );
+  });
+
+  it("rejects deleting a root comment via deleteDiscussionReply", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValueOnce({
+      comment: comment("root-1"),
+    });
+
+    await expect(deleteDiscussionReply(client, "root-1")).rejects.toThrow(
+      'Discussion reply ID "root-1" must reference a reply comment',
+    );
+  });
+
+  it("supports compatibility edit/delete for root comments", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({ comment: comment("root-1") })
+      .mockResolvedValueOnce({
+        commentUpdate: {
+          success: true,
+          comment: { ...comment("root-1"), body: "updated" },
+        },
+      })
+      .mockResolvedValueOnce({ comment: comment("root-1") })
+      .mockResolvedValueOnce({
+        commentDelete: { success: true, entityId: "root-1" },
+      });
+
+    await expect(
+      editDiscussionComment(client, "root-1", { body: "updated" }),
+    ).resolves.toMatchObject({ id: "root-1", body: "updated" });
+    await expect(deleteDiscussionComment(client, "root-1")).resolves.toEqual({
+      id: "root-1",
+      success: true,
+    });
+  });
+
+  it("rejects editing reply from different entity kind", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValueOnce({
+      comment: {
+        ...comment("reply-1", "root-1"),
+        issueId: null,
+        projectId: "project-1",
+        initiativeId: null,
+      },
+    });
+
+    await expect(
+      editDiscussionReply(client, "reply-1", { body: "updated" }, "issue"),
+    ).rejects.toThrow(
+      'Discussion reply ID "reply-1" belongs to project, not issue',
+    );
+  });
+
+  it("supports compatibility edit/delete for reply comments", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({ comment: comment("reply-1", "root-1") })
+      .mockResolvedValueOnce({
+        commentUpdate: {
+          success: true,
+          comment: { ...comment("reply-1", "root-1"), body: "updated" },
+        },
+      })
+      .mockResolvedValueOnce({ comment: comment("reply-1", "root-1") })
+      .mockResolvedValueOnce({
+        commentDelete: { success: true, entityId: "reply-1" },
+      });
+
+    await expect(
+      editDiscussionComment(client, "reply-1", { body: "updated" }),
+    ).resolves.toMatchObject({ id: "reply-1", body: "updated" });
+    await expect(deleteDiscussionComment(client, "reply-1")).resolves.toEqual({
+      id: "reply-1",
+      success: true,
+    });
+  });
+
+  it("fails compatibility edit/delete when target comment is missing", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValueOnce({ comment: null });
+
+    await expect(
+      editDiscussionComment(client, "missing", { body: "updated" }),
+    ).rejects.toThrow('Discussion comment ID "missing" not found');
+  });
+
+  it("fails compatibility edit when update mutation fails", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({ comment: comment("root-1") })
+      .mockResolvedValueOnce({
+        commentUpdate: { success: false, comment: null },
+      });
+
+    await expect(
+      editDiscussionComment(client, "root-1", { body: "updated" }),
+    ).rejects.toThrow("Failed to edit discussion comment");
+  });
+
+  it("fails compatibility delete when delete mutation fails", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({ comment: comment("root-1") })
+      .mockResolvedValueOnce({
+        commentDelete: { success: false, entityId: "root-1" },
+      });
+
+    await expect(deleteDiscussionComment(client, "root-1")).rejects.toThrow(
+      "Failed to delete discussion comment",
+    );
+  });
+
+  it("resolves and unresolves root discussion", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({ comment: comment("root-1") })
+      .mockResolvedValueOnce({
+        commentResolve: {
+          success: true,
+          comment: {
+            ...comment("root-1"),
+            resolvedAt: "2025-01-16T10:00:00.000Z",
+          },
+        },
+      })
+      .mockResolvedValueOnce({ comment: comment("root-1") })
+      .mockResolvedValueOnce({
+        commentUnresolve: {
+          success: true,
+          comment: comment("root-1"),
+        },
+      });
+
+    await expect(
+      resolveDiscussion(client, {
+        threadId: "root-1",
+        resolvingCommentId: "reply-1",
+      }),
+    ).resolves.toMatchObject({ id: "root-1" });
+    await expect(unresolveDiscussion(client, "root-1")).resolves.toMatchObject({
+      id: "root-1",
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Implements issue #146 discussion interface redesign by introducing domain-centric discussion commands across `issues`, `projects`, and `initiatives`, while keeping `comments` as a deprecated compatibility façade.

Key changes:
- adds dedicated GraphQL discussion queries/mutations and regenerates typed operations
- adds `discussion-service` for:
  - listing root discussions for issues, projects, and initiatives
  - listing thread replies, including arbitrarily deep nested replies
  - starting discussions and replying to root threads
  - editing and deleting root/reply comments
  - resolving and unresolving discussion threads
  - enforcing domain-scoped thread operations so issue/project/initiative commands reject mixed-domain thread IDs
- adds domain-centric discussion commands across `issues`, `projects`, and `initiatives`:
  - `discuss`, `discussions`, `replies`, `reply`, `edit`, `delete-comment`, `edit-reply`, `delete-reply`, `resolve`, `unresolve`
- keeps entity delete commands intact while adding non-conflicting discussion deletion via `delete-comment`
- routes legacy `comments` commands through discussion service with explicit deprecation + migration guidance
- updates README examples and migration docs to discussion-first workflows
- adds/updates unit tests for service behavior, command wiring, validation, compatibility, nested replies, and deprecation help text

Closes #146

## Type of change

- [ ] Bug fix
- [x] New feature
- [x] Refactor (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Executed in worktree branch:

```bash
npm run check:ci
npx tsc --noEmit
npm test
npm run build
```

Results:
- all commands exit 0
- `npm test`: 53 files / 654 tests passing

Targeted verification additionally run during implementation:
- `npx vitest run tests/unit/services/discussion-service.test.ts`
- `npx vitest run tests/unit/commands/issues.test.ts tests/unit/commands/projects.test.ts tests/unit/commands/initiatives.test.ts`
- `npx vitest run tests/unit/commands/comments.test.ts`

## Notes for reviewers

Docs note:
- README migration guidance documents root-thread vs reply workflows, nested reply listing, and the generic root/reply edit plus `delete-comment` commands.

Risk note:
- This change expands discussion command surface across three domains. Main regression risk is CLI discoverability/compatibility, especially around command naming, nested reply pagination, and deprecated `comments` behavior. Entity delete commands remain unchanged, and discussion deletion uses `delete-comment` to avoid command collisions.

Additional notes:
- `comments` remains available for backward compatibility but is explicitly deprecated in help/meta text.
- Compatibility scope remains intentionally narrowed for replies: `comments reply` expects a root discussion thread ID; nested reply targets are not supported in compatibility mode.
- Generic `edit <comment>` accepts root discussion IDs and reply IDs.
- `delete-comment <comment>` was added instead of overloading existing entity `delete` commands, preserving backward compatibility for `issues delete`, `projects delete`, and `initiatives delete`.
- Initiative discussion listing preserves not-found behavior with an explicit existence check.
- Domain-scoped commands now validate that the supplied thread/comment ID belongs to the expected issue/project/initiative discussion domain.
