### PR TITLE
feat: add reaction support

### DIFF
--- a/graphql/mutations/reactions.graphql
+++ b/graphql/mutations/reactions.graphql
@@ -1,0 +1,35 @@
+fragment ReactionMutationFields on Reaction {
+  id
+  emoji
+  user {
+    id
+    displayName
+  }
+  externalUser {
+    id
+    name
+  }
+}
+
+mutation CreateReaction($input: ReactionCreateInput!) {
+  reactionCreate(input: $input) {
+    success
+    reaction {
+      ...ReactionMutationFields
+      issue {
+        id
+      }
+      comment {
+        id
+        parentId
+      }
+    }
+  }
+}
+
+mutation DeleteReaction($id: String!) {
+  reactionDelete(id: $id) {
+    success
+    entityId
+  }
+}

--- a/graphql/queries/discussions.graphql
+++ b/graphql/queries/discussions.graphql
@@ -18,6 +18,13 @@ fragment DiscussionCommentFields on Comment {
   }
 }
 
+fragment DiscussionCommentFieldsWithReactions on Comment {
+  ...DiscussionCommentFields
+  reactions {
+    ...ReactionReadFields
+  }
+}
+
 query GetDiscussionCommentContext($id: String!) {
   comment(id: $id) {
     ...DiscussionCommentFields
@@ -41,6 +48,24 @@ query ListIssueDiscussionRoots($issueId: String!, $first: Int, $after: String) {
   }
 }
 
+query ListIssueDiscussionRootsWithReactions(
+  $issueId: String!
+  $first: Int
+  $after: String
+) {
+  issue(id: $issueId) {
+    comments(first: $first, after: $after, filter: { parent: { null: true } }) {
+      nodes {
+        ...DiscussionCommentFieldsWithReactions
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}
+
 query ListProjectDiscussionRoots(
   $projectId: String!
   $first: Int
@@ -50,6 +75,24 @@ query ListProjectDiscussionRoots(
     comments(first: $first, after: $after, filter: { parent: { null: true } }) {
       nodes {
         ...DiscussionCommentFields
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}
+
+query ListProjectDiscussionRootsWithReactions(
+  $projectId: String!
+  $first: Int
+  $after: String
+) {
+  project(id: $projectId) {
+    comments(first: $first, after: $after, filter: { parent: { null: true } }) {
+      nodes {
+        ...DiscussionCommentFieldsWithReactions
       }
       pageInfo {
         hasNextPage
@@ -86,6 +129,33 @@ query ListInitiativeDiscussionRoots(
   }
 }
 
+query ListInitiativeDiscussionRootsWithReactions(
+  $initiativeId: ID!
+  $initiativeLookupId: String!
+  $first: Int
+  $after: String
+) {
+  initiative: initiative(id: $initiativeLookupId) {
+    id
+  }
+  comments(
+    first: $first
+    after: $after
+    filter: {
+      initiative: { id: { eq: $initiativeId } }
+      parent: { null: true }
+    }
+  ) {
+    nodes {
+      ...DiscussionCommentFieldsWithReactions
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+
 query ListIssueDiscussionReplyCandidates(
   $issueId: ID!
   $first: Int
@@ -99,6 +169,27 @@ query ListIssueDiscussionReplyCandidates(
   ) {
     nodes {
       ...DiscussionCommentFields
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+
+query ListIssueDiscussionReplyCandidatesWithReactions(
+  $issueId: ID!
+  $first: Int
+  $after: String
+) {
+  comments(
+    first: $first
+    after: $after
+    orderBy: createdAt
+    filter: { issue: { id: { eq: $issueId } }, parent: { null: false } }
+  ) {
+    nodes {
+      ...DiscussionCommentFieldsWithReactions
     }
     pageInfo {
       hasNextPage
@@ -128,6 +219,27 @@ query ListProjectDiscussionReplyCandidates(
   }
 }
 
+query ListProjectDiscussionReplyCandidatesWithReactions(
+  $projectId: ID!
+  $first: Int
+  $after: String
+) {
+  comments(
+    first: $first
+    after: $after
+    orderBy: createdAt
+    filter: { project: { id: { eq: $projectId } }, parent: { null: false } }
+  ) {
+    nodes {
+      ...DiscussionCommentFieldsWithReactions
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+
 query ListInitiativeDiscussionReplyCandidates(
   $initiativeId: ID!
   $first: Int
@@ -144,6 +256,30 @@ query ListInitiativeDiscussionReplyCandidates(
   ) {
     nodes {
       ...DiscussionCommentFields
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+
+query ListInitiativeDiscussionReplyCandidatesWithReactions(
+  $initiativeId: ID!
+  $first: Int
+  $after: String
+) {
+  comments(
+    first: $first
+    after: $after
+    orderBy: createdAt
+    filter: {
+      initiative: { id: { eq: $initiativeId } }
+      parent: { null: false }
+    }
+  ) {
+    nodes {
+      ...DiscussionCommentFieldsWithReactions
     }
     pageInfo {
       hasNextPage

--- a/graphql/queries/issues.graphql
+++ b/graphql/queries/issues.graphql
@@ -136,6 +136,14 @@ fragment CompleteIssueWithCommentsFields on Issue {
   }
 }
 
+# Complete issue fragment with all relationships, default comments, and reactions
+fragment CompleteIssueWithReactionsFields on Issue {
+  ...CompleteIssueWithDefaultCommentsFields
+  reactions {
+    ...ReactionReadFields
+  }
+}
+
 # Complete issue search fragment with all relationships
 #
 # Combines all issue fragments into a comprehensive field selection.
@@ -281,6 +289,25 @@ query GetIssueByIdentifierWithComments($teamKey: String!, $number: Float!) {
   ) {
     nodes {
       ...CompleteIssueWithCommentsFields
+    }
+  }
+}
+
+# Get single issue by UUID with root reactions
+query GetIssueByIdWithReactions($id: String!) {
+  issue(id: $id) {
+    ...CompleteIssueWithReactionsFields
+  }
+}
+
+# Get issue by identifier with root reactions
+query GetIssueByIdentifierWithReactions($teamKey: String!, $number: Float!) {
+  issues(
+    filter: { team: { key: { eq: $teamKey } }, number: { eq: $number } }
+    first: 1
+  ) {
+    nodes {
+      ...CompleteIssueWithReactionsFields
     }
   }
 }

--- a/graphql/queries/projects.graphql
+++ b/graphql/queries/projects.graphql
@@ -110,6 +110,26 @@ query GetProjects($first: Int = 50, $after: String) {
   }
 }
 
+# Project detail fields for opt-in reaction-aware reads
+#
+# Root project reactions are intentionally unsupported by the current schema.
+# Keep the opt-in variant explicit for callers without changing the core
+# project contract. Only paginated root discussion comments are included here
+# with reactions and pageInfo. Replies are intentionally excluded and must be
+# fetched via the dedicated project discussion queries.
+fragment ProjectDetailFieldsWithReactions on Project {
+  ...ProjectDetailFields
+  comments(first: $first, after: $after, filter: { parent: { null: true } }) {
+    nodes {
+      ...DiscussionCommentFieldsWithReactions
+    }
+    pageInfo {
+      hasNextPage
+      endCursor
+    }
+  }
+}
+
 # Get a single project by ID
 #
 # Fetches complete project details including content, members,
@@ -120,6 +140,16 @@ query GetProjects($first: Int = 50, $after: String) {
 query GetProject($id: String!) {
   project(id: $id) {
     ...ProjectDetailFields
+  }
+}
+
+# Get a single project by ID for opt-in reaction-aware reads
+#
+# Includes only paginated root discussion comments with reactions. Replies are
+# intentionally excluded here and must come from dedicated discussion queries.
+query GetProjectWithReactions($id: String!, $first: Int, $after: String) {
+  project(id: $id) {
+    ...ProjectDetailFieldsWithReactions
   }
 }
 

--- a/graphql/queries/reactions.graphql
+++ b/graphql/queries/reactions.graphql
@@ -1,0 +1,35 @@
+# Root project and initiative reactions are intentionally omitted.
+# Current generated schema exposes ReactionCreateInput.issueId and commentId,
+# but not projectId or initiativeId for root entity reactions.
+
+fragment ReactionReadFields on Reaction {
+  id
+  emoji
+  user {
+    id
+    displayName
+  }
+  externalUser {
+    id
+    name
+  }
+}
+
+query GetIssueReactions($id: String!) {
+  issue(id: $id) {
+    id
+    reactions {
+      ...ReactionReadFields
+    }
+  }
+}
+
+query GetCommentReactions($id: String!) {
+  comment(id: $id) {
+    id
+    parentId
+    reactions {
+      ...ReactionReadFields
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "MIT",
       "dependencies": {
         "@linear/sdk": "82.1.0",
-        "commander": "14.0.3"
+        "commander": "14.0.3",
+        "node-emoji": "2.2.0"
       },
       "bin": {
         "linear": "dist/main.js",
@@ -3962,7 +3963,6 @@
       "version": "4.6.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-4.6.0.tgz",
       "integrity": "sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -4652,7 +4652,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/char-regex/-/char-regex-1.0.2.tgz",
       "integrity": "sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=10"
@@ -5337,7 +5336,6 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/emojilib/-/emojilib-2.4.0.tgz",
       "integrity": "sha512-5U0rVMU5Y2n2+ykNLQqMoqklN9ICBT/KsvC1Gz6vqHbz2AXXGkG+Pm5rMWk/8Vjrr/mY9985Hi8DYzn1F09Nyw==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/env-ci": {
@@ -8053,7 +8051,6 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/node-emoji/-/node-emoji-2.2.0.tgz",
       "integrity": "sha512-Z3lTE9pLaJF47NyMhd4ww1yFTAP8YhYI8SleJiHzM46Fgpm5cnNzSl9XfzFNqbaz+VlJrIj3fXQ4DeN1Rjm6cw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@sindresorhus/is": "^4.6.0",
@@ -11482,7 +11479,6 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/skin-tone/-/skin-tone-2.0.0.tgz",
       "integrity": "sha512-kUMbT1oBJCpgrnKoSr0o6wPtvRWT9W9UKvGLwfJYO2WuahZRHOpEyL1ckyMGgMWh0UdpmaoFqKKD29WTomNEGA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "unicode-emoji-modifier-base": "^1.0.0"
@@ -12180,7 +12176,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unicode-emoji-modifier-base/-/unicode-emoji-modifier-base-1.0.0.tgz",
       "integrity": "sha512-yLSH4py7oFH3oG/9K+XWrz1pSi3dfUrWEnInbxMfArOfc1+33BlGPQtLsOYwvdMy11AwUBetYuaRxSPqgkq+8g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=4"

--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
   "homepage": "https://github.com/linearis-oss/linearis#readme",
   "dependencies": {
     "@linear/sdk": "82.1.0",
-    "commander": "14.0.3"
+    "commander": "14.0.3",
+    "node-emoji": "2.2.0"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.14",

--- a/src/commands/comments.ts
+++ b/src/commands/comments.ts
@@ -1,11 +1,15 @@
 import type { Command } from "commander";
 import { type CommandOptions, createContext } from "../common/context.js";
+import { resolveReactionEmojiInput } from "../common/emoji.js";
 import { invalidParameterError } from "../common/errors.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import { resolveIssueId } from "../resolvers/issue-resolver.js";
 import {
+  createIssueDiscussionCommentReaction,
   deleteDiscussionComment,
+  deleteIssueDiscussionCommentReactionByEmoji,
+  deleteIssueDiscussionCommentReactionById,
   editDiscussionComment,
   listDiscussionsForIssue,
   replyToDiscussion,
@@ -27,6 +31,10 @@ interface ReplyCommentOptions extends CommandOptions {
 
 interface EditCommentOptions extends CommandOptions {
   body?: string;
+}
+
+interface ReactionOptions extends CommandOptions {
+  shortcode?: string;
 }
 
 export const COMMENTS_META: DomainMeta = {
@@ -205,6 +213,95 @@ export function setupCommentsCommands(program: Command): void {
         const ctx = createContext(command.parent!.parent!.opts());
 
         const result = await deleteDiscussionComment(ctx.gql, comment);
+
+        outputSuccess(result);
+      }),
+    );
+
+  comments
+    .command("react <comment> [emoji]")
+    .description(
+      "DEPRECATED compatibility command. Prefer: `issues threads react <thread>` or `issues replies react <reply>`.",
+    )
+    .addHelpText(
+      "after",
+      "\nDEPRECATED compatibility command. Prefer: `issues threads react <thread>` or `issues replies react <reply>`.",
+    )
+    .option("--shortcode <name>", "emoji shortcode (e.g. thumbs_up)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [comment, emoji, options, command] = args as [
+          string,
+          string | undefined,
+          ReactionOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        const result = await createIssueDiscussionCommentReaction(ctx.gql, {
+          commentId: comment,
+          emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  comments
+    .command("unreact <comment> [emoji]")
+    .description(
+      "DEPRECATED compatibility command. Prefer: `issues threads unreact <thread>` or `issues replies unreact <reply>`.",
+    )
+    .addHelpText(
+      "after",
+      "\nDEPRECATED compatibility command. Prefer: `issues threads unreact <thread>` or `issues replies unreact <reply>`.",
+    )
+    .option("--shortcode <name>", "emoji shortcode (e.g. thumbs_up)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [comment, emoji, options, command] = args as [
+          string,
+          string | undefined,
+          ReactionOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        const result = await deleteIssueDiscussionCommentReactionByEmoji(
+          ctx.gql,
+          {
+            commentId: comment,
+            emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+          },
+        );
+
+        outputSuccess(result);
+      }),
+    );
+
+  comments
+    .command("unreact-id <comment> <reactionId>")
+    .description(
+      "DEPRECATED compatibility command. Prefer: `issues threads unreact-id <thread> <reactionId>` or `issues replies unreact-id <reply> <reactionId>`.",
+    )
+    .addHelpText(
+      "after",
+      "\nDEPRECATED compatibility command. Prefer: `issues threads unreact-id <thread> <reactionId>` or `issues replies unreact-id <reply> <reactionId>`.",
+    )
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [comment, reactionId, , command] = args as [
+          string,
+          string,
+          unknown,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+
+        const result = await deleteIssueDiscussionCommentReactionById(ctx.gql, {
+          commentId: comment,
+          reactionId,
+        });
 
         outputSuccess(result);
       }),

--- a/src/commands/initiatives/entity.ts
+++ b/src/commands/initiatives/entity.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import type { LinearSdkClient } from "../../client/linear-client.js";
 import { createContext } from "../../common/context.js";
+import { resolveReactionEmojiInput } from "../../common/emoji.js";
 import { invalidParameterError } from "../../common/errors.js";
 import {
   handleCommand,
@@ -21,12 +22,17 @@ import { resolveInitiativeId } from "../../resolvers/initiative-resolver.js";
 import { resolveTeamId } from "../../resolvers/team-resolver.js";
 import { resolveUserId } from "../../resolvers/user-resolver.js";
 import {
+  createDiscussionCommentReaction,
   deleteDiscussionComment,
+  deleteDiscussionCommentReactionByEmoji,
+  deleteDiscussionCommentReactionById,
   deleteDiscussionReply,
   editDiscussionComment,
   editDiscussionReply,
   listDiscussionReplies,
+  listDiscussionRepliesWithReactions,
   listDiscussionsForInitiative,
+  listDiscussionsForInitiativeWithReactions,
   replyToDiscussion,
   resolveDiscussion,
   startInitiativeDiscussion,
@@ -86,6 +92,7 @@ interface InitiativeReadOptions extends InitiativeExpandOptions {}
 interface DiscussionsOptions {
   limit?: string;
   after?: string;
+  withReactions?: boolean;
 }
 
 interface DiscussionBodyOptions {
@@ -94,6 +101,85 @@ interface DiscussionBodyOptions {
 
 interface ResolveDiscussionOptions {
   withComment?: string;
+}
+
+interface ReactionOptions {
+  shortcode?: string;
+}
+
+function addCommentReactionCommands(
+  parent: ReturnType<Command["command"]>,
+  noun: "thread" | "reply",
+): void {
+  parent
+    .command(`react <${noun}> [emoji]`)
+    .description(`add a reaction to a discussion ${noun}`)
+    .option("--shortcode <name>", "emoji shortcode (e.g. thumbs_up)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [commentId, emoji, options, command] = args as [
+          string,
+          string | undefined,
+          ReactionOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+        const result = await createDiscussionCommentReaction(ctx.gql, {
+          commentId,
+          target: noun,
+          expectedEntityKind: "initiative",
+          emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+        });
+        outputSuccess(result);
+      }),
+    );
+
+  parent
+    .command(`unreact <${noun}> [emoji]`)
+    .description(`remove your reaction from a discussion ${noun} by emoji`)
+    .option("--shortcode <name>", "emoji shortcode (e.g. thumbs_up)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [commentId, emoji, options, command] = args as [
+          string,
+          string | undefined,
+          ReactionOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+        const result = await deleteDiscussionCommentReactionByEmoji(ctx.gql, {
+          commentId,
+          target: noun,
+          expectedEntityKind: "initiative",
+          emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+        });
+        outputSuccess(result);
+      }),
+    );
+
+  parent
+    .command(`unreact-id <${noun}> <reactionId>`)
+    .description(
+      `remove your reaction from a discussion ${noun} by reaction ID`,
+    )
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [commentId, reactionId, , command] = args as [
+          string,
+          string,
+          unknown,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+        const result = await deleteDiscussionCommentReactionById(ctx.gql, {
+          commentId,
+          target: noun,
+          expectedEntityKind: "initiative",
+          reactionId,
+        });
+        outputSuccess(result);
+      }),
+    );
 }
 
 interface InitiativeCreateOptions {
@@ -519,6 +605,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .description("list root discussion threads on an initiative")
     .option("-l, --limit <n>", "max results", "25")
     .option("--after <cursor>", "cursor for next page")
+    .option("--with-reactions", "include normalized discussion reactions")
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [initiative, options, command] = args as [
@@ -529,24 +616,37 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
         const ctx = createContext(rootOptions(command));
 
         const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
-        const result = await listDiscussionsForInitiative(
-          ctx.gql,
-          initiativeId,
-          {
-            limit: parseLimit(options.limit || "25"),
-            after: options.after,
-          },
-        );
+        const paginationOptions = {
+          limit: parseLimit(options.limit || "25"),
+          after: options.after,
+        };
+        const result = options.withReactions
+          ? await listDiscussionsForInitiativeWithReactions(
+              ctx.gql,
+              initiativeId,
+              paginationOptions,
+            )
+          : await listDiscussionsForInitiative(
+              ctx.gql,
+              initiativeId,
+              paginationOptions,
+            );
 
         outputSuccess(result);
       }),
     );
 
-  initiatives
+  const initiativeThreads = initiatives
+    .command("threads")
+    .description("discussion thread reaction operations");
+  addCommentReactionCommands(initiativeThreads, "thread");
+
+  const initiativeReplies = initiatives
     .command("replies <thread>")
     .description("list replies in a root discussion thread")
     .option("-l, --limit <n>", "max results", "50")
     .option("--after <cursor>", "cursor for next page")
+    .option("--with-reactions", "include normalized discussion reactions")
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [thread, options, command] = args as [
@@ -556,19 +656,28 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
         ];
         const ctx = createContext(rootOptions(command));
 
-        const result = await listDiscussionReplies(
-          ctx.gql,
-          thread,
-          {
-            limit: parseLimit(options.limit || "50"),
-            after: options.after,
-          },
-          "initiative",
-        );
+        const paginationOptions = {
+          limit: parseLimit(options.limit || "50"),
+          after: options.after,
+        };
+        const result = options.withReactions
+          ? await listDiscussionRepliesWithReactions(
+              ctx.gql,
+              thread,
+              paginationOptions,
+              "initiative",
+            )
+          : await listDiscussionReplies(
+              ctx.gql,
+              thread,
+              paginationOptions,
+              "initiative",
+            );
 
         outputSuccess(result);
       }),
     );
+  addCommentReactionCommands(initiativeReplies, "reply");
 
   initiatives
     .command("reply <thread>")

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import type { CommandContext } from "../common/context.js";
 import { createContext } from "../common/context.js";
+import { resolveReactionEmojiInput } from "../common/emoji.js";
 import { invalidParameterError } from "../common/errors.js";
 import { validateEstimateAgainstTeamConfig } from "../common/estimate-validation.js";
 import {
@@ -36,12 +37,17 @@ import {
 } from "../resolvers/team-resolver.js";
 import { resolveUserId } from "../resolvers/user-resolver.js";
 import {
+  createDiscussionCommentReaction,
   deleteDiscussionComment,
+  deleteDiscussionCommentReactionByEmoji,
+  deleteDiscussionCommentReactionById,
   deleteDiscussionReply,
   editDiscussionComment,
   editDiscussionReply,
   listDiscussionReplies,
+  listDiscussionRepliesWithReactions,
   listDiscussionsForIssue,
+  listDiscussionsForIssueWithReactions,
   replyToDiscussion,
   resolveDiscussion,
   startIssueDiscussion,
@@ -62,14 +68,21 @@ import {
   getIssueByIdentifierWithAttachments,
   getIssueByIdentifierWithComments,
   getIssueByIdentifierWithCommentThreads,
+  getIssueByIdentifierWithReactions,
   getIssueWithAttachments,
   getIssueWithComments,
   getIssueWithCommentThreads,
+  getIssueWithReactions,
   listIssues,
   searchIssues,
   unarchiveIssue,
   updateIssue,
 } from "../services/issue-service.js";
+import {
+  createReactionForIssue,
+  deleteOwnReactionByEmoji,
+  deleteOwnReactionById,
+} from "../services/reaction-service.js";
 
 interface FilterOptions extends RawFilterFlags {
   limit: string;
@@ -127,11 +140,31 @@ interface ReadOptions {
   withAttachments?: boolean;
   withComments?: boolean;
   withCommentThreads?: boolean;
+  withReactions?: boolean;
+}
+
+function validateReadOptions(options: ReadOptions): void {
+  if (
+    options.withReactions &&
+    (options.withAttachments ||
+      options.withComments ||
+      options.withCommentThreads)
+  ) {
+    throw invalidParameterError(
+      "--with-reactions",
+      "cannot be combined with --with-attachments, --with-comments, or --with-comment-threads",
+    );
+  }
+}
+
+interface ReactionOptions {
+  shortcode?: string;
 }
 
 interface DiscussionsOptions {
   limit?: string;
   after?: string;
+  withReactions?: boolean;
 }
 
 interface DiscussionBodyOptions {
@@ -140,6 +173,92 @@ interface DiscussionBodyOptions {
 
 interface ResolveDiscussionOptions {
   withComment?: string;
+}
+
+function rootOptions(command: Command): Record<string, unknown> {
+  let current: Command = command;
+  while (current.parent) {
+    current = current.parent;
+  }
+  return current.opts();
+}
+
+function addCommentReactionCommands(
+  parent: ReturnType<Command["command"]>,
+  noun: "thread" | "reply",
+): void {
+  parent
+    .command(`react <${noun}> [emoji]`)
+    .description(`add a reaction to a discussion ${noun}`)
+    .option("--shortcode <name>", "emoji shortcode (e.g. thumbs_up)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [commentId, emoji, options, command] = args as [
+          string,
+          string | undefined,
+          ReactionOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+        const result = await createDiscussionCommentReaction(ctx.gql, {
+          commentId,
+          target: noun,
+          expectedEntityKind: "issue",
+          emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  parent
+    .command(`unreact <${noun}> [emoji]`)
+    .description(`remove your reaction from a discussion ${noun} by emoji`)
+    .option("--shortcode <name>", "emoji shortcode (e.g. thumbs_up)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [commentId, emoji, options, command] = args as [
+          string,
+          string | undefined,
+          ReactionOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+        const result = await deleteDiscussionCommentReactionByEmoji(ctx.gql, {
+          commentId,
+          target: noun,
+          expectedEntityKind: "issue",
+          emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  parent
+    .command(`unreact-id <${noun}> <reactionId>`)
+    .description(
+      `remove your reaction from a discussion ${noun} by reaction ID`,
+    )
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [commentId, reactionId, , command] = args as [
+          string,
+          string,
+          unknown,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+        const result = await deleteDiscussionCommentReactionById(ctx.gql, {
+          commentId,
+          target: noun,
+          expectedEntityKind: "issue",
+          reactionId,
+        });
+
+        outputSuccess(result);
+      }),
+    );
 }
 
 export const ISSUES_META: DomainMeta = {
@@ -416,6 +535,7 @@ export function setupIssuesCommands(program: Command): void {
       "--with-comment-threads",
       "group issue comments into root comments with replies",
     )
+    .option("--with-reactions", "include normalized root issue reactions")
     .addHelpText(
       "after",
       `\nWhen passing issue IDs, both UUID and identifiers like ABC-123 are supported.`,
@@ -427,6 +547,7 @@ export function setupIssuesCommands(program: Command): void {
           ReadOptions,
           Command,
         ];
+        validateReadOptions(options);
         const ctx = createContext(command.parent!.parent!.opts());
 
         if (options.withAttachments) {
@@ -477,6 +598,22 @@ export function setupIssuesCommands(program: Command): void {
           return;
         }
 
+        if (options.withReactions) {
+          if (isUuid(issue)) {
+            const result = await getIssueWithReactions(ctx.gql, issue);
+            outputSuccess(result);
+          } else {
+            const { teamKey, issueNumber } = parseIssueIdentifier(issue);
+            const result = await getIssueByIdentifierWithReactions(
+              ctx.gql,
+              teamKey,
+              issueNumber,
+            );
+            outputSuccess(result);
+          }
+          return;
+        }
+
         if (isUuid(issue)) {
           const result = await getIssue(ctx.gql, issue);
           outputSuccess(result);
@@ -489,6 +626,88 @@ export function setupIssuesCommands(program: Command): void {
           );
           outputSuccess(result);
         }
+      }),
+    );
+
+  issues
+    .command("react <issue> [emoji]")
+    .description("add a root reaction to an issue")
+    .option("--shortcode <name>", "emoji shortcode (e.g. thumbs_up)")
+    .addHelpText(
+      "after",
+      `\nWhen passing issue IDs, both UUID and identifiers like ABC-123 are supported.`,
+    )
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [issue, emoji, options, command] = args as [
+          string,
+          string | undefined,
+          ReactionOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+        const issueId = await resolveIssueId(ctx.sdk, issue);
+        const result = await createReactionForIssue(ctx.gql, {
+          issueId,
+          emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  issues
+    .command("unreact <issue> [emoji]")
+    .description("remove your root reaction from an issue by emoji")
+    .option("--shortcode <name>", "emoji shortcode (e.g. thumbs_up)")
+    .addHelpText(
+      "after",
+      `\nWhen passing issue IDs, both UUID and identifiers like ABC-123 are supported.`,
+    )
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [issue, emoji, options, command] = args as [
+          string,
+          string | undefined,
+          ReactionOptions,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+        const issueId = await resolveIssueId(ctx.sdk, issue);
+        const result = await deleteOwnReactionByEmoji(ctx.gql, {
+          kind: "issue",
+          id: issueId,
+          emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+        });
+
+        outputSuccess(result);
+      }),
+    );
+
+  issues
+    .command("unreact-id <issue> <reactionId>")
+    .description("remove your root reaction from an issue by reaction ID")
+    .addHelpText(
+      "after",
+      `\nWhen passing issue IDs, both UUID and identifiers like ABC-123 are supported.`,
+    )
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [issue, reactionId, , command] = args as [
+          string,
+          string,
+          unknown,
+          Command,
+        ];
+        const ctx = createContext(command.parent!.parent!.opts());
+        const issueId = await resolveIssueId(ctx.sdk, issue);
+        const result = await deleteOwnReactionById(ctx.gql, {
+          kind: "issue",
+          id: issueId,
+          reactionId,
+        });
+
+        outputSuccess(result);
       }),
     );
 
@@ -532,6 +751,7 @@ export function setupIssuesCommands(program: Command): void {
     )
     .option("-l, --limit <n>", "max results", "25")
     .option("--after <cursor>", "cursor for next page")
+    .option("--with-reactions", "include normalized discussion reactions")
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [issue, options, command] = args as [
@@ -542,20 +762,33 @@ export function setupIssuesCommands(program: Command): void {
         const ctx = createContext(command.parent!.parent!.opts());
 
         const issueId = await resolveIssueId(ctx.sdk, issue);
-        const result = await listDiscussionsForIssue(ctx.gql, issueId, {
+        const paginationOptions = {
           limit: parseLimit(options.limit || "25"),
           after: options.after,
-        });
+        };
+        const result = options.withReactions
+          ? await listDiscussionsForIssueWithReactions(
+              ctx.gql,
+              issueId,
+              paginationOptions,
+            )
+          : await listDiscussionsForIssue(ctx.gql, issueId, paginationOptions);
 
         outputSuccess(result);
       }),
     );
 
-  issues
+  const issueThreads = issues
+    .command("threads")
+    .description("discussion thread reaction operations");
+  addCommentReactionCommands(issueThreads, "thread");
+
+  const issueReplies = issues
     .command("replies <thread>")
     .description("list replies in a root discussion thread")
     .option("-l, --limit <n>", "max results", "50")
     .option("--after <cursor>", "cursor for next page")
+    .option("--with-reactions", "include normalized discussion reactions")
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [thread, options, command] = args as [
@@ -565,19 +798,28 @@ export function setupIssuesCommands(program: Command): void {
         ];
         const ctx = createContext(command.parent!.parent!.opts());
 
-        const result = await listDiscussionReplies(
-          ctx.gql,
-          thread,
-          {
-            limit: parseLimit(options.limit || "50"),
-            after: options.after,
-          },
-          "issue",
-        );
+        const paginationOptions = {
+          limit: parseLimit(options.limit || "50"),
+          after: options.after,
+        };
+        const result = options.withReactions
+          ? await listDiscussionRepliesWithReactions(
+              ctx.gql,
+              thread,
+              paginationOptions,
+              "issue",
+            )
+          : await listDiscussionReplies(
+              ctx.gql,
+              thread,
+              paginationOptions,
+              "issue",
+            );
 
         outputSuccess(result);
       }),
     );
+  addCommentReactionCommands(issueReplies, "reply");
 
   issues
     .command("reply <thread>")

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { createContext } from "../common/context.js";
+import { resolveReactionEmojiInput } from "../common/emoji.js";
 import { invalidParameterError } from "../common/errors.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
@@ -12,12 +13,17 @@ import { resolveProjectStatusId } from "../resolvers/project-status-resolver.js"
 import { resolveTeamId } from "../resolvers/team-resolver.js";
 import { resolveUserId } from "../resolvers/user-resolver.js";
 import {
+  createDiscussionCommentReaction,
   deleteDiscussionComment,
+  deleteDiscussionCommentReactionByEmoji,
+  deleteDiscussionCommentReactionById,
   deleteDiscussionReply,
   editDiscussionComment,
   editDiscussionReply,
   listDiscussionReplies,
+  listDiscussionRepliesWithReactions,
   listDiscussionsForProject,
+  listDiscussionsForProjectWithReactions,
   replyToDiscussion,
   resolveDiscussion,
   startProjectDiscussion,
@@ -41,6 +47,7 @@ interface ListOptions {
 interface DiscussionsOptions {
   limit?: string;
   after?: string;
+  withReactions?: boolean;
 }
 
 interface DiscussionBodyOptions {
@@ -49,6 +56,93 @@ interface DiscussionBodyOptions {
 
 interface ResolveDiscussionOptions {
   withComment?: string;
+}
+
+interface ReactionOptions {
+  shortcode?: string;
+}
+
+function rootOptions(command: Command): Record<string, unknown> {
+  let current: Command = command;
+  while (current.parent) {
+    current = current.parent;
+  }
+  return current.opts();
+}
+
+function addCommentReactionCommands(
+  parent: ReturnType<Command["command"]>,
+  noun: "thread" | "reply",
+): void {
+  parent
+    .command(`react <${noun}> [emoji]`)
+    .description(`add a reaction to a discussion ${noun}`)
+    .option("--shortcode <name>", "emoji shortcode (e.g. thumbs_up)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [commentId, emoji, options, command] = args as [
+          string,
+          string | undefined,
+          ReactionOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+        const result = await createDiscussionCommentReaction(ctx.gql, {
+          commentId,
+          target: noun,
+          expectedEntityKind: "project",
+          emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+        });
+        outputSuccess(result);
+      }),
+    );
+
+  parent
+    .command(`unreact <${noun}> [emoji]`)
+    .description(`remove your reaction from a discussion ${noun} by emoji`)
+    .option("--shortcode <name>", "emoji shortcode (e.g. thumbs_up)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [commentId, emoji, options, command] = args as [
+          string,
+          string | undefined,
+          ReactionOptions,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+        const result = await deleteDiscussionCommentReactionByEmoji(ctx.gql, {
+          commentId,
+          target: noun,
+          expectedEntityKind: "project",
+          emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+        });
+        outputSuccess(result);
+      }),
+    );
+
+  parent
+    .command(`unreact-id <${noun}> <reactionId>`)
+    .description(
+      `remove your reaction from a discussion ${noun} by reaction ID`,
+    )
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [commentId, reactionId, , command] = args as [
+          string,
+          string,
+          unknown,
+          Command,
+        ];
+        const ctx = createContext(rootOptions(command));
+        const result = await deleteDiscussionCommentReactionById(ctx.gql, {
+          commentId,
+          target: noun,
+          expectedEntityKind: "project",
+          reactionId,
+        });
+        outputSuccess(result);
+      }),
+    );
 }
 
 interface CreateOptions {
@@ -176,6 +270,7 @@ export function setupProjectsCommands(program: Command): void {
     .description("list root discussion threads on a project")
     .option("-l, --limit <n>", "max results", "25")
     .option("--after <cursor>", "cursor for next page")
+    .option("--with-reactions", "include normalized discussion reactions")
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [project, options, command] = args as [
@@ -186,20 +281,37 @@ export function setupProjectsCommands(program: Command): void {
         const ctx = createContext(command.parent!.parent!.opts());
 
         const projectId = await resolveProjectId(ctx.sdk, project);
-        const result = await listDiscussionsForProject(ctx.gql, projectId, {
+        const paginationOptions = {
           limit: parseLimit(options.limit || "25"),
           after: options.after,
-        });
+        };
+        const result = options.withReactions
+          ? await listDiscussionsForProjectWithReactions(
+              ctx.gql,
+              projectId,
+              paginationOptions,
+            )
+          : await listDiscussionsForProject(
+              ctx.gql,
+              projectId,
+              paginationOptions,
+            );
 
         outputSuccess(result);
       }),
     );
 
-  projects
+  const projectThreads = projects
+    .command("threads")
+    .description("discussion thread reaction operations");
+  addCommentReactionCommands(projectThreads, "thread");
+
+  const projectReplies = projects
     .command("replies <thread>")
     .description("list replies in a root discussion thread")
     .option("-l, --limit <n>", "max results", "50")
     .option("--after <cursor>", "cursor for next page")
+    .option("--with-reactions", "include normalized discussion reactions")
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [thread, options, command] = args as [
@@ -209,19 +321,28 @@ export function setupProjectsCommands(program: Command): void {
         ];
         const ctx = createContext(command.parent!.parent!.opts());
 
-        const result = await listDiscussionReplies(
-          ctx.gql,
-          thread,
-          {
-            limit: parseLimit(options.limit || "50"),
-            after: options.after,
-          },
-          "project",
-        );
+        const paginationOptions = {
+          limit: parseLimit(options.limit || "50"),
+          after: options.after,
+        };
+        const result = options.withReactions
+          ? await listDiscussionRepliesWithReactions(
+              ctx.gql,
+              thread,
+              paginationOptions,
+              "project",
+            )
+          : await listDiscussionReplies(
+              ctx.gql,
+              thread,
+              paginationOptions,
+              "project",
+            );
 
         outputSuccess(result);
       }),
     );
+  addCommentReactionCommands(projectReplies, "reply");
 
   projects
     .command("reply <thread>")

--- a/src/common/emoji.ts
+++ b/src/common/emoji.ts
@@ -1,0 +1,53 @@
+import { emojify, get } from "node-emoji";
+
+const SHORTCODE_ALIASES = new Map<string, string>([["thumbs_up", "+1"]]);
+
+function lookupEmojiByShortcode(shortcode: string): string | undefined {
+  const directEmoji = get(shortcode);
+  if (directEmoji) {
+    return directEmoji;
+  }
+
+  const alias = SHORTCODE_ALIASES.get(shortcode);
+  return alias ? get(alias) : undefined;
+}
+
+export function normalizeReactionEmojiInput(raw: string): string {
+  const emoji = raw.trim();
+  if (!emoji) {
+    throw new Error("emoji must not be empty");
+  }
+  return emoji;
+}
+
+export function resolveReactionEmojiInput(
+  positionalEmoji: string | undefined,
+  shortcode: string | undefined,
+): string {
+  const normalizedPositionalEmoji = positionalEmoji?.trim();
+  const normalizedShortcode = shortcode?.trim();
+
+  if (normalizedPositionalEmoji && normalizedShortcode) {
+    throw new Error("cannot provide both positional emoji and --shortcode");
+  }
+
+  if (normalizedPositionalEmoji) {
+    return normalizeReactionEmojiInput(normalizedPositionalEmoji);
+  }
+
+  if (!normalizedShortcode) {
+    throw new Error("emoji or --shortcode is required");
+  }
+
+  const emojified = emojify(`:${normalizedShortcode}:`);
+  const emoji =
+    emojified !== `:${normalizedShortcode}:`
+      ? emojified
+      : lookupEmojiByShortcode(normalizedShortcode);
+
+  if (!emoji) {
+    throw new Error(`unknown emoji shortcode "${normalizedShortcode}"`);
+  }
+
+  return normalizeReactionEmojiInput(emoji);
+}

--- a/src/services/discussion-service.ts
+++ b/src/services/discussion-service.ts
@@ -6,22 +6,35 @@ import {
   DeleteDiscussionReplyDocument,
   type DeleteDiscussionReplyMutation,
   type DiscussionCommentFieldsFragment,
+  type DiscussionCommentFieldsWithReactionsFragment,
   EditDiscussionReplyDocument,
   type EditDiscussionReplyMutation,
   GetDiscussionCommentContextDocument,
   type GetDiscussionCommentContextQuery,
   ListInitiativeDiscussionReplyCandidatesDocument,
   type ListInitiativeDiscussionReplyCandidatesQuery,
+  ListInitiativeDiscussionReplyCandidatesWithReactionsDocument,
+  type ListInitiativeDiscussionReplyCandidatesWithReactionsQuery,
   ListInitiativeDiscussionRootsDocument,
   type ListInitiativeDiscussionRootsQuery,
+  ListInitiativeDiscussionRootsWithReactionsDocument,
+  type ListInitiativeDiscussionRootsWithReactionsQuery,
   ListIssueDiscussionReplyCandidatesDocument,
   type ListIssueDiscussionReplyCandidatesQuery,
+  ListIssueDiscussionReplyCandidatesWithReactionsDocument,
+  type ListIssueDiscussionReplyCandidatesWithReactionsQuery,
   ListIssueDiscussionRootsDocument,
   type ListIssueDiscussionRootsQuery,
+  ListIssueDiscussionRootsWithReactionsDocument,
+  type ListIssueDiscussionRootsWithReactionsQuery,
   ListProjectDiscussionReplyCandidatesDocument,
   type ListProjectDiscussionReplyCandidatesQuery,
+  ListProjectDiscussionReplyCandidatesWithReactionsDocument,
+  type ListProjectDiscussionReplyCandidatesWithReactionsQuery,
   ListProjectDiscussionRootsDocument,
   type ListProjectDiscussionRootsQuery,
+  ListProjectDiscussionRootsWithReactionsDocument,
+  type ListProjectDiscussionRootsWithReactionsQuery,
   ResolveDiscussionDocument,
   type ResolveDiscussionMutation,
   StartDiscussionDocument,
@@ -29,8 +42,18 @@ import {
   UnresolveDiscussionDocument,
   type UnresolveDiscussionMutation,
 } from "../gql/graphql.js";
+import {
+  createReactionForComment,
+  deleteOwnReactionByEmoji,
+  deleteOwnReactionById,
+  normalizeReactions,
+} from "./reaction-service.js";
 
 export type DiscussionThread = DiscussionCommentFieldsFragment;
+export type DiscussionThreadWithReactions = Omit<
+  DiscussionCommentFieldsWithReactionsFragment,
+  "reactions"
+> & { reactions: ReturnType<typeof normalizeReactions> };
 export type DiscussionEntityKind = "issue" | "project" | "initiative";
 
 const DEFAULT_ROOT_LIMIT = 25;
@@ -47,6 +70,62 @@ type DiscussionReplyCandidateQuery =
   | ListIssueDiscussionReplyCandidatesQuery
   | ListProjectDiscussionReplyCandidatesQuery
   | ListInitiativeDiscussionReplyCandidatesQuery;
+
+type DiscussionReplyCandidateWithReactionsQuery =
+  | ListIssueDiscussionReplyCandidatesWithReactionsQuery
+  | ListProjectDiscussionReplyCandidatesWithReactionsQuery
+  | ListInitiativeDiscussionReplyCandidatesWithReactionsQuery;
+
+type DiscussionReactionTarget = "thread" | "reply";
+type CreateDiscussionReactionResult = Awaited<
+  ReturnType<typeof createReactionForComment>
+>;
+type DeleteDiscussionReactionResult = Awaited<
+  ReturnType<typeof deleteOwnReactionByEmoji>
+>;
+
+interface DiscussionReactionTargetInput {
+  commentId: string;
+  target: DiscussionReactionTarget;
+  expectedEntityKind?: DiscussionEntityKind;
+}
+
+interface CreateDiscussionReactionInput extends DiscussionReactionTargetInput {
+  emoji: string;
+}
+
+interface DeleteDiscussionReactionByEmojiInput
+  extends DiscussionReactionTargetInput {
+  emoji: string;
+}
+
+interface DeleteDiscussionReactionByIdInput
+  extends DiscussionReactionTargetInput {
+  reactionId: string;
+}
+
+function normalizeDiscussionCommentReactions<
+  T extends { reactions: Parameters<typeof normalizeReactions>[0] },
+>(
+  comment: T,
+): Omit<T, "reactions"> & {
+  reactions: ReturnType<typeof normalizeReactions>;
+} {
+  return {
+    ...comment,
+    reactions: normalizeReactions(comment.reactions),
+  };
+}
+
+function normalizeDiscussionCommentsReactions<
+  T extends { reactions: Parameters<typeof normalizeReactions>[0] },
+>(
+  comments: readonly T[],
+): Array<
+  Omit<T, "reactions"> & { reactions: ReturnType<typeof normalizeReactions> }
+> {
+  return comments.map(normalizeDiscussionCommentReactions);
+}
 
 function getDiscussionEntityKind(
   comment: Pick<
@@ -157,6 +236,22 @@ async function assertReplyComment(
   return comment;
 }
 
+async function assertDiscussionReactionTarget(
+  client: GraphQLClient,
+  input: DiscussionReactionTargetInput,
+): Promise<void> {
+  if (input.target === "thread") {
+    await assertRootDiscussionThread(
+      client,
+      input.commentId,
+      input.expectedEntityKind,
+    );
+    return;
+  }
+
+  await assertReplyComment(client, input.commentId, input.expectedEntityKind);
+}
+
 function compareDiscussionCommentsChronologically(
   a: Pick<DiscussionCommentFieldsFragment, "createdAt" | "editedAt" | "id">,
   b: Pick<DiscussionCommentFieldsFragment, "createdAt" | "editedAt" | "id">,
@@ -255,14 +350,71 @@ async function listDiscussionReplyCandidates(
   return nodes.sort(compareDiscussionCommentsChronologically);
 }
 
-function filterThreadReplies(
-  comments: readonly DiscussionCommentFieldsFragment[],
+async function listDiscussionReplyCandidatesWithReactions(
+  client: GraphQLClient,
+  thread: DiscussionThreadContext,
+): Promise<DiscussionThreadWithReactions[]> {
+  const entity = getDiscussionThreadEntity(thread);
+  const nodes: DiscussionCommentFieldsWithReactionsFragment[] = [];
+  let after: string | undefined;
+
+  while (true) {
+    let result: DiscussionReplyCandidateWithReactionsQuery;
+
+    if (entity.kind === "issue") {
+      result =
+        await client.request<ListIssueDiscussionReplyCandidatesWithReactionsQuery>(
+          ListIssueDiscussionReplyCandidatesWithReactionsDocument,
+          {
+            issueId: entity.id,
+            first: DISCUSSION_REPLY_FETCH_LIMIT,
+            after,
+          },
+        );
+    } else if (entity.kind === "project") {
+      result =
+        await client.request<ListProjectDiscussionReplyCandidatesWithReactionsQuery>(
+          ListProjectDiscussionReplyCandidatesWithReactionsDocument,
+          {
+            projectId: entity.id,
+            first: DISCUSSION_REPLY_FETCH_LIMIT,
+            after,
+          },
+        );
+    } else {
+      result =
+        await client.request<ListInitiativeDiscussionReplyCandidatesWithReactionsQuery>(
+          ListInitiativeDiscussionReplyCandidatesWithReactionsDocument,
+          {
+            initiativeId: entity.id,
+            first: DISCUSSION_REPLY_FETCH_LIMIT,
+            after,
+          },
+        );
+    }
+
+    nodes.push(...result.comments.nodes);
+
+    if (
+      !result.comments.pageInfo.hasNextPage ||
+      !result.comments.pageInfo.endCursor
+    ) {
+      break;
+    }
+
+    after = result.comments.pageInfo.endCursor;
+  }
+
+  return normalizeDiscussionCommentsReactions(
+    nodes.sort(compareDiscussionCommentsChronologically),
+  );
+}
+
+function filterThreadReplies<T extends DiscussionCommentFieldsFragment>(
+  comments: readonly T[],
   threadId: string,
-): DiscussionCommentFieldsFragment[] {
-  const childrenByParentId = new Map<
-    string,
-    DiscussionCommentFieldsFragment[]
-  >();
+): T[] {
+  const childrenByParentId = new Map<string, T[]>();
 
   for (const comment of comments) {
     if (!comment.parentId) {
@@ -275,7 +427,7 @@ function filterThreadReplies(
     childrenByParentId.set(comment.parentId, siblings);
   }
 
-  const replies: DiscussionCommentFieldsFragment[] = [];
+  const replies: T[] = [];
   const stack = [...(childrenByParentId.get(threadId) ?? [])].reverse();
 
   while (stack.length > 0) {
@@ -301,11 +453,11 @@ function filterThreadReplies(
   return replies;
 }
 
-function paginateDiscussionReplies(
-  replies: readonly DiscussionCommentFieldsFragment[],
+function paginateDiscussionReplies<T extends DiscussionCommentFieldsFragment>(
+  replies: readonly T[],
   limit: number,
   after?: string,
-): PaginatedResult<DiscussionCommentFieldsFragment> {
+): PaginatedResult<T> {
   const startIndex =
     after === undefined
       ? 0
@@ -342,6 +494,82 @@ async function startDiscussion(
   return result.commentCreate.comment;
 }
 
+export async function createDiscussionCommentReaction(
+  client: GraphQLClient,
+  input: CreateDiscussionReactionInput,
+): Promise<CreateDiscussionReactionResult> {
+  await assertDiscussionReactionTarget(client, input);
+
+  return createReactionForComment(client, {
+    commentId: input.commentId,
+    emoji: input.emoji,
+  });
+}
+
+export async function createIssueDiscussionCommentReaction(
+  client: GraphQLClient,
+  input: { commentId: string; emoji: string },
+): Promise<CreateDiscussionReactionResult> {
+  await assertDiscussionCommentExists(client, input.commentId, "issue");
+
+  return createReactionForComment(client, {
+    commentId: input.commentId,
+    emoji: input.emoji,
+  });
+}
+
+export async function deleteDiscussionCommentReactionByEmoji(
+  client: GraphQLClient,
+  input: DeleteDiscussionReactionByEmojiInput,
+): Promise<DeleteDiscussionReactionResult> {
+  await assertDiscussionReactionTarget(client, input);
+
+  return deleteOwnReactionByEmoji(client, {
+    kind: "comment",
+    id: input.commentId,
+    emoji: input.emoji,
+  });
+}
+
+export async function deleteIssueDiscussionCommentReactionByEmoji(
+  client: GraphQLClient,
+  input: { commentId: string; emoji: string },
+): Promise<DeleteDiscussionReactionResult> {
+  await assertDiscussionCommentExists(client, input.commentId, "issue");
+
+  return deleteOwnReactionByEmoji(client, {
+    kind: "comment",
+    id: input.commentId,
+    emoji: input.emoji,
+  });
+}
+
+export async function deleteDiscussionCommentReactionById(
+  client: GraphQLClient,
+  input: DeleteDiscussionReactionByIdInput,
+): Promise<DeleteDiscussionReactionResult> {
+  await assertDiscussionReactionTarget(client, input);
+
+  return deleteOwnReactionById(client, {
+    kind: "comment",
+    id: input.commentId,
+    reactionId: input.reactionId,
+  });
+}
+
+export async function deleteIssueDiscussionCommentReactionById(
+  client: GraphQLClient,
+  input: { commentId: string; reactionId: string },
+): Promise<DeleteDiscussionReactionResult> {
+  await assertDiscussionCommentExists(client, input.commentId, "issue");
+
+  return deleteOwnReactionById(client, {
+    kind: "comment",
+    id: input.commentId,
+    reactionId: input.reactionId,
+  });
+}
+
 export async function listDiscussionsForIssue(
   client: GraphQLClient,
   issueId: string,
@@ -367,6 +595,32 @@ export async function listDiscussionsForIssue(
   };
 }
 
+export async function listDiscussionsForIssueWithReactions(
+  client: GraphQLClient,
+  issueId: string,
+  options: PaginationOptions = {},
+): Promise<PaginatedResult<DiscussionThreadWithReactions>> {
+  const { limit = DEFAULT_ROOT_LIMIT, after } = options;
+  const result =
+    await client.request<ListIssueDiscussionRootsWithReactionsQuery>(
+      ListIssueDiscussionRootsWithReactionsDocument,
+      {
+        issueId,
+        first: limit,
+        after,
+      },
+    );
+
+  if (!result.issue) {
+    throw new Error(`Issue with ID "${issueId}" not found`);
+  }
+
+  return {
+    nodes: normalizeDiscussionCommentsReactions(result.issue.comments.nodes),
+    pageInfo: result.issue.comments.pageInfo,
+  };
+}
+
 export async function listDiscussionsForProject(
   client: GraphQLClient,
   projectId: string,
@@ -388,6 +642,32 @@ export async function listDiscussionsForProject(
 
   return {
     nodes: result.project.comments.nodes,
+    pageInfo: result.project.comments.pageInfo,
+  };
+}
+
+export async function listDiscussionsForProjectWithReactions(
+  client: GraphQLClient,
+  projectId: string,
+  options: PaginationOptions = {},
+): Promise<PaginatedResult<DiscussionThreadWithReactions>> {
+  const { limit = DEFAULT_ROOT_LIMIT, after } = options;
+  const result =
+    await client.request<ListProjectDiscussionRootsWithReactionsQuery>(
+      ListProjectDiscussionRootsWithReactionsDocument,
+      {
+        projectId,
+        first: limit,
+        after,
+      },
+    );
+
+  if (!result.project) {
+    throw new Error(`Project with ID "${projectId}" not found`);
+  }
+
+  return {
+    nodes: normalizeDiscussionCommentsReactions(result.project.comments.nodes),
     pageInfo: result.project.comments.pageInfo,
   };
 }
@@ -418,6 +698,33 @@ export async function listDiscussionsForInitiative(
   };
 }
 
+export async function listDiscussionsForInitiativeWithReactions(
+  client: GraphQLClient,
+  initiativeId: string,
+  options: PaginationOptions = {},
+): Promise<PaginatedResult<DiscussionThreadWithReactions>> {
+  const { limit = DEFAULT_ROOT_LIMIT, after } = options;
+  const result =
+    await client.request<ListInitiativeDiscussionRootsWithReactionsQuery>(
+      ListInitiativeDiscussionRootsWithReactionsDocument,
+      {
+        initiativeId,
+        initiativeLookupId: initiativeId,
+        first: limit,
+        after,
+      },
+    );
+
+  if (!result.initiative) {
+    throw new Error(`Initiative with ID "${initiativeId}" not found`);
+  }
+
+  return {
+    nodes: normalizeDiscussionCommentsReactions(result.comments.nodes),
+    pageInfo: result.comments.pageInfo,
+  };
+}
+
 export async function listDiscussionReplies(
   client: GraphQLClient,
   threadId: string,
@@ -430,6 +737,27 @@ export async function listDiscussionReplies(
     expectedEntityKind,
   );
   const candidates = await listDiscussionReplyCandidates(client, thread);
+  const replies = filterThreadReplies(candidates, threadId);
+  const { limit = DEFAULT_REPLY_LIMIT, after } = options;
+
+  return paginateDiscussionReplies(replies, limit, after);
+}
+
+export async function listDiscussionRepliesWithReactions(
+  client: GraphQLClient,
+  threadId: string,
+  options: PaginationOptions = {},
+  expectedEntityKind?: DiscussionEntityKind,
+): Promise<PaginatedResult<DiscussionThreadWithReactions>> {
+  const thread = await assertRootDiscussionThread(
+    client,
+    threadId,
+    expectedEntityKind,
+  );
+  const candidates = await listDiscussionReplyCandidatesWithReactions(
+    client,
+    thread,
+  );
   const replies = filterThreadReplies(candidates, threadId);
   const { limit = DEFAULT_REPLY_LIMIT, after } = options;
 

--- a/src/services/issue-service.ts
+++ b/src/services/issue-service.ts
@@ -33,11 +33,15 @@ import {
   type GetIssueByIdentifierWithAttachmentsQuery,
   GetIssueByIdentifierWithCommentsDocument,
   type GetIssueByIdentifierWithCommentsQuery,
+  GetIssueByIdentifierWithReactionsDocument,
+  type GetIssueByIdentifierWithReactionsQuery,
   type GetIssueByIdQuery,
   GetIssueByIdWithAttachmentsDocument,
   type GetIssueByIdWithAttachmentsQuery,
   GetIssueByIdWithCommentsDocument,
   type GetIssueByIdWithCommentsQuery,
+  GetIssueByIdWithReactionsDocument,
+  type GetIssueByIdWithReactionsQuery,
   GetIssuesDocument,
   type GetIssuesQuery,
   type IssueCreateInput,
@@ -52,6 +56,7 @@ import {
   UpdateIssueDocument,
   type UpdateIssueMutation,
 } from "../gql/graphql.js";
+import { normalizeReactions } from "./reaction-service.js";
 
 const NON_COMPLETED_ISSUES_FILTER: IssueFilter = {
   state: { type: { neq: "completed" } },
@@ -160,6 +165,31 @@ function threadIssueComments(
     comments: {
       nodes: groupCommentsIntoThreads(issue.comments?.nodes ?? []),
     },
+  };
+}
+
+type NormalizedIssueReactions = ReturnType<typeof normalizeReactions>;
+
+type IssueDetailWithReactions = Omit<
+  NonNullable<GetIssueByIdWithReactionsQuery["issue"]>,
+  "reactions"
+> & {
+  reactions: NormalizedIssueReactions;
+};
+
+type IssueByIdentifierWithReactions = Omit<
+  GetIssueByIdentifierWithReactionsQuery["issues"]["nodes"][0],
+  "reactions"
+> & {
+  reactions: NormalizedIssueReactions;
+};
+
+function normalizeIssueReactions<
+  T extends { reactions: Parameters<typeof normalizeReactions>[0] },
+>(issue: T): Omit<T, "reactions"> & { reactions: NormalizedIssueReactions } {
+  return {
+    ...issue,
+    reactions: normalizeReactions(issue.reactions),
   };
 }
 
@@ -277,6 +307,37 @@ export async function getIssueByIdentifierWithCommentThreads(
     issueNumber,
   );
   return threadIssueComments(issue);
+}
+
+export async function getIssueWithReactions(
+  client: GraphQLClient,
+  id: string,
+): Promise<IssueDetailWithReactions> {
+  const result = await client.request<GetIssueByIdWithReactionsQuery>(
+    GetIssueByIdWithReactionsDocument,
+    { id },
+  );
+  if (!result.issue) {
+    throw new Error(`Issue with ID "${id}" not found`);
+  }
+  return normalizeIssueReactions(result.issue);
+}
+
+export async function getIssueByIdentifierWithReactions(
+  client: GraphQLClient,
+  teamKey: string,
+  issueNumber: number,
+): Promise<IssueByIdentifierWithReactions> {
+  const result = await client.request<GetIssueByIdentifierWithReactionsQuery>(
+    GetIssueByIdentifierWithReactionsDocument,
+    { teamKey, number: issueNumber },
+  );
+  if (!result.issues.nodes.length) {
+    throw new Error(
+      `Issue with identifier "${teamKey}-${issueNumber}" not found`,
+    );
+  }
+  return normalizeIssueReactions(result.issues.nodes[0]);
 }
 
 export async function getIssueWithAttachments(

--- a/src/services/reaction-service.ts
+++ b/src/services/reaction-service.ts
@@ -1,0 +1,289 @@
+import type { GraphQLClient } from "../client/graphql-client.js";
+import { normalizeReactionEmojiInput } from "../common/emoji.js";
+import {
+  CreateReactionDocument,
+  type CreateReactionMutation,
+  DeleteReactionDocument,
+  type DeleteReactionMutation,
+  GetCommentReactionsDocument,
+  type GetCommentReactionsQuery,
+  GetIssueReactionsDocument,
+  type GetIssueReactionsQuery,
+  GetViewerDocument,
+  type GetViewerQuery,
+  type ReactionCreateInput,
+  type ReactionReadFieldsFragment,
+} from "../gql/graphql.js";
+
+type ReactionNode = ReactionReadFieldsFragment;
+
+interface NormalizedReactionUser {
+  id: string;
+  displayName: string;
+  type: "user" | "external";
+}
+
+interface NormalizedReactionGroup {
+  emoji: string;
+  count: number;
+  users: NormalizedReactionUser[];
+  reactionIds: string[];
+}
+
+interface ReactionLookupInput {
+  kind: "issue" | "comment";
+  id: string;
+}
+
+interface DeleteOwnReactionByEmojiInput extends ReactionLookupInput {
+  emoji: string;
+}
+
+interface DeleteOwnReactionByIdInput extends ReactionLookupInput {
+  reactionId: string;
+}
+
+function compareNormalizedUsers(
+  a: NormalizedReactionUser,
+  b: NormalizedReactionUser,
+): number {
+  const nameComparison = a.displayName.localeCompare(b.displayName);
+
+  if (nameComparison !== 0) {
+    return nameComparison;
+  }
+
+  const typeComparison = a.type.localeCompare(b.type);
+
+  if (typeComparison !== 0) {
+    return typeComparison;
+  }
+
+  return a.id.localeCompare(b.id);
+}
+
+function normalizeReactionUser(
+  reaction: ReactionNode,
+): NormalizedReactionUser | undefined {
+  if (reaction.user) {
+    return {
+      id: reaction.user.id,
+      displayName: reaction.user.displayName,
+      type: "user",
+    };
+  }
+
+  if (reaction.externalUser) {
+    return {
+      id: reaction.externalUser.id,
+      displayName: reaction.externalUser.name,
+      type: "external",
+    };
+  }
+
+  return undefined;
+}
+
+async function getViewerId(client: GraphQLClient): Promise<string> {
+  const result = await client.request<GetViewerQuery>(GetViewerDocument);
+  return result.viewer.id;
+}
+
+async function getTargetReactions(
+  client: GraphQLClient,
+  input: ReactionLookupInput,
+): Promise<ReactionNode[]> {
+  if (input.kind === "issue") {
+    const result = await client.request<GetIssueReactionsQuery>(
+      GetIssueReactionsDocument,
+      { id: input.id },
+    );
+
+    if (!result.issue) {
+      throw new Error(`Issue with ID "${input.id}" not found`);
+    }
+
+    return result.issue.reactions;
+  }
+
+  const result = await client.request<GetCommentReactionsQuery>(
+    GetCommentReactionsDocument,
+    { id: input.id },
+  );
+
+  if (!result.comment) {
+    throw new Error(`Discussion comment ID "${input.id}" not found`);
+  }
+
+  return result.comment.reactions;
+}
+
+async function createReaction(
+  client: GraphQLClient,
+  input: ReactionCreateInput,
+  duplicateLookup: ReactionLookupInput,
+): Promise<CreateReactionMutation["reactionCreate"]["reaction"]> {
+  const normalizedEmoji = normalizeReactionEmojiInput(input.emoji);
+  const normalizedInput = { ...input, emoji: normalizedEmoji };
+  const viewerId = await getViewerId(client);
+  const existingReactions = await getTargetReactions(client, duplicateLookup);
+
+  const duplicateReaction = existingReactions.find(
+    (reaction) =>
+      reaction.emoji === normalizedEmoji && reaction.user?.id === viewerId,
+  );
+
+  if (duplicateReaction) {
+    throw new Error(`Already reacted with emoji ${normalizedEmoji}`);
+  }
+
+  const result = await client.request<CreateReactionMutation>(
+    CreateReactionDocument,
+    { input: normalizedInput },
+  );
+
+  if (!result.reactionCreate.success) {
+    throw new Error("Failed to create reaction");
+  }
+
+  return result.reactionCreate.reaction;
+}
+
+async function deleteReaction(
+  client: GraphQLClient,
+  reactionId: string,
+): Promise<{ id: string; success: boolean }> {
+  const result = await client.request<DeleteReactionMutation>(
+    DeleteReactionDocument,
+    { id: reactionId },
+  );
+
+  if (!result.reactionDelete.success) {
+    throw new Error("Failed to delete reaction");
+  }
+
+  return { id: result.reactionDelete.entityId, success: true };
+}
+
+export function normalizeReactions(
+  reactions: readonly ReactionNode[],
+): NormalizedReactionGroup[] {
+  const reactionsByEmoji = new Map<string, ReactionNode[]>();
+
+  for (const reaction of reactions) {
+    const existing = reactionsByEmoji.get(reaction.emoji);
+
+    if (existing) {
+      existing.push(reaction);
+      continue;
+    }
+
+    reactionsByEmoji.set(reaction.emoji, [reaction]);
+  }
+
+  return [...reactionsByEmoji.entries()]
+    .sort((leftEntry, rightEntry) => {
+      const [leftEmoji, leftReactions] = leftEntry;
+      const [rightEmoji, rightReactions] = rightEntry;
+      const countComparison = rightReactions.length - leftReactions.length;
+
+      if (countComparison !== 0) {
+        return countComparison;
+      }
+
+      return leftEmoji.localeCompare(rightEmoji);
+    })
+    .map(([emoji, groupedReactions]) => {
+      const users = groupedReactions
+        .map(normalizeReactionUser)
+        .filter((user): user is NormalizedReactionUser => user !== undefined)
+        .sort(compareNormalizedUsers);
+
+      const reactionIds = groupedReactions
+        .map((reaction) => reaction.id)
+        .sort((left, right) => left.localeCompare(right));
+
+      return {
+        emoji,
+        count: groupedReactions.length,
+        users,
+        reactionIds,
+      };
+    });
+}
+
+export async function createReactionForIssue(
+  client: GraphQLClient,
+  input: {
+    issueId: string;
+    emoji: string;
+  },
+): Promise<CreateReactionMutation["reactionCreate"]["reaction"]> {
+  return createReaction(
+    client,
+    { issueId: input.issueId, emoji: input.emoji },
+    { kind: "issue", id: input.issueId },
+  );
+}
+
+export async function createReactionForComment(
+  client: GraphQLClient,
+  input: {
+    commentId: string;
+    emoji: string;
+  },
+): Promise<CreateReactionMutation["reactionCreate"]["reaction"]> {
+  return createReaction(
+    client,
+    { commentId: input.commentId, emoji: input.emoji },
+    { kind: "comment", id: input.commentId },
+  );
+}
+
+export async function deleteOwnReactionByEmoji(
+  client: GraphQLClient,
+  input: DeleteOwnReactionByEmojiInput,
+): Promise<{ id: string; success: boolean }> {
+  const normalizedEmoji = normalizeReactionEmojiInput(input.emoji);
+  const viewerId = await getViewerId(client);
+  const existingReactions = await getTargetReactions(client, input);
+
+  const matchingReactions = existingReactions.filter(
+    (reaction) =>
+      reaction.emoji === normalizedEmoji && reaction.user?.id === viewerId,
+  );
+
+  if (matchingReactions.length === 0) {
+    throw new Error(`No own reaction found with emoji ${normalizedEmoji}`);
+  }
+
+  if (matchingReactions.length > 1) {
+    throw new Error(
+      `Multiple own reactions found with emoji ${normalizedEmoji}`,
+    );
+  }
+
+  return deleteReaction(client, matchingReactions[0].id);
+}
+
+export async function deleteOwnReactionById(
+  client: GraphQLClient,
+  input: DeleteOwnReactionByIdInput,
+): Promise<{ id: string; success: boolean }> {
+  const viewerId = await getViewerId(client);
+  const existingReactions = await getTargetReactions(client, input);
+
+  const reaction = existingReactions.find(
+    (candidate) => candidate.id === input.reactionId,
+  );
+
+  if (!reaction) {
+    throw new Error(`Reaction "${input.reactionId}" not found`);
+  }
+
+  if (reaction.user?.id !== viewerId) {
+    throw new Error(`Reaction "${input.reactionId}" is not owned by viewer`);
+  }
+
+  return deleteReaction(client, reaction.id);
+}

--- a/tests/unit/commands/comments.test.ts
+++ b/tests/unit/commands/comments.test.ts
@@ -22,6 +22,15 @@ vi.mock("../../../src/resolvers/issue-resolver.js", () => ({
 }));
 
 vi.mock("../../../src/services/discussion-service.js", () => ({
+  createIssueDiscussionCommentReaction: vi
+    .fn()
+    .mockResolvedValue({ id: "reaction-1" }),
+  deleteIssueDiscussionCommentReactionByEmoji: vi
+    .fn()
+    .mockResolvedValue({ id: "reaction-1", success: true }),
+  deleteIssueDiscussionCommentReactionById: vi
+    .fn()
+    .mockResolvedValue({ id: "reaction-1", success: true }),
   listDiscussionsForIssue: vi.fn().mockResolvedValue({
     nodes: [],
     pageInfo: {
@@ -44,7 +53,10 @@ vi.mock("../../../src/services/discussion-service.js", () => ({
 import { setupCommentsCommands } from "../../../src/commands/comments.js";
 import { resolveIssueId } from "../../../src/resolvers/issue-resolver.js";
 import {
+  createIssueDiscussionCommentReaction,
   deleteDiscussionComment,
+  deleteIssueDiscussionCommentReactionByEmoji,
+  deleteIssueDiscussionCommentReactionById,
   editDiscussionComment,
   listDiscussionsForIssue,
   replyToDiscussion,
@@ -80,7 +92,9 @@ describe("comments compatibility delegation", () => {
       "Deprecated compatibility facade for issue discussions",
     );
     expect(commentsHelp).toMatch(/Prefer the `issues`\s+discussion commands/i);
-    expect(commentsHelp).toMatch(/migrate to `issues discussions\s+<issue>`/i);
+    expect(commentsHelp).toMatch(
+      /migrate to `issues\s+discussions\s+<issue>`/i,
+    );
     expect(commentsHelp).toMatch(
       /nested-reply\s+targets are not\s+supported in compatibility mode/i,
     );
@@ -269,6 +283,131 @@ describe("comments compatibility delegation", () => {
     expect(deleteDiscussionComment).toHaveBeenCalledWith(
       expect.anything(),
       "root-1",
+    );
+  });
+
+  it("comments react help points users to domain-native issue reaction commands", () => {
+    const program = createProgram();
+    const comments = program.commands.find(
+      (command) => command.name() === "comments",
+    );
+    const react = comments!.commands.find(
+      (command) => command.name() === "react",
+    );
+
+    expect(react).toBeDefined();
+    expect(react!.helpInformation()).toMatch(
+      /DEPRECATED compatibility command/i,
+    );
+    expect(react!.helpInformation()).toMatch(
+      /Prefer: `issues threads react <thread>`|`issues replies react <reply>`/,
+    );
+  });
+
+  it("comments react delegates to comment reaction service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "comments",
+      "react",
+      "comment-1",
+      "👍",
+    ]);
+
+    expect(createIssueDiscussionCommentReaction).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        commentId: "comment-1",
+        emoji: "👍",
+      },
+    );
+  });
+
+  it("comments react supports shortcode emoji input", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "comments",
+      "react",
+      "comment-1",
+      "--shortcode",
+      "thumbs_up",
+    ]);
+
+    expect(createIssueDiscussionCommentReaction).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        commentId: "comment-1",
+        emoji: "👍",
+      },
+    );
+  });
+
+  it("comments unreact delegates to comment reaction service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "comments",
+      "unreact",
+      "comment-1",
+      "👍",
+    ]);
+
+    expect(deleteIssueDiscussionCommentReactionByEmoji).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        commentId: "comment-1",
+        emoji: "👍",
+      },
+    );
+  });
+
+  it("comments unreact supports shortcode emoji input", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "comments",
+      "unreact",
+      "comment-1",
+      "--shortcode",
+      "thumbs_up",
+    ]);
+
+    expect(deleteIssueDiscussionCommentReactionByEmoji).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        commentId: "comment-1",
+        emoji: "👍",
+      },
+    );
+  });
+
+  it("comments unreact-id delegates to comment reaction service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "comments",
+      "unreact-id",
+      "comment-1",
+      "reaction-1",
+    ]);
+
+    expect(deleteIssueDiscussionCommentReactionById).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        commentId: "comment-1",
+        reactionId: "reaction-1",
+      },
     );
   });
 });

--- a/tests/unit/commands/initiatives.test.ts
+++ b/tests/unit/commands/initiatives.test.ts
@@ -124,6 +124,24 @@ vi.mock("../../../src/services/discussion-service.js", () => ({
       endCursor: null,
     },
   }),
+  listDiscussionsForInitiativeWithReactions: vi.fn().mockResolvedValue({
+    nodes: [],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+  }),
+  listDiscussionRepliesWithReactions: vi.fn().mockResolvedValue({
+    nodes: [],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+  }),
   replyToDiscussion: vi.fn().mockResolvedValue({ id: "discussion-reply-1" }),
   editDiscussionReply: vi.fn().mockResolvedValue({ id: "discussion-reply-1" }),
   deleteDiscussionReply: vi
@@ -137,6 +155,15 @@ vi.mock("../../../src/services/discussion-service.js", () => ({
     .mockResolvedValue({ id: "discussion-comment-1", success: true }),
   resolveDiscussion: vi.fn().mockResolvedValue({ id: "discussion-root-1" }),
   unresolveDiscussion: vi.fn().mockResolvedValue({ id: "discussion-root-1" }),
+  createDiscussionCommentReaction: vi
+    .fn()
+    .mockResolvedValue({ id: "reaction-1" }),
+  deleteDiscussionCommentReactionByEmoji: vi
+    .fn()
+    .mockResolvedValue({ id: "reaction-1", success: true }),
+  deleteDiscussionCommentReactionById: vi
+    .fn()
+    .mockResolvedValue({ id: "reaction-1", success: true }),
 }));
 
 import { setupInitiativesCommands } from "../../../src/commands/initiatives/index.js";
@@ -145,12 +172,17 @@ import { resolveInitiativeId } from "../../../src/resolvers/initiative-resolver.
 import { resolveProjectId } from "../../../src/resolvers/project-resolver.js";
 import { resolveUserId } from "../../../src/resolvers/user-resolver.js";
 import {
+  createDiscussionCommentReaction,
   deleteDiscussionComment,
+  deleteDiscussionCommentReactionByEmoji,
+  deleteDiscussionCommentReactionById,
   deleteDiscussionReply,
   editDiscussionComment,
   editDiscussionReply,
   listDiscussionReplies,
+  listDiscussionRepliesWithReactions,
   listDiscussionsForInitiative,
+  listDiscussionsForInitiativeWithReactions,
   replyToDiscussion,
   resolveDiscussion,
   startInitiativeDiscussion,
@@ -576,6 +608,26 @@ describe("initiative discussion commands", () => {
     });
   });
 
+  it("wires discussions --with-reactions to reaction-aware service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "discussions",
+      "Growth",
+      "--with-reactions",
+    ]);
+
+    expect(listDiscussionsForInitiativeWithReactions).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-initiative-uuid",
+      { limit: 25, after: undefined },
+    );
+    expect(listDiscussionsForInitiative).not.toHaveBeenCalled();
+  });
+
   it("wires replies with pagination", async () => {
     const program = createProgram();
 
@@ -609,6 +661,27 @@ describe("initiative discussion commands", () => {
         endCursor: null,
       },
     });
+  });
+
+  it("wires replies --with-reactions to reaction-aware service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "replies",
+      "thread-1",
+      "--with-reactions",
+    ]);
+
+    expect(listDiscussionRepliesWithReactions).toHaveBeenCalledWith(
+      expect.anything(),
+      "thread-1",
+      { limit: 50, after: undefined },
+      "initiative",
+    );
+    expect(listDiscussionReplies).not.toHaveBeenCalled();
   });
 
   it("wires reply", async () => {
@@ -819,5 +892,78 @@ describe("initiative discussion commands", () => {
       "initiative",
     );
     expect(outputSuccess).toHaveBeenCalledWith({ id: "discussion-root-1" });
+  });
+
+  it("initiatives threads react delegates to comment reaction service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "threads",
+      "react",
+      "thread-1",
+      "🎉",
+    ]);
+
+    expect(createDiscussionCommentReaction).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        commentId: "thread-1",
+        target: "thread",
+        expectedEntityKind: "initiative",
+        emoji: "🎉",
+      },
+    );
+  });
+
+  it("initiatives replies unreact supports --shortcode", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "replies",
+      "unreact",
+      "reply-1",
+      "--shortcode",
+      "thumbs_up",
+    ]);
+
+    expect(deleteDiscussionCommentReactionByEmoji).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        commentId: "reply-1",
+        target: "reply",
+        expectedEntityKind: "initiative",
+        emoji: "👍",
+      },
+    );
+  });
+
+  it("initiatives replies unreact-id delegates to comment reaction service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "replies",
+      "unreact-id",
+      "reply-1",
+      "reaction-123",
+    ]);
+
+    expect(deleteDiscussionCommentReactionById).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        commentId: "reply-1",
+        target: "reply",
+        expectedEntityKind: "initiative",
+        reactionId: "reaction-123",
+      },
+    );
   });
 });

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -102,6 +102,14 @@ vi.mock("../../../src/services/issue-service.js", () => ({
     attachments: { nodes: [{ id: "att-1", title: "PR #42" }] },
   }),
   getIssueByIdentifierWithAttachments: vi.fn(),
+  getIssueWithReactions: vi.fn().mockResolvedValue({
+    id: "resolved-issue-uuid",
+    reactions: [{ emoji: "👍", count: 1, users: [], reactionIds: ["r-1"] }],
+  }),
+  getIssueByIdentifierWithReactions: vi.fn().mockResolvedValue({
+    id: "resolved-issue-uuid",
+    reactions: [{ emoji: "👍", count: 1, users: [], reactionIds: ["r-1"] }],
+  }),
   listIssues: vi.fn().mockResolvedValue([]),
   searchIssues: vi.fn().mockResolvedValue([]),
 }));
