### PR TITLE
fix(issues): resolve estimate context via team resolver

### DIFF
--- a/src/resolvers/issue-resolver.ts
+++ b/src/resolvers/issue-resolver.ts
@@ -1,107 +1,42 @@
 import type { LinearSdkClient } from "../client/linear-client.js";
 import { notFoundError } from "../common/errors.js";
 import { isUuid, parseIssueIdentifier } from "../common/identifier.js";
-import type { TeamEstimateContext } from "./team-resolver.js";
-
-type TeamEstimationType =
-  | "notUsed"
-  | "exponential"
-  | "fibonacci"
-  | "linear"
-  | "tShirt";
-
-type IssueEstimateNode = {
-  id: string;
-  team: {
-    id: string;
-    key: string;
-    name: string;
-    issueEstimationType: TeamEstimationType;
-    issueEstimationExtended: boolean;
-    issueEstimationAllowZero: boolean;
-  };
-};
+import {
+  resolveTeamEstimateContext,
+  type TeamEstimateContext,
+} from "./team-resolver.js";
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function isTeamEstimationType(value: unknown): value is TeamEstimationType {
-  return (
-    value === "notUsed" ||
-    value === "exponential" ||
-    value === "fibonacci" ||
-    value === "linear" ||
-    value === "tShirt"
-  );
+function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
+  if ((typeof value !== "object" && typeof value !== "function") || !value) {
+    return false;
+  }
+
+  return typeof (value as { then?: unknown }).then === "function";
 }
 
