### PR TITLE
fix(milestones): pass flat variables to create/update mutations

### DIFF
--- a/src/services/milestone-service.ts
+++ b/src/services/milestone-service.ts
@@ -63,7 +63,7 @@ export async function createMilestone(
 ): Promise<CreatedMilestone> {
   const result = await client.request<CreateProjectMilestoneMutation>(
     CreateProjectMilestoneDocument,
-    { input },
+    input,
   );
 
   if (
@@ -83,7 +83,7 @@ export async function updateMilestone(
 ): Promise<UpdatedMilestone> {
   const result = await client.request<UpdateProjectMilestoneMutation>(
     UpdateProjectMilestoneDocument,
-    { id, input },
+    { id, ...input },
   );
 
   if (


### PR DESCRIPTION
## What & why

`milestones create` hard-fails and `milestones update` silently drops fields. Both come from the same mistake in `src/services/milestone-service.ts`: the variables are passed wrapped in `{ input }` / `{ id, input }`, but the **ProjectMilestone** mutations declare **flat** variables (`$projectId`, `$name`, `$description`, `$targetDate`, `$sortOrder`) — not a single `$input`. (The `{ input }` shape is correct in `project-service`, because `CreateProject` uses a single `$input: ProjectCreateInput!`; it was copied to milestones, whose documents differ.)

Closes #228.

### Before
```
$ linearis milestones create "M1" --project <uuid> --description "x"
{ "error": "GraphQL request failed: Variable \"$projectId\" of required type \"String!\" was not provided." }
```
`milestones update` returned success but ignored `--description` / `--target-date` / `--sort-order` (only `$id` bound).

### Fix
Pass the variables flat so they match the mutation documents:
- `createMilestone`: `{ input }` → `input`
- `updateMilestone`: `{ id, input }` → `{ id, ...input }`

The function params (`ProjectMilestoneCreateInput` / `ProjectMilestoneUpdateInput`) already carry exactly the flat fields, so this is a one-token change in each call.

### Verification
Verified against the live Linear API (via the compiled equivalent): `milestones create` now succeeds, and `milestones update --description ... --target-date ...` now actually applies the changes.

### Note
A small test asserting each service's variables object matches its mutation document's declared variables would catch this `{ input }`-vs-flat class of bug across services.