@@ -110,6 +118,17 @@ vi.mock("../../../src/services/issue-relation-service.js", () => ({
   createIssueRelation: vi.fn(),
   deleteIssueRelation: vi.fn(),
   findIssueRelation: vi.fn(),
+}));
+
+vi.mock("../../../src/services/reaction-service.js", () => ({
+  createReactionForIssue: vi.fn().mockResolvedValue({ id: "reaction-1" }),
+  createReactionForComment: vi.fn().mockResolvedValue({ id: "reaction-1" }),
+  deleteOwnReactionByEmoji: vi
+    .fn()
+    .mockResolvedValue({ id: "reaction-1", success: true }),
+  deleteOwnReactionById: vi
+    .fn()
+    .mockResolvedValue({ id: "reaction-1", success: true }),
 }));
 
 vi.mock("../../../src/services/discussion-service.js", () => ({
@@ -124,6 +143,24 @@ vi.mock("../../../src/services/discussion-service.js", () => ({
     },
   }),
   listDiscussionReplies: vi.fn().mockResolvedValue({
+    nodes: [],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+  }),
+  listDiscussionsForIssueWithReactions: vi.fn().mockResolvedValue({
+    nodes: [],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+  }),
+  listDiscussionRepliesWithReactions: vi.fn().mockResolvedValue({
     nodes: [],
     pageInfo: {
       hasNextPage: false,
@@ -147,6 +184,15 @@ vi.mock("../../../src/services/discussion-service.js", () => ({
   }),
   resolveDiscussion: vi.fn().mockResolvedValue({ id: "discussion-root-1" }),
   unresolveDiscussion: vi.fn().mockResolvedValue({ id: "discussion-root-1" }),
+  createDiscussionCommentReaction: vi
+    .fn()
+    .mockResolvedValue({ id: "reaction-1" }),
+  deleteDiscussionCommentReactionByEmoji: vi
+    .fn()
+    .mockResolvedValue({ id: "reaction-1", success: true }),
+  deleteDiscussionCommentReactionById: vi
+    .fn()
+    .mockResolvedValue({ id: "reaction-1", success: true }),
 }));
 
 import { setupIssuesCommands } from "../../../src/commands/issues.js";
@@ -160,12 +206,16 @@ import {
 } from "../../../src/resolvers/team-resolver.js";
 import { resolveUserId } from "../../../src/resolvers/user-resolver.js";
 import {
+  createDiscussionCommentReaction,
   deleteDiscussionComment,
+  deleteDiscussionCommentReactionById,
   deleteDiscussionReply,
   editDiscussionComment,
   editDiscussionReply,
   listDiscussionReplies,
+  listDiscussionRepliesWithReactions,
   listDiscussionsForIssue,
+  listDiscussionsForIssueWithReactions,
   replyToDiscussion,
   resolveDiscussion,
   startIssueDiscussion,
@@ -180,14 +230,21 @@ import {
   getIssueByIdentifierWithAttachments,
   getIssueByIdentifierWithComments,
   getIssueByIdentifierWithCommentThreads,
+  getIssueByIdentifierWithReactions,
   getIssueWithAttachments,
   getIssueWithComments,
   getIssueWithCommentThreads,
+  getIssueWithReactions,
   listIssues,
   searchIssues,
   unarchiveIssue,
   updateIssue,
 } from "../../../src/services/issue-service.js";
+import {
+  createReactionForIssue,
+  deleteOwnReactionByEmoji,
+  deleteOwnReactionById,
+} from "../../../src/services/reaction-service.js";
 
 function createProgram(): Command {
   const program = new Command();
@@ -1113,6 +1170,78 @@ describe("issues read", () => {
     expect(getIssueWithComments).not.toHaveBeenCalled();
   });
 
+  it.each([
+    ["--with-attachments"],
+    ["--with-comments"],
+    ["--with-comment-threads"],
+  ])("rejects issues read %s with --with-reactions", async (flag) => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "read",
+      "550e8400-e29b-41d4-a716-446655440000",
+      flag,
+      "--with-reactions",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          error:
+            "Invalid --with-reactions: cannot be combined with --with-attachments, --with-comments, or --with-comment-threads",
+        },
+        null,
+        2,
+      ),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(getIssueWithAttachments).not.toHaveBeenCalled();
+    expect(getIssueWithComments).not.toHaveBeenCalled();
+    expect(getIssueWithCommentThreads).not.toHaveBeenCalled();
+    expect(getIssueWithReactions).not.toHaveBeenCalled();
+  });
+
+  it("issues read --with-reactions routes to reaction-aware issue read for UUIDs", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "read",
+      "550e8400-e29b-41d4-a716-446655440000",
+      "--with-reactions",
+    ]);
+
+    expect(getIssueWithReactions).toHaveBeenCalledWith(
+      expect.anything(),
+      "550e8400-e29b-41d4-a716-446655440000",
+    );
+    expect(getIssueWithComments).not.toHaveBeenCalled();
+    expect(getIssueWithAttachments).not.toHaveBeenCalled();
+  });
+
+  it("issues read --with-reactions routes to reaction-aware issue read for identifiers", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "read",
+      "ENG-42",
+      "--with-reactions",
+    ]);
+
+    expect(getIssueByIdentifierWithReactions).toHaveBeenCalledWith(
+      expect.anything(),
+      "ENG",
+      42,
+    );
+    expect(getIssueByIdentifierWithComments).not.toHaveBeenCalled();
+    expect(getIssueByIdentifierWithAttachments).not.toHaveBeenCalled();
+  });
+
   it("calls getIssueWithAttachments when flag is set with UUID", async () => {
     const program = createProgram();
     await program.parseAsync([
@@ -1146,6 +1275,91 @@ describe("issues read", () => {
       "ENG",
       42,
     );
+  });
+});
+
+describe("issues reaction commands", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("issues react resolves issue and delegates to reaction service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "react",
+      "ENG-42",
+      "👍",
+    ]);
+
+    expect(resolveIssueId).toHaveBeenCalledWith(expect.anything(), "ENG-42");
+    expect(createReactionForIssue).toHaveBeenCalledWith(expect.anything(), {
+      issueId: "resolved-issue-uuid",
+      emoji: "👍",
+    });
+  });
+
+  it("issues react supports --shortcode", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "react",
+      "ENG-42",
+      "--shortcode",
+      "thumbs_up",
+    ]);
+
+    expect(createReactionForIssue).toHaveBeenCalledWith(expect.anything(), {
+      issueId: "resolved-issue-uuid",
+      emoji: "👍",
+    });
+  });
+
+  it("issues unreact resolves issue and deletes viewer reaction by emoji", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "unreact",
+      "ENG-42",
+      "👍",
+    ]);
+
+    expect(deleteOwnReactionByEmoji).toHaveBeenCalledWith(expect.anything(), {
+      kind: "issue",
+      id: "resolved-issue-uuid",
+      emoji: "👍",
+    });
+  });
+
+  it("issues unreact-id resolves issue and deletes viewer reaction by id", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "unreact-id",
+      "ENG-42",
+      "reaction-123",
+    ]);
+
+    expect(deleteOwnReactionById).toHaveBeenCalledWith(expect.anything(), {
+      kind: "issue",
+      id: "resolved-issue-uuid",
+      reactionId: "reaction-123",
+    });
   });
 });
 
