### PR TITLE
fix(ci): rerun validation when PR base changes

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -10,6 +10,7 @@ on:
       - synchronize
       - ready_for_review
       - reopened
+      - edited
 
 permissions:
   contents: read


### PR DESCRIPTION
## What does this PR do?

Adds the `pull_request.edited` trigger to CI validation so checks rerun when a PR base branch changes.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [x] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [ ] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [ ] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `npm test`
- `npm run check:ci`
- Local CHANGELOG guard reproduction with `GITHUB_BASE_REF=next`

## Notes for reviewers

This fixes stale CI when a PR is retargeted from `main` to `next`. Without `edited`, GitHub does not rerun the workflow after the base branch changes, leaving checks based on the old `GITHUB_BASE_REF`.
