### PR TITLE
test: add TypeScript type-checking for tests

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -77,6 +77,9 @@ jobs:
       - name: TypeScript type check
         run: npx tsc --noEmit
 
+      - name: Test TypeScript type check
+        run: npm run test:typecheck
+
   commitlint:
     name: Validate Commit Messages
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "clean": "rm -rf dist/",
     "start": "tsx src/main.ts",
     "test": "vitest run",
+    "test:typecheck": "tsc -p tsconfig.test.json --noEmit",
     "test:integration": "vitest run --config vitest.integration.config.ts",
     "test:watch": "vitest",
     "test:ui": "vitest --ui",

--- a/scripts/release/calver-plugin.d.cts
+++ b/scripts/release/calver-plugin.d.cts
@@ -1,0 +1,27 @@
+export interface MapCalverReleaseTypeInput {
+  branchName: string;
+  releaseType: string | null;
+  lastVersion: string;
+  nowIso?: string;
+}
+
+export interface AnalyzeCommitsContext {
+  branch?: { name?: string };
+  lastRelease?: { version?: string };
+  logger: { log(message: string): void };
+  nextRelease?: { version?: string };
+}
+
+export declare function mapCalverReleaseType(
+  input: MapCalverReleaseTypeInput,
+): string | null;
+
+export declare function analyzeCommits(
+  pluginConfig: unknown,
+  context: AnalyzeCommitsContext,
+): Promise<string | null>;
+
+export declare function verifyRelease(
+  pluginConfig: unknown,
+  context: AnalyzeCommitsContext,
+): Promise<void>;

--- a/scripts/release/calver.d.cts
+++ b/scripts/release/calver.d.cts
@@ -1,0 +1,13 @@
+export interface ComputeCalverVersionInput {
+  lastVersion: string;
+  branchName: string;
+  nowIso?: string;
+}
+
+export declare function computeCalverVersion(
+  input: ComputeCalverVersionInput,
+): string;
+
+export declare function isMonthRollover(
+  input: ComputeCalverVersionInput,
+): boolean;

--- a/tests/unit/services/initiative-service.test.ts
+++ b/tests/unit/services/initiative-service.test.ts
@@ -1,7 +1,10 @@
 import { type DocumentNode, type FragmentDefinitionNode, Kind } from "graphql";
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
-import { GetInitiativeDocument } from "../../../src/gql/graphql.js";
+import {
+  GetInitiativeDocument,
+  PaginationOrderBy,
+} from "../../../src/gql/graphql.js";
 import {
   archiveInitiative,
   createInitiative,
@@ -72,7 +75,7 @@ describe("listInitiatives", () => {
       after: "cursor-1",
       includeArchived: true,
       filter: { name: { eqIgnoreCase: "Growth" } },
-      orderBy: { createdAt: "Asc" },
+      orderBy: PaginationOrderBy.CreatedAt,
     });
 
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
@@ -80,7 +83,7 @@ describe("listInitiatives", () => {
       after: "cursor-1",
       includeArchived: true,
       filter: { name: { eqIgnoreCase: "Growth" } },
-      orderBy: { createdAt: "Asc" },
+      orderBy: PaginationOrderBy.CreatedAt,
       sort: undefined,
     });
   });

--- a/tests/unit/services/issue-service.test.ts
+++ b/tests/unit/services/issue-service.test.ts
@@ -368,7 +368,8 @@ describe("getIssueByIdentifierWithComments", () => {
     });
     const result = await getIssueByIdentifierWithComments(client, "ENG", 42);
 
-    expect(result.comments.nodes[0].user.displayName).toBe("Ada");
+    expect(result.comments.nodes).toHaveLength(1);
+    expect(result.comments.nodes[0]?.user?.displayName).toBe("Ada");
     expect(client.request).toHaveBeenCalledWith(
       GetIssueByIdentifierWithCommentsDocument,
       {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,9 +25,8 @@
   "exclude": [
     "node_modules",
     "dist",
-    // Tests excluded from TypeScript compilation to prevent them from
-    // being compiled into dist/. Tests are type-checked and validated
-    // by Vitest at runtime, which provides sufficient type safety.
+    // Tests are excluded from the production build config because
+    // tsconfig.test.json handles test-only type-checking with no emit.
     "tests",
     "**/*.test.ts",
     "**/*.spec.ts",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,16 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    "types": ["node", "vitest/globals"]
+  },
+  "include": [
+    "src/**/*",
+    "tests/**/*",
+    "vitest.base.config.ts",
+    "vitest.config.ts",
+    "vitest.integration.config.ts"
+  ],
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## Summary
- add a dedicated `tsconfig.test.json` for real test-only type-checking
- wire a new `npm run test:typecheck` script into CI validation
- add narrow declarations and test adjustments needed for the new compiler check to pass

## Verification
- `npm run check:ci`
- `npx tsc --noEmit`
- `npm run test:typecheck`

## Notes
- `npm test` and `npm run build` could not be completed locally because the available runtime does not match the repo's Node 22 requirement and failed during Vitest/tsx startup. CI on Node 22 should provide the authoritative runtime validation.

Closes #198