@@ -1256,6 +1470,26 @@ describe("issues discussion commands", () => {
     );
   });
 
+  it("issues discussions --with-reactions routes to reaction-aware service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "discussions",
+      "ENG-42",
+      "--with-reactions",
+    ]);
+
+    expect(listDiscussionsForIssueWithReactions).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+      { limit: 25, after: undefined },
+    );
+    expect(listDiscussionsForIssue).not.toHaveBeenCalled();
+  });
+
   it("issues replies forwards pagination", async () => {
     const program = createProgram();
 
@@ -1280,6 +1514,27 @@ describe("issues discussion commands", () => {
       },
       "issue",
     );
+  });
+
+  it("issues replies --with-reactions routes to reaction-aware service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "replies",
+      "thread-1",
+      "--with-reactions",
+    ]);
+
+    expect(listDiscussionRepliesWithReactions).toHaveBeenCalledWith(
+      expect.anything(),
+      "thread-1",
+      { limit: 50, after: undefined },
+      "issue",
+    );
+    expect(listDiscussionReplies).not.toHaveBeenCalled();
   });
 
   it("issues reply requires --body", async () => {
@@ -1497,6 +1752,54 @@ describe("issues discussion commands", () => {
       expect.anything(),
       "thread-1",
       "issue",
+    );
+  });
+
+  it("issues threads react delegates to comment reaction service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "threads",
+      "react",
+      "thread-1",
+      "🎉",
+    ]);
+
+    expect(createDiscussionCommentReaction).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        commentId: "thread-1",
+        target: "thread",
+        expectedEntityKind: "issue",
+        emoji: "🎉",
+      },
+    );
+  });
+
+  it("issues replies unreact-id delegates to comment reaction service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "replies",
+      "unreact-id",
+      "reply-1",
+      "reaction-123",
+    ]);
+
+    expect(deleteDiscussionCommentReactionById).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        commentId: "reply-1",
+        target: "reply",
+        expectedEntityKind: "issue",
+        reactionId: "reaction-123",
+      },
     );
   });
 });

