### PR TITLE
refactor: replace fragile root option lookups with getRootOpts

### DIFF
--- a/src/commands/attachments.ts
+++ b/src/commands/attachments.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { createContext } from "../common/context.js";
+import { createContext, getRootOpts } from "../common/context.js";
 import { handleCommand, outputSuccess } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import type { AttachmentFilter } from "../gql/graphql.js";
@@ -87,7 +87,7 @@ export function setupAttachmentsCommands(program: Command): void {
           ListOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const issueId = await resolveIssueId(ctx.sdk, issue);
         const filter = buildAttachmentFilter(options);
         const result = await listAttachments(ctx.gql, issueId, filter);
@@ -108,7 +108,7 @@ export function setupAttachmentsCommands(program: Command): void {
           CreateOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const issueId = await resolveIssueId(ctx.sdk, issue);
         const result = await createAttachment(ctx.gql, {
           issueId,
@@ -126,7 +126,7 @@ export function setupAttachmentsCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [id, , command] = args as [string, unknown, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const result = await deleteAttachment(ctx.gql, id);
         outputSuccess(result);
       }),

--- a/src/commands/auth.ts
+++ b/src/commands/auth.ts
@@ -6,7 +6,7 @@ import {
   resolveApiToken,
   type TokenSource,
 } from "../common/auth.js";
-import { createGraphQLClient } from "../common/context.js";
+import { createGraphQLClient, getRootOpts } from "../common/context.js";
 import { handleCommand, outputSuccess } from "../common/output.js";
 import { clearToken, saveToken } from "../common/token-storage.js";
 import type { Viewer } from "../common/types.js";
@@ -124,7 +124,7 @@ export function setupAuthCommands(program: Command): void {
       try {
         if (!options.force) {
           try {
-            const rootOpts = command.parent!.parent!.opts() as CommandOptions;
+            const rootOpts = getRootOpts(command) as CommandOptions;
             const { token, source } = resolveApiToken(rootOpts);
             try {
               const viewer = await validateApiToken(token);
@@ -202,7 +202,7 @@ export function setupAuthCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [, command] = args as [CommandOptions, Command];
-        const rootOpts = command.parent!.parent!.opts() as CommandOptions;
+        const rootOpts = getRootOpts(command) as CommandOptions;
 
         let token: string;
         let source: TokenSource;
@@ -245,7 +245,7 @@ export function setupAuthCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [, command] = args as [CommandOptions, Command];
-        const rootOpts = command.parent!.parent!.opts() as CommandOptions;
+        const rootOpts = getRootOpts(command) as CommandOptions;
 
         clearToken();
 

--- a/src/commands/comments.ts
+++ b/src/commands/comments.ts
@@ -1,5 +1,9 @@
 import type { Command } from "commander";
-import { type CommandOptions, createContext } from "../common/context.js";
+import {
+  type CommandOptions,
+  createContext,
+  getRootOpts,
+} from "../common/context.js";
 import { resolveReactionEmojiInput } from "../common/emoji.js";
 import { invalidParameterError } from "../common/errors.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
@@ -89,7 +93,7 @@ export function setupCommentsCommands(program: Command): void {
           ListCommentOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const limit = parseLimit(options.limit || "25");
         const resolvedIssueId = await resolveIssueId(ctx.sdk, issue);
@@ -120,7 +124,7 @@ export function setupCommentsCommands(program: Command): void {
           CreateCommentOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         if (!options.body) {
           throw invalidParameterError("--body", "is required");
@@ -158,7 +162,7 @@ export function setupCommentsCommands(program: Command): void {
           ReplyCommentOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         if (!options.body) {
           throw invalidParameterError("--body", "is required");
@@ -188,7 +192,7 @@ export function setupCommentsCommands(program: Command): void {
           EditCommentOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         if (!options.body) {
           throw invalidParameterError("--body", "is required");
@@ -211,7 +215,7 @@ export function setupCommentsCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [comment, , command] = args as [string, unknown, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const result = await deleteDiscussionComment(ctx.gql, comment);
 
@@ -237,7 +241,7 @@ export function setupCommentsCommands(program: Command): void {
           ReactionOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const result = await createIssueDiscussionCommentReaction(ctx.gql, {
           commentId: comment,
@@ -266,7 +270,7 @@ export function setupCommentsCommands(program: Command): void {
           ReactionOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const result = await deleteIssueDiscussionCommentReactionByEmoji(
           ctx.gql,
@@ -297,7 +301,7 @@ export function setupCommentsCommands(program: Command): void {
           unknown,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const result = await deleteIssueDiscussionCommentReactionById(ctx.gql, {
           commentId: comment,

--- a/src/commands/cycles.ts
+++ b/src/commands/cycles.ts
@@ -1,5 +1,9 @@
 import type { Command } from "commander";
-import { type CommandOptions, createContext } from "../common/context.js";
+import {
+  type CommandOptions,
+  createContext,
+  getRootOpts,
+} from "../common/context.js";
 import {
   invalidParameterError,
   notFoundError,
@@ -63,7 +67,7 @@ export function setupCyclesCommands(program: Command): void {
           );
         }
 
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         // Resolve team filter if provided
         const teamId = options.team
@@ -123,7 +127,7 @@ export function setupCyclesCommands(program: Command): void {
           CycleReadOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const cycleId = await resolveCycleId(ctx.sdk, cycle, options.team);
 

--- a/src/commands/documents.ts
+++ b/src/commands/documents.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { createContext } from "../common/context.js";
+import { createContext, getRootOpts } from "../common/context.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import type { DocumentUpdateInput } from "../gql/graphql.js";
@@ -110,7 +110,7 @@ export function setupDocumentsCommands(program: Command): void {
           );
         }
 
-        const rootOpts = command.parent!.parent!.opts();
+        const rootOpts = getRootOpts(command);
         const ctx = createContext(rootOpts);
 
         const limit = parseLimit(options.limit || "50");
@@ -169,7 +169,7 @@ export function setupDocumentsCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [document, , command] = args as [string, unknown, Command];
-        const rootOpts = command.parent!.parent!.opts();
+        const rootOpts = getRootOpts(command);
         const ctx = createContext(rootOpts);
 
         const documentResult = await getDocument(ctx.gql, document);
@@ -190,7 +190,7 @@ export function setupDocumentsCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [options, command] = args as [DocumentCreateOptions, Command];
-        const rootOpts = command.parent!.parent!.opts();
+        const rootOpts = getRootOpts(command);
         const ctx = createContext(rootOpts);
 
         const projectId = options.project
@@ -248,7 +248,7 @@ export function setupDocumentsCommands(program: Command): void {
           DocumentUpdateOptions,
           Command,
         ];
-        const rootOpts = command.parent!.parent!.opts();
+        const rootOpts = getRootOpts(command);
         const ctx = createContext(rootOpts);
 
         const input: DocumentUpdateInput = {};
@@ -271,7 +271,7 @@ export function setupDocumentsCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [document, , command] = args as [string, unknown, Command];
-        const rootOpts = command.parent!.parent!.opts();
+        const rootOpts = getRootOpts(command);
         const ctx = createContext(rootOpts);
 
         const result = await deleteDocument(ctx.gql, document);

--- a/src/commands/files.ts
+++ b/src/commands/files.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { type CommandOptions, getApiToken } from "../common/auth.js";
+import { getRootOpts } from "../common/context.js";
 import { handleCommand, outputSuccess } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import { FileService } from "../services/file-service.js";
@@ -37,7 +38,7 @@ export function setupFilesCommands(program: Command): void {
           CommandOptions & { output?: string; overwrite?: boolean },
           Command,
         ];
-        const apiToken = getApiToken(command.parent!.parent!.opts());
+        const apiToken = getApiToken(getRootOpts(command));
         const fileService = new FileService(apiToken);
         const result = await fileService.downloadFile(url, {
           output: options.output,
@@ -61,7 +62,7 @@ export function setupFilesCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [filePath, , command] = args as [string, CommandOptions, Command];
-        const apiToken = getApiToken(command.parent!.parent!.opts());
+        const apiToken = getApiToken(getRootOpts(command));
         const fileService = new FileService(apiToken);
         const result = await fileService.uploadFile(filePath);
 

--- a/src/commands/initiatives/entity.ts
+++ b/src/commands/initiatives/entity.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import type { LinearSdkClient } from "../../client/linear-client.js";
-import { createContext } from "../../common/context.js";
+import { createContext, getRootOpts } from "../../common/context.js";
 import { resolveReactionEmojiInput } from "../../common/emoji.js";
 import { invalidParameterError } from "../../common/errors.js";
 import {
@@ -123,7 +123,7 @@ function addCommentReactionCommands(
           ReactionOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
         const result = await createDiscussionCommentReaction(ctx.gql, {
           commentId,
           target: noun,
@@ -146,7 +146,7 @@ function addCommentReactionCommands(
           ReactionOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
         const result = await deleteDiscussionCommentReactionByEmoji(ctx.gql, {
           commentId,
           target: noun,
@@ -170,7 +170,7 @@ function addCommentReactionCommands(
           unknown,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
         const result = await deleteDiscussionCommentReactionById(ctx.gql, {
           commentId,
           target: noun,
@@ -210,14 +210,6 @@ type InitiativeSortBy =
   | "healthUpdatedAt"
   | "manual"
   | "owner";
-
-function rootOptions(command: Command): Record<string, unknown> {
-  let current: Command = command;
-  while (current.parent) {
-    current = current.parent;
-  }
-  return current.opts();
-}
 
 function parseSortOrder(value?: string): "asc" | "desc" | undefined {
   if (!value) return undefined;
@@ -500,7 +492,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [options, command] = args as [InitiativeListOptions, Command];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         const sortOrder = parseSortOrder(options.sortOrder);
         const sortBy = parseSortBy(options.sortBy);
@@ -561,7 +553,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           InitiativeReadOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
         const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
 
         // Read query already returns expanded fields. Keep flags accepted for
@@ -584,7 +576,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           DiscussionBodyOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         if (!options.body) {
           throw invalidParameterError("--body", "is required");
@@ -613,7 +605,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           DiscussionsOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
         const paginationOptions = {
@@ -654,7 +646,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           DiscussionsOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         const paginationOptions = {
           limit: parseLimit(options.limit || "50"),
@@ -694,7 +686,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           DiscussionBodyOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         if (!options.body) {
           throw invalidParameterError("--body", "is required");
@@ -721,7 +713,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           DiscussionBodyOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         if (!options.body) {
           throw invalidParameterError("--body", "is required");
@@ -751,7 +743,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           DiscussionBodyOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         if (!options.body) {
           throw invalidParameterError("--body", "is required");
@@ -776,7 +768,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [comment, , command] = args as [string, unknown, Command];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         const result = await deleteDiscussionComment(
           ctx.gql,
@@ -794,7 +786,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [reply, , command] = args as [string, unknown, Command];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         const result = await deleteDiscussionReply(
           ctx.gql,
@@ -817,7 +809,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           ResolveDiscussionOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         const result = await resolveDiscussion(ctx.gql, {
           threadId: thread,
@@ -835,7 +827,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [thread, , command] = args as [string, unknown, Command];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         const result = await unresolveDiscussion(ctx.gql, thread, "initiative");
 
@@ -859,7 +851,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           InitiativeCreateOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         const input: InitiativeCreateInput = { name };
 
@@ -911,7 +903,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           InitiativeUpdateOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
         const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
 
         const input: InitiativeUpdateInput = {};
@@ -964,7 +956,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [initiative, , command] = args as [string, unknown, Command];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
         const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
         const result = await archiveInitiative(ctx.gql, initiativeId);
         outputSuccess(result);
@@ -977,7 +969,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [initiative, , command] = args as [string, unknown, Command];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
         const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
         const result = await unarchiveInitiative(ctx.gql, initiativeId);
         outputSuccess(result);
@@ -990,7 +982,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [initiative, , command] = args as [string, unknown, Command];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
         const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
         const result = await deleteInitiative(ctx.gql, initiativeId);
         outputSuccess(result);

--- a/src/commands/initiatives/projects.ts
+++ b/src/commands/initiatives/projects.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { createContext } from "../../common/context.js";
+import { createContext, getRootOpts } from "../../common/context.js";
 import { handleCommand, outputSuccess } from "../../common/output.js";
 import {
   resolveInitiativeId,
@@ -10,14 +10,6 @@ import {
   createInitiativeProjectLink,
   deleteInitiativeProjectLink,
 } from "../../services/initiative-project-service.js";
-
-function rootOptions(command: Command): Record<string, unknown> {
-  let current: Command = command;
-  while (current.parent) {
-    current = current.parent;
-  }
-  return current.opts();
-}
 
 export function setupInitiativeProjectCommands(initiatives: Command): void {
   initiatives
@@ -31,7 +23,7 @@ export function setupInitiativeProjectCommands(initiatives: Command): void {
           unknown,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
         const projectId = await resolveProjectId(ctx.sdk, project);
@@ -56,7 +48,7 @@ export function setupInitiativeProjectCommands(initiatives: Command): void {
           unknown,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
         const projectId = await resolveProjectId(ctx.sdk, project);

--- a/src/commands/initiatives/relations.ts
+++ b/src/commands/initiatives/relations.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { createContext } from "../../common/context.js";
+import { createContext, getRootOpts } from "../../common/context.js";
 import { handleCommand, outputSuccess } from "../../common/output.js";
 import {
   resolveInitiativeId,
@@ -9,14 +9,6 @@ import {
   createInitiativeRelation,
   deleteInitiativeRelation,
 } from "../../services/initiative-relation-service.js";
-
-function rootOptions(command: Command): Record<string, unknown> {
-  let current: Command = command;
-  while (current.parent) {
-    current = current.parent;
-  }
-  return current.opts();
-}
 
 export function setupInitiativeRelationCommands(initiatives: Command): void {
   initiatives
@@ -30,7 +22,7 @@ export function setupInitiativeRelationCommands(initiatives: Command): void {
           unknown,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         const parentId = await resolveInitiativeId(ctx.sdk, parent);
         const childId = await resolveInitiativeId(ctx.sdk, child);
@@ -55,7 +47,7 @@ export function setupInitiativeRelationCommands(initiatives: Command): void {
           unknown,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         const parentId = await resolveInitiativeId(ctx.sdk, parent);
         const childId = await resolveInitiativeId(ctx.sdk, child);

--- a/src/commands/initiatives/updates.ts
+++ b/src/commands/initiatives/updates.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { createContext } from "../../common/context.js";
+import { createContext, getRootOpts } from "../../common/context.js";
 import { invalidParameterError } from "../../common/errors.js";
 import {
   handleCommand,
@@ -39,14 +39,6 @@ interface InitiativeUpdatesUpdateOptions {
   health?: string;
 }
 
-function rootOptions(command: Command): Record<string, unknown> {
-  let current: Command = command;
-  while (current.parent) {
-    current = current.parent;
-  }
-  return current.opts();
-}
-
 function parseHealth(value?: string): InitiativeUpdateHealthType | undefined {
   if (!value) return undefined;
 
@@ -81,7 +73,7 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
           InitiativeUpdatesListOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         const initiativeId = await resolveInitiativeId(
           ctx.sdk,
@@ -105,7 +97,7 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [updateId, , command] = args as [string, unknown, Command];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
         const result = await getInitiativeUpdate(ctx.gql, updateId);
         outputSuccess(result);
       }),
@@ -123,7 +115,7 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
           InitiativeUpdatesCreateOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         const initiativeId = await resolveInitiativeId(
           ctx.sdk,
@@ -158,7 +150,7 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
           InitiativeUpdatesUpdateOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
 
         const input: InitiativeUpdateUpdateInput = {};
 
@@ -189,7 +181,7 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [updateId, , command] = args as [string, unknown, Command];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
         const result = await archiveInitiativeUpdate(ctx.gql, updateId);
         outputSuccess(result);
       }),
@@ -201,7 +193,7 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [updateId, , command] = args as [string, unknown, Command];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
         const result = await unarchiveInitiativeUpdate(ctx.gql, updateId);
         outputSuccess(result);
       }),

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import type { CommandContext } from "../common/context.js";
-import { createContext } from "../common/context.js";
+import { createContext, getRootOpts } from "../common/context.js";
 import { resolveReactionEmojiInput } from "../common/emoji.js";
 import { invalidParameterError } from "../common/errors.js";
 import { validateEstimateAgainstTeamConfig } from "../common/estimate-validation.js";
@@ -175,14 +175,6 @@ interface ResolveDiscussionOptions {
   withComment?: string;
 }
 
-function rootOptions(command: Command): Record<string, unknown> {
-  let current: Command = command;
-  while (current.parent) {
-    current = current.parent;
-  }
-  return current.opts();
-}
-
 function addCommentReactionCommands(
   parent: ReturnType<Command["command"]>,
   noun: "thread" | "reply",
@@ -199,7 +191,7 @@ function addCommentReactionCommands(
           ReactionOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
         const result = await createDiscussionCommentReaction(ctx.gql, {
           commentId,
           target: noun,
@@ -223,7 +215,7 @@ function addCommentReactionCommands(
           ReactionOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
         const result = await deleteDiscussionCommentReactionByEmoji(ctx.gql, {
           commentId,
           target: noun,
@@ -248,7 +240,7 @@ function addCommentReactionCommands(
           unknown,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
         const result = await deleteDiscussionCommentReactionById(ctx.gql, {
           commentId,
           target: noun,
@@ -468,7 +460,7 @@ export function setupIssuesCommands(program: Command): void {
   ).action(
     handleCommand(async (...args: unknown[]) => {
       const [options, command] = args as [FilterOptions, Command];
-      const ctx = createContext(command.parent!.parent!.opts());
+      const ctx = createContext(getRootOpts(command));
 
       const paginationOptions = {
         limit: parseLimit(options.limit),
@@ -507,7 +499,7 @@ export function setupIssuesCommands(program: Command): void {
         FilterOptions,
         Command,
       ];
-      const ctx = createContext(command.parent!.parent!.opts());
+      const ctx = createContext(getRootOpts(command));
 
       const paginationOptions = {
         limit: parseLimit(options.limit),
@@ -548,7 +540,7 @@ export function setupIssuesCommands(program: Command): void {
           Command,
         ];
         validateReadOptions(options);
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         if (options.withAttachments) {
           if (isUuid(issue)) {
@@ -645,7 +637,7 @@ export function setupIssuesCommands(program: Command): void {
           ReactionOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const issueId = await resolveIssueId(ctx.sdk, issue);
         const result = await createReactionForIssue(ctx.gql, {
           issueId,
@@ -672,7 +664,7 @@ export function setupIssuesCommands(program: Command): void {
           ReactionOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const issueId = await resolveIssueId(ctx.sdk, issue);
         const result = await deleteOwnReactionByEmoji(ctx.gql, {
           kind: "issue",
@@ -699,7 +691,7 @@ export function setupIssuesCommands(program: Command): void {
           unknown,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const issueId = await resolveIssueId(ctx.sdk, issue);
         const result = await deleteOwnReactionById(ctx.gql, {
           kind: "issue",
@@ -726,7 +718,7 @@ export function setupIssuesCommands(program: Command): void {
           DiscussionBodyOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         if (!options.body) {
           throw invalidParameterError("--body", "is required");
@@ -759,7 +751,7 @@ export function setupIssuesCommands(program: Command): void {
           DiscussionsOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const issueId = await resolveIssueId(ctx.sdk, issue);
         const paginationOptions = {
@@ -796,7 +788,7 @@ export function setupIssuesCommands(program: Command): void {
           DiscussionsOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const paginationOptions = {
           limit: parseLimit(options.limit || "50"),
@@ -836,7 +828,7 @@ export function setupIssuesCommands(program: Command): void {
           DiscussionBodyOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         if (!options.body) {
           throw invalidParameterError("--body", "is required");
@@ -863,7 +855,7 @@ export function setupIssuesCommands(program: Command): void {
           DiscussionBodyOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         if (!options.body) {
           throw invalidParameterError("--body", "is required");
@@ -893,7 +885,7 @@ export function setupIssuesCommands(program: Command): void {
           DiscussionBodyOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         if (!options.body) {
           throw invalidParameterError("--body", "is required");
@@ -918,7 +910,7 @@ export function setupIssuesCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [comment, , command] = args as [string, unknown, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const result = await deleteDiscussionComment(ctx.gql, comment, "issue");
 
@@ -932,7 +924,7 @@ export function setupIssuesCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [reply, , command] = args as [string, unknown, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const result = await deleteDiscussionReply(ctx.gql, reply, "issue");
 
@@ -951,7 +943,7 @@ export function setupIssuesCommands(program: Command): void {
           ResolveDiscussionOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const result = await resolveDiscussion(ctx.gql, {
           threadId: thread,
@@ -969,7 +961,7 @@ export function setupIssuesCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [thread, , command] = args as [string, unknown, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const result = await unresolveDiscussion(ctx.gql, thread, "issue");
 
@@ -1003,7 +995,7 @@ export function setupIssuesCommands(program: Command): void {
           CreateOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const relationActions = parseRelationFlags(options);
 
@@ -1214,7 +1206,7 @@ export function setupIssuesCommands(program: Command): void {
 
         const relationActions = parseRelationFlags(options);
 
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const issueEstimateContext =
           parsedEstimate !== undefined
@@ -1359,7 +1351,7 @@ export function setupIssuesCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [issue, , command] = args as [string, unknown, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const issueId = await resolveIssueId(ctx.sdk, issue);
         const result = await archiveIssue(ctx.gql, issueId);
         outputSuccess(result);
@@ -1372,7 +1364,7 @@ export function setupIssuesCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [issue, , command] = args as [string, unknown, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const issueId = await resolveIssueId(ctx.sdk, issue);
         const result = await unarchiveIssue(ctx.gql, issueId);
         outputSuccess(result);
@@ -1385,7 +1377,7 @@ export function setupIssuesCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [issue, , command] = args as [string, unknown, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const issueId = await resolveIssueId(ctx.sdk, issue);
         const result = await deleteIssue(ctx.gql, issueId);
         outputSuccess(result);

--- a/src/commands/labels.ts
+++ b/src/commands/labels.ts
@@ -1,5 +1,9 @@
 import type { Command } from "commander";
-import { type CommandOptions, createContext } from "../common/context.js";
+import {
+  type CommandOptions,
+  createContext,
+  getRootOpts,
+} from "../common/context.js";
 import { invalidParameterError } from "../common/errors.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
@@ -71,7 +75,7 @@ export function setupLabelsCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [options, command] = args as [ListLabelsOptions, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const type = parseLabelType(options.type);
         const scope = parseLabelScope(options.scope);
         const pagination = {

--- a/src/commands/milestones.ts
+++ b/src/commands/milestones.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { createContext } from "../common/context.js";
+import { createContext, getRootOpts } from "../common/context.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import type { ProjectMilestoneUpdateInput } from "../gql/graphql.js";
@@ -72,7 +72,7 @@ export function setupMilestonesCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [options, command] = args as [MilestoneListOptions, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         // Resolve project ID
         const projectId = await resolveProjectId(ctx.sdk, options.project);
@@ -99,7 +99,7 @@ export function setupMilestonesCommands(program: Command): void {
           MilestoneReadOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const milestoneId = await resolveMilestoneId(
           ctx.gql,
@@ -132,7 +132,7 @@ export function setupMilestonesCommands(program: Command): void {
           MilestoneCreateOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         // Resolve project ID
         const projectId = await resolveProjectId(ctx.sdk, options.project);
@@ -167,7 +167,7 @@ export function setupMilestonesCommands(program: Command): void {
           MilestoneUpdateOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const milestoneId = await resolveMilestoneId(
           ctx.gql,

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { createContext } from "../common/context.js";
+import { createContext, getRootOpts } from "../common/context.js";
 import { resolveReactionEmojiInput } from "../common/emoji.js";
 import { invalidParameterError } from "../common/errors.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
@@ -62,14 +62,6 @@ interface ReactionOptions {
   shortcode?: string;
 }
 
-function rootOptions(command: Command): Record<string, unknown> {
-  let current: Command = command;
-  while (current.parent) {
-    current = current.parent;
-  }
-  return current.opts();
-}
-
 function addCommentReactionCommands(
   parent: ReturnType<Command["command"]>,
   noun: "thread" | "reply",
@@ -86,7 +78,7 @@ function addCommentReactionCommands(
           ReactionOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
         const result = await createDiscussionCommentReaction(ctx.gql, {
           commentId,
           target: noun,
@@ -109,7 +101,7 @@ function addCommentReactionCommands(
           ReactionOptions,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
         const result = await deleteDiscussionCommentReactionByEmoji(ctx.gql, {
           commentId,
           target: noun,
@@ -133,7 +125,7 @@ function addCommentReactionCommands(
           unknown,
           Command,
         ];
-        const ctx = createContext(rootOptions(command));
+        const ctx = createContext(getRootOpts(command));
         const result = await deleteDiscussionCommentReactionById(ctx.gql, {
           commentId,
           target: noun,
@@ -216,7 +208,7 @@ export function setupProjectsCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [options, command] = args as [ListOptions, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const result = await listProjects(ctx.gql, {
           limit: parseLimit(options.limit),
           after: options.after,
@@ -231,7 +223,7 @@ export function setupProjectsCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [project, , command] = args as [string, unknown, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const projectId = await resolveProjectId(ctx.sdk, project);
         const result = await getProject(ctx.gql, projectId);
         outputSuccess(result);
@@ -249,7 +241,7 @@ export function setupProjectsCommands(program: Command): void {
           DiscussionBodyOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         if (!options.body) {
           throw invalidParameterError("--body", "is required");
@@ -278,7 +270,7 @@ export function setupProjectsCommands(program: Command): void {
           DiscussionsOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const projectId = await resolveProjectId(ctx.sdk, project);
         const paginationOptions = {
@@ -319,7 +311,7 @@ export function setupProjectsCommands(program: Command): void {
           DiscussionsOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const paginationOptions = {
           limit: parseLimit(options.limit || "50"),
@@ -359,7 +351,7 @@ export function setupProjectsCommands(program: Command): void {
           DiscussionBodyOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         if (!options.body) {
           throw invalidParameterError("--body", "is required");
@@ -386,7 +378,7 @@ export function setupProjectsCommands(program: Command): void {
           DiscussionBodyOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         if (!options.body) {
           throw invalidParameterError("--body", "is required");
@@ -416,7 +408,7 @@ export function setupProjectsCommands(program: Command): void {
           DiscussionBodyOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         if (!options.body) {
           throw invalidParameterError("--body", "is required");
@@ -441,7 +433,7 @@ export function setupProjectsCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [comment, , command] = args as [string, unknown, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const result = await deleteDiscussionComment(
           ctx.gql,
@@ -459,7 +451,7 @@ export function setupProjectsCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [reply, , command] = args as [string, unknown, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const result = await deleteDiscussionReply(ctx.gql, reply, "project");
 
@@ -478,7 +470,7 @@ export function setupProjectsCommands(program: Command): void {
           ResolveDiscussionOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const result = await resolveDiscussion(ctx.gql, {
           threadId: thread,
@@ -496,7 +488,7 @@ export function setupProjectsCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [thread, , command] = args as [string, unknown, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const result = await unresolveDiscussion(ctx.gql, thread, "project");
 
@@ -524,7 +516,7 @@ export function setupProjectsCommands(program: Command): void {
           CreateOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const teamNames = options.teams
           .split(",")
@@ -614,7 +606,7 @@ export function setupProjectsCommands(program: Command): void {
           UpdateOptions,
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
 
         const projectId = await resolveProjectId(ctx.sdk, project);
 
@@ -701,7 +693,7 @@ export function setupProjectsCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [project, , command] = args as [string, unknown, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const projectId = await resolveProjectId(ctx.sdk, project);
         const result = await archiveProject(ctx.gql, projectId);
         outputSuccess(result);
@@ -714,7 +706,7 @@ export function setupProjectsCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [project, , command] = args as [string, unknown, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const projectId = await resolveProjectId(ctx.sdk, project, {
           includeArchived: true,
         });
@@ -729,7 +721,7 @@ export function setupProjectsCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [project, , command] = args as [string, unknown, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const projectId = await resolveProjectId(ctx.sdk, project, {
           includeArchived: true,
         });

--- a/src/commands/teams.ts
+++ b/src/commands/teams.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import { createContext } from "../common/context.js";
+import { createContext, getRootOpts } from "../common/context.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import { resolveTeamId } from "../resolvers/team-resolver.js";
@@ -32,7 +32,7 @@ export function setupTeamsCommands(program: Command): void {
           { limit: string; after?: string },
           Command,
         ];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const result = await listTeams(ctx.gql, {
           limit: parseLimit(options.limit),
           after: options.after,
@@ -48,7 +48,7 @@ export function setupTeamsCommands(program: Command): void {
       handleCommand(async (...args: unknown[]) => {
         const team = args[0] as string;
         const command = args.at(-1) as Command;
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const teamId = await resolveTeamId(ctx.sdk, team);
         const result = await getTeam(ctx.gql, { id: teamId });
         outputSuccess(result);

--- a/src/commands/users.ts
+++ b/src/commands/users.ts
@@ -1,5 +1,9 @@
 import type { Command } from "commander";
-import { type CommandOptions, createContext } from "../common/context.js";
+import {
+  type CommandOptions,
+  createContext,
+  getRootOpts,
+} from "../common/context.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import { listUsers } from "../services/user-service.js";
@@ -35,7 +39,7 @@ export function setupUsersCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [options, command] = args as [ListUsersOptions, Command];
-        const ctx = createContext(command.parent!.parent!.opts());
+        const ctx = createContext(getRootOpts(command));
         const result = await listUsers(ctx.gql, options.active || false, {
           limit: parseLimit(options.limit),
           after: options.after,

--- a/src/common/context.ts
+++ b/src/common/context.ts
@@ -1,3 +1,4 @@
+import type { Command } from "commander";
 import { GraphQLClient } from "../client/graphql-client.js";
 import { LinearSdkClient } from "../client/linear-client.js";
 import { type CommandOptions, getApiToken } from "./auth.js";
@@ -19,4 +20,14 @@ export function createContext(options: CommandOptions): CommandContext {
 
 export function createGraphQLClient(token: string): GraphQLClient {
   return new GraphQLClient(token);
+}
+
+export function getRootOpts(command: Command): CommandOptions {
+  let current: Command = command;
+
+  while (current.parent) {
+    current = current.parent;
+  }
+
+  return current.opts() as CommandOptions;
 }

--- a/tests/unit/commands/attachments.test.ts
+++ b/tests/unit/commands/attachments.test.ts
@@ -6,6 +6,7 @@ vi.mock("../../../src/common/context.js", () => ({
     gql: { request: vi.fn() },
     sdk: {},
   })),
+  getRootOpts: vi.fn(() => ({ apiToken: "test-token" })),
 }));
 
 vi.mock("../../../src/common/output.js", async (importOriginal) => {

--- a/tests/unit/commands/auth.test.ts
+++ b/tests/unit/commands/auth.test.ts
@@ -24,6 +24,7 @@ vi.mock("../../../src/services/auth-service.js", () => ({
 
 vi.mock("../../../src/common/context.js", () => ({
   createGraphQLClient: vi.fn(() => ({})),
+  getRootOpts: vi.fn(() => ({ apiToken: "test-token" })),
 }));
 
 vi.mock("../../../src/common/auth.js", async (importOriginal) => {

--- a/tests/unit/commands/comments.test.ts
+++ b/tests/unit/commands/comments.test.ts
@@ -6,6 +6,7 @@ vi.mock("../../../src/common/context.js", () => ({
     gql: { request: vi.fn() },
     sdk: { sdk: {} },
   })),
+  getRootOpts: vi.fn(() => ({ apiToken: "test-token" })),
 }));
 
 vi.mock("../../../src/common/output.js", async (importOriginal) => {

--- a/tests/unit/commands/initiatives.test.ts
+++ b/tests/unit/commands/initiatives.test.ts
@@ -6,6 +6,7 @@ vi.mock("../../../src/common/context.js", () => ({
     gql: { request: vi.fn() },
     sdk: { sdk: {} },
   })),
+  getRootOpts: vi.fn(() => ({ apiToken: "test-token" })),
 }));
 
 vi.mock("../../../src/common/output.js", async (importOriginal) => {
@@ -167,6 +168,7 @@ vi.mock("../../../src/services/discussion-service.js", () => ({
 }));
 
 import { setupInitiativesCommands } from "../../../src/commands/initiatives/index.js";
+import { getRootOpts } from "../../../src/common/context.js";
 import { outputSuccess } from "../../../src/common/output.js";
 import { resolveInitiativeId } from "../../../src/resolvers/initiative-resolver.js";
 import { resolveProjectId } from "../../../src/resolvers/project-resolver.js";
@@ -892,6 +894,24 @@ describe("initiative discussion commands", () => {
       "initiative",
     );
     expect(outputSuccess).toHaveBeenCalledWith({ id: "discussion-root-1" });
+  });
+
+  it("initiatives threads react reads options from the root command", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "--api-token",
+      "root-token",
+      "initiatives",
+      "threads",
+      "react",
+      "thread-1",
+      "👍",
+    ]);
+
+    expect(getRootOpts).toHaveBeenCalledWith(expect.any(Command));
   });
 
   it("initiatives threads react delegates to comment reaction service", async () => {

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -8,6 +8,7 @@ vi.mock("../../../src/common/context.js", () => ({
     gql: { request: vi.fn() },
     sdk: { sdk: {} },
   })),
+  getRootOpts: vi.fn(() => ({ apiToken: "test-token" })),
 }));
 
 vi.mock("../../../src/common/output.js", async (importOriginal) => {

--- a/tests/unit/commands/labels.test.ts
+++ b/tests/unit/commands/labels.test.ts
@@ -6,6 +6,7 @@ vi.mock("../../../src/common/context.js", () => ({
     gql: { request: vi.fn() },
     sdk: { sdk: {} },
   })),
+  getRootOpts: vi.fn(() => ({ apiToken: "test-token" })),
 }));
 
 vi.mock("../../../src/common/output.js", async (importOriginal) => {

--- a/tests/unit/commands/projects.test.ts
+++ b/tests/unit/commands/projects.test.ts
@@ -6,6 +6,7 @@ vi.mock("../../../src/common/context.js", () => ({
     gql: { request: vi.fn() },
     sdk: { sdk: {} },
   })),
+  getRootOpts: vi.fn(() => ({ apiToken: "test-token" })),
 }));
 
 vi.mock("../../../src/common/output.js", async (importOriginal) => {

--- a/tests/unit/commands/teams.test.ts
+++ b/tests/unit/commands/teams.test.ts
@@ -6,6 +6,7 @@ vi.mock("../../../src/common/context.js", () => ({
     gql: { request: vi.fn() },
     sdk: { sdk: {} },
   })),
+  getRootOpts: vi.fn(() => ({ apiToken: "test-token" })),
 }));
 
 vi.mock("../../../src/common/output.js", async (importOriginal) => {

--- a/tests/unit/common/context.test.ts
+++ b/tests/unit/common/context.test.ts
@@ -1,0 +1,35 @@
+import { Command } from "commander";
+import { describe, expect, it } from "vitest";
+import { getRootOpts } from "../../../src/common/context.js";
+
+describe("getRootOpts", () => {
+  it("returns root options for nested commands", () => {
+    const root = new Command();
+    root.option("--api-token <token>");
+    root.option("--json");
+
+    const child = root.command("issues");
+    const grandchild = child.command("list");
+
+    root.parse(["--api-token", "token-123", "--json", "issues", "list"], {
+      from: "user",
+    });
+
+    expect(getRootOpts(grandchild)).toEqual(
+      expect.objectContaining({ apiToken: "token-123", json: true }),
+    );
+  });
+
+  it("returns the command's own options when already at root", () => {
+    const root = new Command();
+    root.option("--api-token <token>");
+
+    root.parse(["--api-token", "root-token"], {
+      from: "user",
+    });
+
+    expect(getRootOpts(root)).toEqual(
+      expect.objectContaining({ apiToken: "root-token" }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- add `getRootOpts(command)` in `src/common/context.ts`
- replace fragile `command.parent!.parent!.opts()` lookups across command files
- add a focused unit test and update affected command-test mocks

## Verification
- `npm run check:ci`
- `npm run generate`
- `npx tsc --noEmit`
- `npx tsc`

Closes #61
