### PR TITLE
feat: add GraphQL lookup queries for resolver migration

### DIFF
--- a/graphql/queries/initiatives.graphql
+++ b/graphql/queries/initiatives.graphql
@@ -165,17 +165,8 @@ query GetInitiativeUpdate($id: String!) {
   }
 }
 
-query FindInitiativesByName($name: String!, $teamId: ID, $ownerId: ID) {
-  initiatives(
-    first: 20
-    filter: {
-      and: [
-        { name: { eqIgnoreCase: $name } }
-        { teams: { some: { id: { eq: $teamId } } } }
-        { owner: { id: { eq: $ownerId } } }
-      ]
-    }
-  ) {
+query FindInitiativesByName($filter: InitiativeFilter!) {
+  initiatives(first: 20, filter: $filter) {
     nodes {
       ...InitiativeNameLookupFields
     }

--- a/graphql/queries/issues.graphql
+++ b/graphql/queries/issues.graphql
@@ -144,6 +144,23 @@ fragment CompleteIssueWithReactionsFields on Issue {
   }
 }
 
+fragment WorkflowStateLookupFields on WorkflowState {
+  id
+  name
+  team {
+    id
+    key
+    name
+  }
+}
+
+fragment IssueEstimateContextFields on Issue {
+  id
+  team {
+    ...TeamEstimateLookupFields
+  }
+}
+
 # Complete issue search fragment with all relationships
 #
 # Combines all issue fragments into a comprehensive field selection.
@@ -319,6 +336,31 @@ query GetIssueTeam($issueId: String!) {
   issue(id: $issueId) {
     team {
       id
+    }
+  }
+}
+
+query FindWorkflowStates($filter: WorkflowStateFilter!) {
+  workflowStates(filter: $filter, first: 10) {
+    nodes {
+      ...WorkflowStateLookupFields
+    }
+  }
+}
+
+query GetIssueEstimateContextById($id: String!) {
+  issue(id: $id) {
+    ...IssueEstimateContextFields
+  }
+}
+
+query GetIssueEstimateContextByIdentifier($teamKey: String!, $number: Float!) {
+  issues(
+    filter: { team: { key: { eq: $teamKey } }, number: { eq: $number } }
+    first: 1
+  ) {
+    nodes {
+      ...IssueEstimateContextFields
     }
   }
 }

--- a/graphql/queries/labels.graphql
+++ b/graphql/queries/labels.graphql
@@ -61,3 +61,11 @@ query GetProjectLabels($first: Int = 50, $after: String) {
     }
   }
 }
+
+query FindProjectLabelsByName($name: String!) {
+  projectLabels(filter: { name: { eqIgnoreCase: $name } }, first: 1) {
+    nodes {
+      ...ProjectLabelFields
+    }
+  }
+}

--- a/graphql/queries/projects.graphql
+++ b/graphql/queries/projects.graphql
@@ -90,6 +90,11 @@ fragment ProjectDetailFields on Project {
   }
 }
 
+fragment ProjectLookupFields on Project {
+  id
+  name
+}
+
 # List all projects in the workspace
 #
 # Fetches a paginated list of projects across all teams with enriched
@@ -163,6 +168,18 @@ query GetProjectStatuses {
     nodes {
       id
       name
+    }
+  }
+}
+
+query FindProjectsByName($name: String!, $includeArchived: Boolean = false) {
+  projects(
+    filter: { name: { eqIgnoreCase: $name } }
+    first: 2
+    includeArchived: $includeArchived
+  ) {
+    nodes {
+      ...ProjectLookupFields
     }
   }
 }

--- a/graphql/queries/teams.graphql
+++ b/graphql/queries/teams.graphql
@@ -21,10 +21,17 @@ fragment TeamFields on Team {
   name
 }
 
-fragment TeamDetailFields on Team {
+fragment TeamEstimateLookupFields on Team {
   id
   key
   name
+  issueEstimationType
+  issueEstimationExtended
+  issueEstimationAllowZero
+}
+
+fragment TeamDetailFields on Team {
+  ...TeamEstimateLookupFields
   description
   private
   timezone
@@ -36,9 +43,6 @@ fragment TeamDetailFields on Team {
     key
     name
   }
-  issueEstimationType
-  issueEstimationExtended
-  issueEstimationAllowZero
   defaultIssueEstimate
   inheritIssueEstimation
   cyclesEnabled
@@ -76,5 +80,29 @@ query GetTeams($first: Int = 50, $after: String) {
 query GetTeamById($id: String!) {
   team(id: $id) {
     ...TeamDetailFields
+  }
+}
+
+query FindTeamEstimateContextById($id: ID!) {
+  teams(filter: { id: { eq: $id } }, first: 1) {
+    nodes {
+      ...TeamEstimateLookupFields
+    }
+  }
+}
+
+query FindTeamEstimateContextByKey($key: String!) {
+  teams(filter: { key: { eq: $key } }, first: 1) {
+    nodes {
+      ...TeamEstimateLookupFields
+    }
+  }
+}
+
+query FindTeamEstimateContextByName($name: String!) {
+  teams(filter: { name: { eq: $name } }, first: 1) {
+    nodes {
+      ...TeamEstimateLookupFields
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add resolver-oriented GraphQL lookup queries for team estimate context, project lookup, project label lookup, workflow states, and issue estimate context
- switch initiative name lookup to a generated `InitiativeFilter` input so later resolver migration can drop SDK-only filter types
- keep scope limited to query/codegen preparation without changing resolver or command behavior

Closes #208

## Verification
- `npm run generate`
- `npm run check:ci`
- `npx tsc --noEmit`
- `npm test` (environment-limited locally; rely on CI)
- `npm run build` (environment-limited locally; rely on CI)