--- a/tests/unit/commands/projects.test.ts
+++ b/tests/unit/commands/projects.test.ts
@@ -66,6 +66,24 @@ vi.mock("../../../src/services/discussion-service.js", () => ({
       endCursor: null,
     },
   }),
+  listDiscussionsForProjectWithReactions: vi.fn().mockResolvedValue({
+    nodes: [],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+  }),
+  listDiscussionRepliesWithReactions: vi.fn().mockResolvedValue({
+    nodes: [],
+    pageInfo: {
+      hasNextPage: false,
+      hasPreviousPage: false,
+      startCursor: null,
+      endCursor: null,
+    },
+  }),
   replyToDiscussion: vi.fn().mockResolvedValue({ id: "discussion-reply-1" }),
   editDiscussionReply: vi.fn().mockResolvedValue({ id: "discussion-reply-1" }),
   deleteDiscussionReply: vi.fn().mockResolvedValue({
@@ -81,18 +99,32 @@ vi.mock("../../../src/services/discussion-service.js", () => ({
   }),
   resolveDiscussion: vi.fn().mockResolvedValue({ id: "discussion-root-1" }),
   unresolveDiscussion: vi.fn().mockResolvedValue({ id: "discussion-root-1" }),
+  createDiscussionCommentReaction: vi
+    .fn()
+    .mockResolvedValue({ id: "reaction-1" }),
+  deleteDiscussionCommentReactionByEmoji: vi
+    .fn()
+    .mockResolvedValue({ id: "reaction-1", success: true }),
+  deleteDiscussionCommentReactionById: vi
+    .fn()
+    .mockResolvedValue({ id: "reaction-1", success: true }),
 }));
 
 import { setupProjectsCommands } from "../../../src/commands/projects.js";
 import { outputSuccess } from "../../../src/common/output.js";
 import { resolveProjectId } from "../../../src/resolvers/project-resolver.js";
 import {
+  createDiscussionCommentReaction,
   deleteDiscussionComment,
+  deleteDiscussionCommentReactionByEmoji,
+  deleteDiscussionCommentReactionById,
   deleteDiscussionReply,
   editDiscussionComment,
   editDiscussionReply,
   listDiscussionReplies,
+  listDiscussionRepliesWithReactions,
   listDiscussionsForProject,
+  listDiscussionsForProjectWithReactions,
   replyToDiscussion,
   resolveDiscussion,
   startProjectDiscussion,
@@ -400,6 +432,26 @@ describe("projects discussion commands", () => {
     });
   });
 