-function toIssueEstimateNode(
-  node: unknown,
-  issueIdOrIdentifier: string,
-): IssueEstimateNode {
-  if (!isRecord(node)) {
-    throw new Error(
-      `Issue "${issueIdOrIdentifier}" is missing required team estimation context`,
-    );
-  }
-
-  const issueId = node.id;
-  const team = node.team;
-
-  if (typeof issueId !== "string" || !isRecord(team)) {
-    throw new Error(
-      `Issue "${issueIdOrIdentifier}" is missing required team estimation context`,
-    );
-  }
-
-  const teamId = team.id;
-  const teamKey = team.key;
-  const teamName = team.name;
-  const issueEstimationType = team.issueEstimationType;
-  const issueEstimationExtended = team.issueEstimationExtended;
-  const issueEstimationAllowZero = team.issueEstimationAllowZero;
-
-  if (
-    typeof teamId !== "string" ||
-    typeof teamKey !== "string" ||
-    typeof teamName !== "string" ||
-    !isTeamEstimationType(issueEstimationType) ||
-    typeof issueEstimationExtended !== "boolean" ||
-    typeof issueEstimationAllowZero !== "boolean"
-  ) {
-    throw new Error(
-      `Issue "${issueIdOrIdentifier}" is missing required team estimation context`,
-    );
-  }
-
-  return {
-    id: issueId,
-    team: {
-      id: teamId,
-      key: teamKey,
-      name: teamName,
-      issueEstimationType,
-      issueEstimationExtended,
-      issueEstimationAllowZero,
-    },
-  };
+async function resolveRelationValue(value: unknown): Promise<unknown> {
+  return isPromiseLike(value) ? await value : value;
 }
 
-function mapIssueNodeToEstimateContext(
-  node: IssueEstimateNode,
-): IssueEstimateContext {
-  return {
-    issueId: node.id,
-    team: {
-      teamId: node.team.id,
-      teamKey: node.team.key,
-      teamName: node.team.name,
-      issueEstimationType: node.team.issueEstimationType,
-      issueEstimationExtended: node.team.issueEstimationExtended,
-      issueEstimationAllowZero: node.team.issueEstimationAllowZero,
-    },
-  };
+function getTeamLookupFromRelation(team: unknown): string | undefined {
+  if (!isRecord(team)) return undefined;
+
+  if (typeof team.id === "string") return team.id;
+  if (typeof team.key === "string") return team.key;
+
+  return undefined;
+}
+
+async function getIssueTeamLookup(
+  node: Record<string, unknown>,
+): Promise<string | undefined> {
+  if (typeof node.teamId === "string") return node.teamId;
+
+  return getTeamLookupFromRelation(await resolveRelationValue(node.team));
 }
 
 export interface IssueEstimateContext {
@@ -146,28 +81,45 @@ export async function resolveIssueEstimateContext(
   client: LinearSdkClient,
   issueIdOrIdentifier: string,
 ): Promise<IssueEstimateContext> {
-  const issues = isUuid(issueIdOrIdentifier)
-    ? await client.sdk.issues({
+  const issueIsUuid = isUuid(issueIdOrIdentifier);
+  const issues = await (issueIsUuid
+    ? client.sdk.issues({
         filter: { id: { eq: issueIdOrIdentifier } },
         first: 1,
       })
-    : await client.sdk.issues({
-        filter: {
-          number: {
-            eq: parseIssueIdentifier(issueIdOrIdentifier).issueNumber,
+    : (() => {
+        const { teamKey, issueNumber } =
+          parseIssueIdentifier(issueIdOrIdentifier);
+
+        return client.sdk.issues({
+          filter: {
+            number: { eq: issueNumber },
+            team: { key: { eq: teamKey } },
           },
-          team: {
-            key: { eq: parseIssueIdentifier(issueIdOrIdentifier).teamKey },
-          },
-        },
-        first: 1,
-      });
+          first: 1,
+        });
+      })());
 
   if (issues.nodes.length === 0) {
     throw notFoundError("Issue", issueIdOrIdentifier);
   }
 
-  return mapIssueNodeToEstimateContext(
-    toIssueEstimateNode(issues.nodes[0], issueIdOrIdentifier),
-  );
+  const issueNode = issues.nodes[0];
+  if (!isRecord(issueNode) || typeof issueNode.id !== "string") {
+    throw new Error(
+      `Issue "${issueIdOrIdentifier}" is missing required team context`,
+    );
+  }
+
+  const teamLookup = await getIssueTeamLookup(issueNode);
+  if (!teamLookup) {
+    throw new Error(
+      `Issue "${issueIdOrIdentifier}" is missing required team context`,
+    );
+  }
+
+  return {
+    issueId: issueNode.id,
+    team: await resolveTeamEstimateContext(client, teamLookup),
+  };
 }

--- a/tests/unit/resolvers/issue-resolver.test.ts
+++ b/tests/unit/resolvers/issue-resolver.test.ts
@@ -14,10 +14,10 @@ type IssueNode = {
         id?: string;
         key?: string;
       }
-    | (() => Promise<{
+    | Promise<{
         id?: string;
         key?: string;
-      }>);
+      }>;
 };
 
 type TeamNode = {
@@ -176,7 +176,7 @@ describe("resolveIssueEstimateContext", () => {
       [
         {
           id: "issue-uuid",
-          team: vi.fn().mockResolvedValue({ id: teamId, key: "ENG" }),
+          team: Promise.resolve({ id: teamId, key: "ENG" }),
         },
       ],
       [exponentialTeam],
@@ -203,7 +203,7 @@ describe("resolveIssueEstimateContext", () => {
       [
         {
           id: "issue-uuid",
-          team: vi.fn().mockResolvedValue({ key: "ENG" }),
+          team: Promise.resolve({ key: "ENG" }),
         },
       ],
       [exponentialTeam],

--- a/tests/unit/resolvers/issue-resolver.test.ts
+++ b/tests/unit/resolvers/issue-resolver.test.ts
@@ -8,28 +8,51 @@ import {
 
 type IssueNode = {
   id: string;
-  team?: {
-    id: string;
-    key: string;
-    name: string;
-    issueEstimationType:
-      | "notUsed"
-      | "exponential"
-      | "fibonacci"
-      | "linear"
-      | "tShirt";
-    issueEstimationExtended: boolean;
-    issueEstimationAllowZero: boolean;
-  };
+  teamId?: string;
+  team?:
+    | {
+        id?: string;
+        key?: string;
+      }
+    | (() => Promise<{
+        id?: string;
+        key?: string;
+      }>);
 };
 
-function mockSdkClient(nodes: IssueNode[]) {
+type TeamNode = {
+  id: string;
+  key: string;
+  name: string;
+  issueEstimationType:
+    | "notUsed"
+    | "exponential"
+    | "fibonacci"
+    | "linear"
+    | "tShirt";
+  issueEstimationExtended: boolean;
+  issueEstimationAllowZero: boolean;
+};
+
+function mockSdkClient(issueNodes: IssueNode[], teamNodes: TeamNode[] = []) {
   return {
     sdk: {
-      issues: vi.fn().mockResolvedValue({ nodes }),
+      issues: vi.fn().mockResolvedValue({ nodes: issueNodes }),
+      teams: vi.fn().mockResolvedValue({ nodes: teamNodes }),
     },
   } as unknown as LinearSdkClient;
 }
+
+const teamId = "550e8400-e29b-41d4-a716-446655440001";
+
+const exponentialTeam: TeamNode = {
+  id: teamId,
+  key: "ENG",
+  name: "Engineering",
+  issueEstimationType: "exponential",
+  issueEstimationExtended: false,
+  issueEstimationAllowZero: false,
+};
 
 describe("resolveIssueId", () => {
   it("returns UUID as-is", async () => {
@@ -56,27 +79,18 @@ describe("resolveIssueId", () => {
 });
 
 describe("resolveIssueEstimateContext", () => {
-  it("resolves by identifier with issueId + nested team estimate context fields", async () => {
-    const client = mockSdkClient([
-      {
-        id: "issue-uuid",
-        team: {
-          id: "team-uuid",
-          key: "ENG",
-          name: "Engineering",
-          issueEstimationType: "exponential",
-          issueEstimationExtended: false,
-          issueEstimationAllowZero: false,
-        },
-      },
-    ]);
+  it("resolves identifier, extracts teamId, delegates to team estimate resolver, and returns issueId plus team context", async () => {
+    const client = mockSdkClient(
+      [{ id: "issue-uuid", teamId }],
+      [exponentialTeam],
+    );
 
     await expect(
       resolveIssueEstimateContext(client, "ENG-42"),
     ).resolves.toEqual({
       issueId: "issue-uuid",
       team: {
-        teamId: "team-uuid",
+        teamId,
         teamKey: "ENG",
         teamName: "Engineering",
         issueEstimationType: "exponential",
@@ -84,34 +98,121 @@ describe("resolveIssueEstimateContext", () => {
         issueEstimationAllowZero: false,
       },
     });
+
+    expect(client.sdk.issues).toHaveBeenCalledWith({
+      filter: {
+        number: { eq: 42 },
+        team: { key: { eq: "ENG" } },
+      },
+      first: 1,
+    });
+    expect(client.sdk.teams).toHaveBeenCalledWith({
+      filter: { id: { eq: teamId } },
+      first: 1,
+    });
   });
 
-  it("resolves by UUID and verifies sdk issues filter id eq", async () => {
-    const issues = vi.fn().mockResolvedValue({
-      nodes: [
-        {
-          id: "issue-uuid",
-          team: {
-            id: "team-uuid",
-            key: "OPS",
-            name: "Operations",
-            issueEstimationType: "linear",
-            issueEstimationExtended: true,
-            issueEstimationAllowZero: true,
-          },
-        },
-      ],
-    });
-
-    const client = { sdk: { issues } } as unknown as LinearSdkClient;
+  it("resolves by UUID and uses sdk issues filter id eq", async () => {
+    const client = mockSdkClient(
+      [{ id: "issue-uuid", teamId }],
+      [exponentialTeam],
+    );
 
     await resolveIssueEstimateContext(
       client,
       "550e8400-e29b-41d4-a716-446655440000",
     );
 
-    expect(issues).toHaveBeenCalledWith({
+    expect(client.sdk.issues).toHaveBeenCalledWith({
       filter: { id: { eq: "550e8400-e29b-41d4-a716-446655440000" } },
+      first: 1,
+    });
+  });
+
+  it("resolves identifier and uses sdk issues filter number plus team key", async () => {
+    const client = mockSdkClient(
+      [{ id: "issue-uuid", teamId }],
+      [exponentialTeam],
+    );
+
+    await resolveIssueEstimateContext(client, "ENG-42");
+
+    expect(client.sdk.issues).toHaveBeenCalledWith({
+      filter: {
+        number: { eq: 42 },
+        team: { key: { eq: "ENG" } },
+      },
+      first: 1,
+    });
+  });
+
+  it("succeeds when issue node has no nested team estimation fields", async () => {
+    const client = mockSdkClient(
+      [
+        {
+          id: "issue-uuid",
+          team: {
+            id: teamId,
+            key: "ENG",
+          },
+        },
+      ],
+      [exponentialTeam],
+    );
+
+    await expect(
+      resolveIssueEstimateContext(client, "ENG-42"),
+    ).resolves.toMatchObject({
+      issueId: "issue-uuid",
+      team: {
+        teamId,
+        teamKey: "ENG",
+      },
+    });
+  });
+
+  it("falls back to async team relation id when teamId is absent", async () => {
+    const client = mockSdkClient(
+      [
+        {
+          id: "issue-uuid",
+          team: vi.fn().mockResolvedValue({ id: teamId, key: "ENG" }),
+        },
+      ],
+      [exponentialTeam],
+    );
+
+    await expect(
+      resolveIssueEstimateContext(client, "ENG-42"),
+    ).resolves.toMatchObject({
+      issueId: "issue-uuid",
+      team: {
+        teamId,
+        teamKey: "ENG",
+      },
+    });
+
+    expect(client.sdk.teams).toHaveBeenCalledWith({
+      filter: { id: { eq: teamId } },
+      first: 1,
+    });
+  });
+
+  it("falls back to async team relation key when relation id is absent", async () => {
+    const client = mockSdkClient(
+      [
+        {
+          id: "issue-uuid",
+          team: vi.fn().mockResolvedValue({ key: "ENG" }),
+        },
+      ],
+      [exponentialTeam],
+    );
+
+    await resolveIssueEstimateContext(client, "ENG-42");
+
+    expect(client.sdk.teams).toHaveBeenCalledWith({
+      filter: { key: { eq: "ENG" } },
       first: 1,
     });
   });
@@ -124,19 +225,11 @@ describe("resolveIssueEstimateContext", () => {
     ).rejects.toThrow('Issue "ENG-999" not found');
   });
 
-  it("throws when issue team estimation context is missing", async () => {
-    const issues = vi.fn().mockResolvedValue({
-      nodes: [
-        {
-          id: "issue-uuid",
-        },
-      ],
-    });
-
-    const client = { sdk: { issues } } as unknown as LinearSdkClient;
+  it("throws when issue team context is missing", async () => {
+    const client = mockSdkClient([{ id: "issue-uuid" }]);
 
     await expect(resolveIssueEstimateContext(client, "ENG-42")).rejects.toThrow(
-      'Issue "ENG-42" is missing required team estimation context',
+      'Issue "ENG-42" is missing required team context',
     );
   });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes `linearis issues update <ISSUE> --estimate <N>` by resolving team estimation configuration through the existing team resolver instead of expecting nested estimation fields on issue SDK results.

Closes #186

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `npx vitest run tests/unit/resolvers/issue-resolver.test.ts tests/unit/resolvers/team-resolver.test.ts`
- `npm run check:ci`
- `npx tsc --noEmit`
- `npm test`
- `npm run build`

## Notes for reviewers

- `resolveIssueEstimateContext()` now resolves the issue first, extracts `teamId` or a minimal team relation (`id`/`key`), then delegates estimation config loading to `resolveTeamEstimateContext()`.
- This preserves existing team estimate validation behavior and avoids GraphQL or generated-code changes.
- Tests now model realistic SDK issue shapes without nested team estimation fields.
