### PR TITLE
fix(discussions): forward parent entity id when replying to a thread

### DIFF
--- a/src/services/discussion-service.ts
+++ b/src/services/discussion-service.ts
@@ -795,13 +795,25 @@ export async function replyToDiscussion(
   client: GraphQLClient,
   input: { threadId: string; body: string; entityKind?: DiscussionEntityKind },
 ): Promise<StartDiscussionMutation["commentCreate"]["comment"]> {
-  await assertRootDiscussionThread(client, input.threadId, input.entityKind);
+  const thread = await assertRootDiscussionThread(
+    client,
+    input.threadId,
+    input.entityKind,
+  );
+  const entity = getDiscussionThreadEntity(thread);
+  const entityField =
+    entity.kind === "issue"
+      ? { issueId: entity.id }
+      : entity.kind === "project"
+        ? { projectId: entity.id }
+        : { initiativeId: entity.id };
 
   const result = await client.request<StartDiscussionMutation>(
     StartDiscussionDocument,
     {
       input: {
         parentId: input.threadId,
+        ...entityField,
         body: input.body,
       },
     },

--- a/tests/unit/services/discussion-service.test.ts
+++ b/tests/unit/services/discussion-service.test.ts
@@ -3,6 +3,7 @@ import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import {
   GetDiscussionCommentContextDocument,
   type ListIssueDiscussionRootsQuery,
+  StartDiscussionDocument,
 } from "../../../src/gql/graphql.js";
 
 vi.mock("../../../src/services/reaction-service.js", async (importOriginal) => {
@@ -703,10 +704,17 @@ describe("replyToDiscussion", () => {
     );
   });
 
-  it("creates a reply for root thread", async () => {
+  it("creates a reply for root thread and forwards the parent entity id", async () => {
     const client = createClientMock();
     vi.mocked(client.request)
-      .mockResolvedValueOnce({ comment: comment("root-1") })
+      .mockResolvedValueOnce({
+        comment: {
+          ...comment("root-1"),
+          issueId: "issue-1",
+          projectId: null,
+          initiativeId: null,
+        },
+      })
       .mockResolvedValueOnce({
         commentCreate: {
           success: true,
@@ -721,6 +729,13 @@ describe("replyToDiscussion", () => {
 
     expect(result.id).toBe("reply-1");
     expect(result.parentId).toBe("root-1");
+    expect(client.request).toHaveBeenNthCalledWith(2, StartDiscussionDocument, {
+      input: {
+        parentId: "root-1",
+        issueId: "issue-1",
+        body: "hello",
+      },
+    });
   });
 });
 


### PR DESCRIPTION
## Problem

`linearis issues reply <root-thread-id> --body "..."` always fails:

```
GraphQL request failed: Argument Validation Error - Exactly one of
projectUpdateId, initiativeUpdateId, postId, documentContentId, projectId,
initiativeId or issueId must be defined.
```

`replyToDiscussion` built the `CommentCreateInput` with only `parentId` + `body`. Linear's `commentCreate` requires the parent entity id (`issueId`/`projectId`/`initiativeId`) **in addition to** `parentId`, even for a threaded reply. Root comments via `issues discuss` work because `startIssueDiscussion` passes `issueId`; only the reply path was missing it.

## Fix

`assertRootDiscussionThread` already fetches the thread via `GetDiscussionCommentContext`, which selects all three entity ids. Capture its return value (previously discarded) and forward the correct id using the existing `getDiscussionThreadEntity` helper. No extra network call.

## Test

Tightened the existing `replyToDiscussion` happy-path test to assert the second request forwards `issueId` alongside `parentId`. `tsc --noEmit` clean, `biome check` clean on both files, full discussion-service suite green (39/39).

(The unrelated `calver-plugin` unit test fails identically on a clean `main` checkout - date-based versioning, untouched here.)

Closes #226