+  it("projects discussions --with-reactions routes to reaction-aware service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "discussions",
+      "My Project",
+      "--with-reactions",
+    ]);
+
+    expect(listDiscussionsForProjectWithReactions).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-project-uuid",
+      { limit: 25, after: undefined },
+    );
+    expect(listDiscussionsForProject).not.toHaveBeenCalled();
+  });
+
   it("projects replies forwards pagination", async () => {
     const program = createProgram();
 
@@ -433,6 +485,27 @@ describe("projects discussion commands", () => {
         endCursor: null,
       },
     });
+  });
+
+  it("projects replies --with-reactions routes to reaction-aware service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "replies",
+      "thread-1",
+      "--with-reactions",
+    ]);
+
+    expect(listDiscussionRepliesWithReactions).toHaveBeenCalledWith(
+      expect.anything(),
+      "thread-1",
+      { limit: 50, after: undefined },
+      "project",
+    );
+    expect(listDiscussionReplies).not.toHaveBeenCalled();
   });
 
   it("projects reply delegates to discussion service", async () => {
@@ -655,6 +728,79 @@ describe("projects discussion commands", () => {
       "project",
     );
     expect(outputSuccess).toHaveBeenCalledWith({ id: "discussion-root-1" });
+  });
+
+  it("projects threads react delegates to comment reaction service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "threads",
+      "react",
+      "thread-1",
+      "🎉",
+    ]);
+
+    expect(createDiscussionCommentReaction).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        commentId: "thread-1",
+        target: "thread",
+        expectedEntityKind: "project",
+        emoji: "🎉",
+      },
+    );
+  });
+
+  it("projects threads unreact supports --shortcode", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "threads",
+      "unreact",
+      "thread-1",
+      "--shortcode",
+      "thumbs_up",
+    ]);
+
+    expect(deleteDiscussionCommentReactionByEmoji).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        commentId: "thread-1",
+        target: "thread",
+        expectedEntityKind: "project",
+        emoji: "👍",
+      },
+    );
+  });
+
+  it("projects replies unreact-id delegates to comment reaction service", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "replies",
+      "unreact-id",
+      "reply-1",
+      "reaction-123",
+    ]);
+
+    expect(deleteDiscussionCommentReactionById).toHaveBeenCalledWith(
+      expect.anything(),
+      {
+        commentId: "reply-1",
+        target: "reply",
+        expectedEntityKind: "project",
+        reactionId: "reaction-123",
+      },
+    );
   });
 });
 

--- a/tests/unit/common/emoji.test.ts
+++ b/tests/unit/common/emoji.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import {
+  normalizeReactionEmojiInput,
+  resolveReactionEmojiInput,
+} from "../../../src/common/emoji.js";
+
+describe("resolveReactionEmojiInput", () => {
+  it("accepts positional emoji", () => {
+    expect(resolveReactionEmojiInput("👍", undefined)).toBe("👍");
+  });
+
+  it("accepts shortcode through the primary emojify path", () => {
+    expect(resolveReactionEmojiInput(undefined, "smile")).toBe("😄");
+  });
+
+  it("accepts thumbs_up through the fallback alias path", () => {
+    expect(resolveReactionEmojiInput(undefined, "thumbs_up")).toBe("👍");
+  });
+
+  it("treats whitespace-only shortcode input as missing", () => {
+    expect(() => resolveReactionEmojiInput(undefined, "   ")).toThrow(
+      "emoji or --shortcode is required",
+    );
+  });
+
+  it("rejects unknown shortcode", () => {
+    expect(() =>
+      resolveReactionEmojiInput(undefined, "nonexistent_shortcode"),
+    ).toThrow('unknown emoji shortcode "nonexistent_shortcode"');
+  });
+
+  it("rejects missing emoji input", () => {
+    expect(() => resolveReactionEmojiInput(undefined, undefined)).toThrow(
+      "emoji or --shortcode is required",
+    );
+  });
+
+  it("treats whitespace-only positional input as absent when shortcode is provided", () => {
+    expect(resolveReactionEmojiInput("   ", "smile")).toBe("😄");
+  });
+
+  it("rejects mixed positional emoji and shortcode", () => {
+    expect(() => resolveReactionEmojiInput("👍", "thumbs_up")).toThrow(
+      "cannot provide both positional emoji and --shortcode",
+    );
+  });
+
+  it("treats whitespace-only shortcode as absent when positional emoji is provided", () => {
+    expect(resolveReactionEmojiInput("👍", "   ")).toBe("👍");
+  });
+});
+
+describe("normalizeReactionEmojiInput", () => {
+  it("trims whitespace around emoji", () => {
+    expect(normalizeReactionEmojiInput("  👍  ")).toBe("👍");
+  });
+
+  it("rejects empty emoji", () => {
+    expect(() => normalizeReactionEmojiInput("   ")).toThrow(
+      "emoji must not be empty",
+    );
+  });
+});

--- a/tests/unit/services/discussion-service.test.ts
+++ b/tests/unit/services/discussion-service.test.ts
@@ -1,18 +1,46 @@
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import {
   GetDiscussionCommentContextDocument,
   type ListIssueDiscussionRootsQuery,
 } from "../../../src/gql/graphql.js";
+
+vi.mock("../../../src/services/reaction-service.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../../../src/services/reaction-service.js")
+    >();
+  return {
+    ...actual,
+    createReactionForComment: vi.fn().mockResolvedValue({ id: "reaction-1" }),
+    deleteOwnReactionByEmoji: vi
+      .fn()
+      .mockResolvedValue({ id: "reaction-1", success: true }),
+    deleteOwnReactionById: vi
+      .fn()
+      .mockResolvedValue({ id: "reaction-1", success: true }),
+  };
+});
+
 import {
+  createDiscussionCommentReaction,
+  createIssueDiscussionCommentReaction,
   deleteDiscussionComment,
+  deleteDiscussionCommentReactionByEmoji,
+  deleteDiscussionCommentReactionById,
   deleteDiscussionReply,
+  deleteIssueDiscussionCommentReactionByEmoji,
+  deleteIssueDiscussionCommentReactionById,
   editDiscussionComment,
   editDiscussionReply,
   listDiscussionReplies,
+  listDiscussionRepliesWithReactions,
   listDiscussionsForInitiative,
+  listDiscussionsForInitiativeWithReactions,
   listDiscussionsForIssue,
+  listDiscussionsForIssueWithReactions,
   listDiscussionsForProject,
+  listDiscussionsForProjectWithReactions,
   replyToDiscussion,
   resolveDiscussion,
   startInitiativeDiscussion,
@@ -20,6 +48,11 @@ import {
   startProjectDiscussion,
   unresolveDiscussion,
 } from "../../../src/services/discussion-service.js";
+import {
+  createReactionForComment,
+  deleteOwnReactionByEmoji,
+  deleteOwnReactionById,
+} from "../../../src/services/reaction-service.js";
 
 function createClientMock(): GraphQLClient {
   return {
@@ -28,6 +61,7 @@ function createClientMock(): GraphQLClient {
 }
 
 const MOCK_USER = { id: "user-1", displayName: "Test User" };
+const REACTION_USER = { id: "user-1", displayName: "Ada" };
 
 function comment(id: string, parentId: string | null = null) {
   return {
@@ -42,6 +76,219 @@ function comment(id: string, parentId: string | null = null) {
     user: MOCK_USER,
   };
 }
+
+function commentWithReaction(id: string, parentId: string | null = null) {
+  return {
+    ...comment(id, parentId),
+    reactions: [
+      {
+        id: "r-1",
+        emoji: "👍",
+        user: REACTION_USER,
+        externalUser: null,
+      },
+    ],
+  };
+}
+
+describe("discussion comment reactions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("creates thread reaction after validating root comment and entity kind", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValue({
+      comment: {
+        ...comment("thread-1"),
+        issueId: "issue-1",
+        projectId: null,
+        initiativeId: null,
+      },
+    });
+
+    await expect(
+      createDiscussionCommentReaction(client, {
+        commentId: "thread-1",
+        target: "thread",
+        expectedEntityKind: "issue",
+        emoji: "👍",
+      }),
+    ).resolves.toEqual({ id: "reaction-1" });
+
+    expect(client.request).toHaveBeenCalledWith(
+      GetDiscussionCommentContextDocument,
+      { id: "thread-1" },
+    );
+    expect(createReactionForComment).toHaveBeenCalledWith(expect.anything(), {
+      commentId: "thread-1",
+      emoji: "👍",
+    });
+  });
+
+  it("rejects thread reaction when comment is a reply", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValue({
+      comment: {
+        ...comment("reply-1", "thread-1"),
+        issueId: "issue-1",
+        projectId: null,
+        initiativeId: null,
+      },
+    });
+
+    await expect(
+      createDiscussionCommentReaction(client, {
+        commentId: "reply-1",
+        target: "thread",
+        expectedEntityKind: "issue",
+        emoji: "👍",
+      }),
+    ).rejects.toThrow(
+      'Discussion thread ID "reply-1" must reference a root comment',
+    );
+
+    expect(createReactionForComment).not.toHaveBeenCalled();
+  });
+
+  it("rejects reply reaction when entity kind does not match", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValue({
+      comment: {
+        ...comment("reply-1", "thread-1"),
+        issueId: null,
+        projectId: "project-1",
+        initiativeId: null,
+      },
+    });
+
+    await expect(
+      deleteDiscussionCommentReactionByEmoji(client, {
+        commentId: "reply-1",
+        target: "reply",
+        expectedEntityKind: "issue",
+        emoji: "👍",
+      }),
+    ).rejects.toThrow(
+      'Discussion reply ID "reply-1" belongs to project, not issue',
+    );
+
+    expect(deleteOwnReactionByEmoji).not.toHaveBeenCalled();
+  });
+
+  it("deletes reply reaction by id after validation", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValue({
+      comment: {
+        ...comment("reply-1", "thread-1"),
+        issueId: null,
+        projectId: null,
+        initiativeId: "initiative-1",
+      },
+    });
+
+    await expect(
+      deleteDiscussionCommentReactionById(client, {
+        commentId: "reply-1",
+        target: "reply",
+        expectedEntityKind: "initiative",
+        reactionId: "reaction-1",
+      }),
+    ).resolves.toEqual({ id: "reaction-1", success: true });
+
+    expect(deleteOwnReactionById).toHaveBeenCalledWith(expect.anything(), {
+      kind: "comment",
+      id: "reply-1",
+      reactionId: "reaction-1",
+    });
+  });
+
+  it("creates deprecated issue comment reaction after validating issue ownership", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValue({
+      comment: {
+        ...comment("comment-1"),
+        issueId: "issue-1",
+        projectId: null,
+        initiativeId: null,
+      },
+    });
+
+    await expect(
+      createIssueDiscussionCommentReaction(client, {
+        commentId: "comment-1",
+        emoji: "👍",
+      }),
+    ).resolves.toEqual({ id: "reaction-1" });
+
+    expect(createReactionForComment).toHaveBeenCalledWith(expect.anything(), {
+      commentId: "comment-1",
+      emoji: "👍",
+    });
+  });
+
+  it("rejects deprecated issue comment reaction for non-issue comment", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValue({
+      comment: {
+        ...comment("comment-1"),
+        issueId: null,
+        projectId: "project-1",
+        initiativeId: null,
+      },
+    });
+
+    await expect(
+      createIssueDiscussionCommentReaction(client, {
+        commentId: "comment-1",
+        emoji: "👍",
+      }),
+    ).rejects.toThrow(
+      'Discussion comment ID "comment-1" belongs to project, not issue',
+    );
+
+    expect(createReactionForComment).not.toHaveBeenCalled();
+  });
+
+  it("rejects deprecated issue comment unreact by emoji for missing comment", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValue({ comment: null });
+
+    await expect(
+      deleteIssueDiscussionCommentReactionByEmoji(client, {
+        commentId: "comment-1",
+        emoji: "👍",
+      }),
+    ).rejects.toThrow('Discussion comment ID "comment-1" not found');
+
+    expect(deleteOwnReactionByEmoji).not.toHaveBeenCalled();
+  });
+
+  it("deletes deprecated issue comment reaction by id after validation", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValue({
+      comment: {
+        ...comment("comment-1"),
+        issueId: "issue-1",
+        projectId: null,
+        initiativeId: null,
+      },
+    });
+
+    await expect(
+      deleteIssueDiscussionCommentReactionById(client, {
+        commentId: "comment-1",
+        reactionId: "reaction-1",
+      }),
+    ).resolves.toEqual({ id: "reaction-1", success: true });
+
+    expect(deleteOwnReactionById).toHaveBeenCalledWith(expect.anything(), {
+      kind: "comment",
+      id: "comment-1",
+      reactionId: "reaction-1",
+    });
+  });
+});
 
 describe("listDiscussionsForIssue", () => {
   it("returns root threads only", async () => {
@@ -80,6 +327,33 @@ describe("listDiscussionsForIssue", () => {
       listDiscussionsForIssue(client, "issue-missing"),
     ).rejects.toThrow('Issue with ID "issue-missing" not found');
   });
+
+  it("listDiscussionsForIssueWithReactions normalizes thread reactions", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValue({
+      issue: {
+        comments: {
+          nodes: [commentWithReaction("root-1")],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+    });
+
+    const result = await listDiscussionsForIssueWithReactions(
+      client,
+      "issue-1",
+      { limit: 10 },
+    );
+
+    expect(result.nodes[0].reactions).toEqual([
+      {
+        emoji: "👍",
+        count: 1,
+        users: [{ id: "user-1", displayName: "Ada", type: "user" }],
+        reactionIds: ["r-1"],
+      },
+    ]);
+  });
 });
 
 describe("listDiscussionsForProject", () => {
@@ -116,6 +390,33 @@ describe("listDiscussionsForProject", () => {
       listDiscussionsForProject(client, "project-missing"),
     ).rejects.toThrow('Project with ID "project-missing" not found');
   });
+
+  it("listDiscussionsForProjectWithReactions normalizes thread reactions", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValue({
+      project: {
+        comments: {
+          nodes: [commentWithReaction("root-1")],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+    });
+
+    const result = await listDiscussionsForProjectWithReactions(
+      client,
+      "project-1",
+      { limit: 10 },
+    );
+
+    expect(result.nodes[0].reactions).toEqual([
+      {
+        emoji: "👍",
+        count: 1,
+        users: [{ id: "user-1", displayName: "Ada", type: "user" }],
+        reactionIds: ["r-1"],
+      },
+    ]);
+  });
 });
 
 describe("listDiscussionsForInitiative", () => {
@@ -147,6 +448,32 @@ describe("listDiscussionsForInitiative", () => {
     await expect(
       listDiscussionsForInitiative(client, "initiative-missing"),
     ).rejects.toThrow('Initiative with ID "initiative-missing" not found');
+  });
+
+  it("listDiscussionsForInitiativeWithReactions normalizes thread reactions", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request).mockResolvedValue({
+      initiative: { id: "initiative-1" },
+      comments: {
+        nodes: [commentWithReaction("root-1")],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+
+    const result = await listDiscussionsForInitiativeWithReactions(
+      client,
+      "initiative-1",
+      { limit: 10 },
+    );
+
+    expect(result.nodes[0].reactions).toEqual([
+      {
+        emoji: "👍",
+        count: 1,
+        users: [{ id: "user-1", displayName: "Ada", type: "user" }],
+        reactionIds: ["r-1"],
+      },
+    ]);
   });
 });
 
@@ -280,6 +607,41 @@ describe("listDiscussionReplies", () => {
     await expect(listDiscussionReplies(client, "reply-1")).rejects.toThrow(
       'Discussion thread ID "reply-1" must reference a root comment',
     );
+  });
+
+  it("listDiscussionRepliesWithReactions normalizes reply reactions", async () => {
+    const client = createClientMock();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        comment: {
+          ...comment("root-1"),
+          issueId: "issue-1",
+          projectId: null,
+          initiativeId: null,
+        },
+      })
+      .mockResolvedValueOnce({
+        comments: {
+          nodes: [commentWithReaction("reply-1", "root-1")],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      });
+
+    const result = await listDiscussionRepliesWithReactions(
+      client,
+      "root-1",
+      { limit: 10 },
+      "issue",
+    );
+
+    expect(result.nodes[0].reactions).toEqual([
+      {
+        emoji: "👍",
+        count: 1,
+        users: [{ id: "user-1", displayName: "Ada", type: "user" }],
+        reactionIds: ["r-1"],
+      },
+    ]);
   });
 });
 

--- a/tests/unit/services/initiative-service.test.ts
+++ b/tests/unit/services/initiative-service.test.ts
@@ -1,5 +1,7 @@
+import { type DocumentNode, type FragmentDefinitionNode, Kind } from "graphql";
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { GetInitiativeDocument } from "../../../src/gql/graphql.js";
 import {
   archiveInitiative,
   createInitiative,
@@ -15,6 +17,46 @@ function mockGqlClient(response: Record<string, unknown>): GraphQLClient {
     request: vi.fn().mockResolvedValue(response),
   } as unknown as GraphQLClient;
 }
+
+function getFragment(
+  document: DocumentNode,
+  name: string,
+): FragmentDefinitionNode {
+  const fragment = document.definitions.find(
+    (definition): definition is FragmentDefinitionNode =>
+      definition.kind === Kind.FRAGMENT_DEFINITION &&
+      definition.name.value === name,
+  );
+
+  if (!fragment) {
+    throw new Error(`Fragment ${name} not found`);
+  }
+
+  return fragment;
+}
+
+describe("initiative reaction-aware read documents", () => {
+  it("keeps initiative detail reads free of out-of-scope reaction fragments", () => {
+    const baseFragment = getFragment(
+      GetInitiativeDocument,
+      "InitiativeExpandedFields",
+    );
+
+    expect(
+      baseFragment.selectionSet.selections
+        .filter((selection) => selection.kind === Kind.FIELD)
+        .map((selection) => selection.name.value),
+    ).toContain("initiativeUpdates");
+
+    expect(() =>
+      getFragment(GetInitiativeDocument, "InitiativeUpdateFieldsWithReactions"),
+    ).toThrow("Fragment InitiativeUpdateFieldsWithReactions not found");
+
+    expect(() =>
+      getFragment(GetInitiativeDocument, "InitiativeFieldsWithReactions"),
+    ).toThrow("Fragment InitiativeFieldsWithReactions not found");
+  });
+});
 
 describe("listInitiatives", () => {
   it("forwards pagination, includeArchived, filter, and orderBy", async () => {

--- a/tests/unit/services/issue-service.test.ts
+++ b/tests/unit/services/issue-service.test.ts
@@ -9,8 +9,10 @@ import {
   GetIssueByIdentifierDocument,
   GetIssueByIdentifierWithAttachmentsDocument,
   GetIssueByIdentifierWithCommentsDocument,
+  GetIssueByIdentifierWithReactionsDocument,
   GetIssueByIdWithAttachmentsDocument,
   GetIssueByIdWithCommentsDocument,
+  GetIssueByIdWithReactionsDocument,
   GetIssuesDocument,
   PaginationOrderBy,
   SearchIssuesDocument,
@@ -25,9 +27,11 @@ import {
   getIssueByIdentifierWithAttachments,
   getIssueByIdentifierWithComments,
   getIssueByIdentifierWithCommentThreads,
+  getIssueByIdentifierWithReactions,
   getIssueWithAttachments,
   getIssueWithComments,
   getIssueWithCommentThreads,
+  getIssueWithReactions,
   listIssues,
   searchIssues,
   unarchiveIssue,
@@ -565,6 +569,129 @@ describe("updateIssue", () => {
     await expect(
       updateIssue(client, "issue-id", { title: "Fail" }),
     ).rejects.toThrow("Failed to update issue");
+  });
+});
+
+describe("getIssueWithReactions", () => {
+  it("returns issue by UUID with normalized grouped reactions", async () => {
+    const client = mockGqlClient({
+      issue: {
+        id: "issue-1",
+        title: "Found",
+        comments: { nodes: [{ id: "comment-1", body: "First" }] },
+        reactions: [
+          {
+            id: "r-2",
+            emoji: "👍",
+            user: { id: "user-2", displayName: "Bob" },
+            externalUser: null,
+          },
+          {
+            id: "r-1",
+            emoji: "👍",
+            user: { id: "user-1", displayName: "Ada" },
+            externalUser: null,
+          },
+          {
+            id: "r-3",
+            emoji: "🎉",
+            user: null,
+            externalUser: { id: "ext-1", name: "Zed" },
+          },
+        ],
+      },
+    });
+
+    const result = await getIssueWithReactions(client, "issue-1");
+
+    expect(result.reactions).toEqual([
+      {
+        emoji: "👍",
+        count: 2,
+        users: [
+          { id: "user-1", displayName: "Ada", type: "user" },
+          { id: "user-2", displayName: "Bob", type: "user" },
+        ],
+        reactionIds: ["r-1", "r-2"],
+      },
+      {
+        emoji: "🎉",
+        count: 1,
+        users: [{ id: "ext-1", displayName: "Zed", type: "external" }],
+        reactionIds: ["r-3"],
+      },
+    ]);
+    expect(client.request).toHaveBeenCalledWith(
+      GetIssueByIdWithReactionsDocument,
+      { id: "issue-1" },
+    );
+  });
+
+  it("throws when issue not found by UUID", async () => {
+    const client = mockGqlClient({ issue: null });
+
+    await expect(getIssueWithReactions(client, "missing")).rejects.toThrow(
+      'Issue with ID "missing" not found',
+    );
+  });
+});
+
+describe("getIssueByIdentifierWithReactions", () => {
+  it("returns issue by identifier with normalized grouped reactions", async () => {
+    const client = mockGqlClient({
+      issues: {
+        nodes: [
+          {
+            id: "issue-1",
+            title: "Found",
+            comments: { nodes: [{ id: "comment-1", body: "First" }] },
+            reactions: [
+              {
+                id: "r-2",
+                emoji: "👍",
+                user: { id: "user-2", displayName: "Bob" },
+                externalUser: null,
+              },
+              {
+                id: "r-1",
+                emoji: "👍",
+                user: { id: "user-1", displayName: "Ada" },
+                externalUser: null,
+              },
+            ],
+          },
+        ],
+      },
+    });
+
+    const result = await getIssueByIdentifierWithReactions(client, "ENG", 42);
+
+    expect(result.reactions).toEqual([
+      {
+        emoji: "👍",
+        count: 2,
+        users: [
+          { id: "user-1", displayName: "Ada", type: "user" },
+          { id: "user-2", displayName: "Bob", type: "user" },
+        ],
+        reactionIds: ["r-1", "r-2"],
+      },
+    ]);
+    expect(client.request).toHaveBeenCalledWith(
+      GetIssueByIdentifierWithReactionsDocument,
+      {
+        teamKey: "ENG",
+        number: 42,
+      },
+    );
+  });
+
+  it("throws when issue not found by identifier", async () => {
+    const client = mockGqlClient({ issues: { nodes: [] } });
+
+    await expect(
+      getIssueByIdentifierWithReactions(client, "ENG", 999),
+    ).rejects.toThrow('Issue with identifier "ENG-999" not found');
   });
 });
 

--- a/tests/unit/services/project-service.test.ts
+++ b/tests/unit/services/project-service.test.ts
@@ -1,7 +1,12 @@
 // tests/unit/services/project-service.test.ts
+import { type DocumentNode, type FragmentDefinitionNode, Kind } from "graphql";
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
-import { ArchiveProjectDocument } from "../../../src/gql/graphql.js";
+import {
+  ArchiveProjectDocument,
+  GetProjectDocument,
+  GetProjectWithReactionsDocument,
+} from "../../../src/gql/graphql.js";
 import {
   archiveProject,
   createProject,
@@ -17,6 +22,96 @@ function mockGqlClient(response: Record<string, unknown>): GraphQLClient {
     request: vi.fn().mockResolvedValue(response),
   } as unknown as GraphQLClient;
 }
+
+function getFragment(
+  document: DocumentNode,
+  name: string,
+): FragmentDefinitionNode {
+  const fragment = document.definitions.find(
+    (definition): definition is FragmentDefinitionNode =>
+      definition.kind === Kind.FRAGMENT_DEFINITION &&
+      definition.name.value === name,
+  );
+
+  if (!fragment) {
+    throw new Error(`Fragment ${name} not found`);
+  }
+
+  return fragment;
+}
+
+describe("project reaction-aware read documents", () => {
+  it("adds only paginated root discussion comments with reactions to the opt-in project read", () => {
+    const baseFragment = getFragment(GetProjectDocument, "ProjectDetailFields");
+    const reactionFragment = getFragment(
+      GetProjectWithReactionsDocument,
+      "ProjectDetailFieldsWithReactions",
+    );
+
+    const reactionSelections = reactionFragment.selectionSet.selections.filter(
+      (selection) =>
+        selection.kind === Kind.FRAGMENT_SPREAD ||
+        selection.kind === Kind.FIELD,
+    );
+
+    expect(
+      reactionSelections.map((selection) =>
+        selection.kind === Kind.FRAGMENT_SPREAD
+          ? `...${selection.name.value}`
+          : selection.name.value,
+      ),
+    ).toEqual(["...ProjectDetailFields", "comments"]);
+
+    const commentsField = reactionSelections.find(
+      (selection) =>
+        selection.kind === Kind.FIELD && selection.name.value === "comments",
+    );
+
+    expect(commentsField).toBeDefined();
+    if (!commentsField || commentsField.kind !== Kind.FIELD) {
+      throw new Error("comments field not found");
+    }
+
+    expect(
+      commentsField.arguments?.map((argument) => argument.name.value),
+    ).toEqual(["first", "after", "filter"]);
+
+    const filterArgument = commentsField.arguments?.find(
+      (argument) => argument.name.value === "filter",
+    );
+    expect(filterArgument).toBeDefined();
+
+    const commentsSelections = commentsField.selectionSet?.selections.filter(
+      (selection) => selection.kind === Kind.FIELD,
+    );
+    expect(
+      commentsSelections?.map((selection) => selection.name.value),
+    ).toEqual(["nodes", "pageInfo"]);
+
+    const nodesField = commentsSelections?.find(
+      (selection) => selection.name.value === "nodes",
+    );
+    expect(nodesField?.selectionSet?.selections).toHaveLength(1);
+    expect(nodesField?.selectionSet?.selections[0]).toMatchObject({
+      kind: Kind.FRAGMENT_SPREAD,
+      name: { value: "DiscussionCommentFieldsWithReactions" },
+    });
+
+    const pageInfoField = commentsSelections?.find(
+      (selection) => selection.name.value === "pageInfo",
+    );
+    expect(
+      pageInfoField?.selectionSet?.selections
+        .filter((selection) => selection.kind === Kind.FIELD)
+        .map((selection) => selection.name.value),
+    ).toEqual(["hasNextPage", "endCursor"]);
+
+    const baseFieldNames = baseFragment.selectionSet.selections
+      .filter((selection) => selection.kind === Kind.FIELD)
+      .map((selection) => selection.name.value);
+    expect(baseFieldNames).not.toContain("comments");
+  });
+});
 
 describe("listProjects", () => {
   it("returns projects", async () => {

--- a/tests/unit/services/reaction-service.test.ts
+++ b/tests/unit/services/reaction-service.test.ts
@@ -1,0 +1,455 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import {
+  createReactionForComment,
+  createReactionForIssue,
+  deleteOwnReactionByEmoji,
+  deleteOwnReactionById,
+  normalizeReactions,
+} from "../../../src/services/reaction-service.js";
+
+function createClient(): GraphQLClient {
+  return { request: vi.fn() } as unknown as GraphQLClient;
+}
+
+describe("createReactionForIssue", () => {
+  it("creates a reaction when the viewer has not used that emoji yet", async () => {
+    const client = createClient();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        viewer: { id: "user-1", name: "Ada", email: "ada@example.com" },
+      })
+      .mockResolvedValueOnce({
+        issue: {
+          id: "issue-1",
+          reactions: [
+            {
+              id: "r-1",
+              emoji: "🎉",
+              user: { id: "user-2", displayName: "Bob" },
+              externalUser: null,
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        reactionCreate: {
+          success: true,
+          reaction: {
+            id: "r-2",
+            emoji: "👍",
+            user: { id: "user-1", displayName: "Ada" },
+            externalUser: null,
+          },
+        },
+      });
+
+    await expect(
+      createReactionForIssue(client, { issueId: "issue-1", emoji: "👍" }),
+    ).resolves.toEqual({
+      id: "r-2",
+      emoji: "👍",
+      user: { id: "user-1", displayName: "Ada" },
+      externalUser: null,
+    });
+    expect(client.request).toHaveBeenNthCalledWith(3, expect.anything(), {
+      input: { issueId: "issue-1", emoji: "👍" },
+    });
+  });
+
+  it("rejects duplicate viewer reaction before mutation", async () => {
+    const client = createClient();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        viewer: { id: "user-1", name: "Ada", email: "ada@example.com" },
+      })
+      .mockResolvedValueOnce({
+        issue: {
+          id: "issue-1",
+          reactions: [
+            {
+              id: "r-1",
+              emoji: "👍",
+              user: { id: "user-1", displayName: "Ada" },
+              externalUser: null,
+            },
+          ],
+        },
+      });
+
+    await expect(
+      createReactionForIssue(client, { issueId: "issue-1", emoji: "👍" }),
+    ).rejects.toThrow("Already reacted with emoji 👍");
+  });
+
+  it("normalizes emoji before duplicate viewer reaction checks", async () => {
+    const client = createClient();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        viewer: { id: "user-1", name: "Ada", email: "ada@example.com" },
+      })
+      .mockResolvedValueOnce({
+        issue: {
+          id: "issue-1",
+          reactions: [
+            {
+              id: "r-1",
+              emoji: "👍",
+              user: { id: "user-1", displayName: "Ada" },
+              externalUser: null,
+            },
+          ],
+        },
+      });
+
+    await expect(
+      createReactionForIssue(client, { issueId: "issue-1", emoji: "  👍  " }),
+    ).rejects.toThrow("Already reacted with emoji 👍");
+    expect(client.request).toHaveBeenCalledTimes(2);
+  });
+
+  it("fails clearly when the issue target does not exist", async () => {
+    const client = createClient();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        viewer: { id: "user-1", name: "Ada", email: "ada@example.com" },
+      })
+      .mockResolvedValueOnce({ issue: null });
+
+    await expect(
+      createReactionForIssue(client, {
+        issueId: "issue-missing",
+        emoji: "👍",
+      }),
+    ).rejects.toThrow('Issue with ID "issue-missing" not found');
+  });
+});
+
+describe("createReactionForComment", () => {
+  it("creates a reaction for a comment when the viewer has not used that emoji yet", async () => {
+    const client = createClient();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        viewer: { id: "user-1", name: "Ada", email: "ada@example.com" },
+      })
+      .mockResolvedValueOnce({
+        comment: {
+          id: "comment-1",
+          parentId: null,
+          reactions: [
+            {
+              id: "r-1",
+              emoji: "👀",
+              user: { id: "user-2", displayName: "Bob" },
+              externalUser: null,
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        reactionCreate: {
+          success: true,
+          reaction: {
+            id: "r-2",
+            emoji: "👍",
+            user: { id: "user-1", displayName: "Ada" },
+            externalUser: null,
+          },
+        },
+      });
+
+    await expect(
+      createReactionForComment(client, { commentId: "comment-1", emoji: "👍" }),
+    ).resolves.toEqual({
+      id: "r-2",
+      emoji: "👍",
+      user: { id: "user-1", displayName: "Ada" },
+      externalUser: null,
+    });
+  });
+
+  it("fails clearly when the comment target does not exist", async () => {
+    const client = createClient();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        viewer: { id: "user-1", name: "Ada", email: "ada@example.com" },
+      })
+      .mockResolvedValueOnce({ comment: null });
+
+    await expect(
+      createReactionForComment(client, {
+        commentId: "comment-missing",
+        emoji: "👍",
+      }),
+    ).rejects.toThrow('Discussion comment ID "comment-missing" not found');
+  });
+});
+
+describe("deleteOwnReactionByEmoji", () => {
+  it("deletes viewer-owned matching reaction", async () => {
+    const client = createClient();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        viewer: { id: "user-1", name: "Ada", email: "ada@example.com" },
+      })
+      .mockResolvedValueOnce({
+        comment: {
+          id: "comment-1",
+          parentId: null,
+          reactions: [
+            {
+              id: "r-1",
+              emoji: "👍",
+              user: { id: "user-1", displayName: "Ada" },
+              externalUser: null,
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        reactionDelete: { success: true, entityId: "r-1" },
+      });
+
+    await expect(
+      deleteOwnReactionByEmoji(client, {
+        kind: "comment",
+        id: "comment-1",
+        emoji: "👍",
+      }),
+    ).resolves.toEqual({ id: "r-1", success: true });
+  });
+
+  it("normalizes emoji before matching viewer-owned reactions", async () => {
+    const client = createClient();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        viewer: { id: "user-1", name: "Ada", email: "ada@example.com" },
+      })
+      .mockResolvedValueOnce({
+        comment: {
+          id: "comment-1",
+          parentId: null,
+          reactions: [
+            {
+              id: "r-1",
+              emoji: "👍",
+              user: { id: "user-1", displayName: "Ada" },
+              externalUser: null,
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        reactionDelete: { success: true, entityId: "r-1" },
+      });
+
+    await expect(
+      deleteOwnReactionByEmoji(client, {
+        kind: "comment",
+        id: "comment-1",
+        emoji: "  👍  ",
+      }),
+    ).resolves.toEqual({ id: "r-1", success: true });
+  });
+
+  it("fails when the viewer has no matching reaction for the emoji", async () => {
+    const client = createClient();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        viewer: { id: "user-1", name: "Ada", email: "ada@example.com" },
+      })
+      .mockResolvedValueOnce({
+        comment: {
+          id: "comment-1",
+          parentId: null,
+          reactions: [
+            {
+              id: "r-1",
+              emoji: "👍",
+              user: { id: "user-2", displayName: "Bob" },
+              externalUser: null,
+            },
+          ],
+        },
+      });
+
+    await expect(
+      deleteOwnReactionByEmoji(client, {
+        kind: "comment",
+        id: "comment-1",
+        emoji: "👍",
+      }),
+    ).rejects.toThrow("No own reaction found with emoji 👍");
+  });
+
+  it("fails when the viewer has multiple matching reactions for the emoji", async () => {
+    const client = createClient();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        viewer: { id: "user-1", name: "Ada", email: "ada@example.com" },
+      })
+      .mockResolvedValueOnce({
+        comment: {
+          id: "comment-1",
+          parentId: null,
+          reactions: [
+            {
+              id: "r-1",
+              emoji: "👍",
+              user: { id: "user-1", displayName: "Ada" },
+              externalUser: null,
+            },
+            {
+              id: "r-2",
+              emoji: "👍",
+              user: { id: "user-1", displayName: "Ada" },
+              externalUser: null,
+            },
+          ],
+        },
+      });
+
+    await expect(
+      deleteOwnReactionByEmoji(client, {
+        kind: "comment",
+        id: "comment-1",
+        emoji: "👍",
+      }),
+    ).rejects.toThrow("Multiple own reactions found with emoji 👍");
+  });
+});
+
+describe("deleteOwnReactionById", () => {
+  it("deletes a viewer-owned reaction by id", async () => {
+    const client = createClient();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        viewer: { id: "user-1", name: "Ada", email: "ada@example.com" },
+      })
+      .mockResolvedValueOnce({
+        issue: {
+          id: "issue-1",
+          reactions: [
+            {
+              id: "r-1",
+              emoji: "👍",
+              user: { id: "user-1", displayName: "Ada" },
+              externalUser: null,
+            },
+          ],
+        },
+      })
+      .mockResolvedValueOnce({
+        reactionDelete: { success: true, entityId: "r-1" },
+      });
+
+    await expect(
+      deleteOwnReactionById(client, {
+        kind: "issue",
+        id: "issue-1",
+        reactionId: "r-1",
+      }),
+    ).resolves.toEqual({ id: "r-1", success: true });
+  });
+
+  it("fails when the reaction id does not exist on the target", async () => {
+    const client = createClient();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        viewer: { id: "user-1", name: "Ada", email: "ada@example.com" },
+      })
+      .mockResolvedValueOnce({
+        issue: {
+          id: "issue-1",
+          reactions: [
+            {
+              id: "r-1",
+              emoji: "👍",
+              user: { id: "user-1", displayName: "Ada" },
+              externalUser: null,
+            },
+          ],
+        },
+      });
+
+    await expect(
+      deleteOwnReactionById(client, {
+        kind: "issue",
+        id: "issue-1",
+        reactionId: "missing-reaction",
+      }),
+    ).rejects.toThrow('Reaction "missing-reaction" not found');
+  });
+
+  it("fails when the reaction is not owned by the viewer", async () => {
+    const client = createClient();
+    vi.mocked(client.request)
+      .mockResolvedValueOnce({
+        viewer: { id: "user-1", name: "Ada", email: "ada@example.com" },
+      })
+      .mockResolvedValueOnce({
+        issue: {
+          id: "issue-1",
+          reactions: [
+            {
+              id: "r-1",
+              emoji: "👍",
+              user: { id: "user-2", displayName: "Bob" },
+              externalUser: null,
+            },
+          ],
+        },
+      });
+
+    await expect(
+      deleteOwnReactionById(client, {
+        kind: "issue",
+        id: "issue-1",
+        reactionId: "r-1",
+      }),
+    ).rejects.toThrow('Reaction "r-1" is not owned by viewer');
+  });
+});
+
+describe("normalizeReactions", () => {
+  it("groups and sorts workspace and external users deterministically", () => {
+    const result = normalizeReactions([
+      {
+        id: "r-2",
+        emoji: "👍",
+        user: { id: "u-2", displayName: "Bob" },
+        externalUser: null,
+      },
+      {
+        id: "r-1",
+        emoji: "👍",
+        user: { id: "u-1", displayName: "Ada" },
+        externalUser: null,
+      },
+      {
+        id: "r-3",
+        emoji: "🎉",
+        user: null,
+        externalUser: { id: "x-1", name: "CI Bot" },
+      },
+    ]);
+
+    expect(result).toEqual([
+      {
+        emoji: "👍",
+        count: 2,
+        users: [
+          { id: "u-1", displayName: "Ada", type: "user" },
+          { id: "u-2", displayName: "Bob", type: "user" },
+        ],
+        reactionIds: ["r-1", "r-2"],
+      },
+      {
+        emoji: "🎉",
+        count: 1,
+        users: [{ id: "x-1", displayName: "CI Bot", type: "external" }],
+        reactionIds: ["r-3"],
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds reaction support for supported Linear targets:

- Adds typed GraphQL operations for reaction create/delete and opt-in reaction-aware reads.
- Adds emoji/shortcode normalization plus a shared reaction service for duplicate checks, ownership checks, and normalized JSON output.
- Adds issue root reaction commands, discussion thread/reply reaction commands across issues/projects/initiatives, and deprecated `comments` reaction aliases.
- Documents the schema fallback: root project/initiative reactions are omitted because the generated schema does not support them.

Closes #83

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `npx vitest run tests/unit/common/emoji.test.ts tests/unit/services/reaction-service.test.ts tests/unit/services/issue-service.test.ts tests/unit/services/project-service.test.ts tests/unit/services/initiative-service.test.ts tests/unit/services/discussion-service.test.ts tests/unit/commands/issues.test.ts tests/unit/commands/projects.test.ts tests/unit/commands/initiatives.test.ts tests/unit/commands/comments.test.ts`
- `npm run check:ci`
- `npx tsc --noEmit`
- `npm test`
- `npm run build`

## Notes for reviewers

- Root project and root initiative reactions are intentionally not shipped; `ReactionCreateInput` supports `issueId` and `commentId`, but not root `projectId` or root `initiativeId`.
- Project/initiative reaction support is limited to discussion comments (threads/replies), matching the supported `commentId` reaction target.
- `comments` reaction commands are deprecated compatibility aliases and validate issue discussion ownership before delegating to the reaction service.
