### PR TITLE
fix(release): Correct CalVer version during verification

### DIFF
--- a/scripts/release/calver-plugin.cjs
+++ b/scripts/release/calver-plugin.cjs
@@ -48,6 +48,12 @@ async function analyzeCommits(pluginConfig, context) {
   return mappedReleaseType;
 }
 
+const VERSION_TOKEN = `$${"{version}"}`;
+
+function formatGitTag(tagFormat, version) {
+  return (tagFormat ?? `v${VERSION_TOKEN}`).replaceAll(VERSION_TOKEN, version);
+}
+
 async function verifyRelease(_, context) {
   const lastVersion = context.lastRelease?.version ?? "1970.1.0";
   const branchName = context.branch?.name ?? "main";
@@ -64,9 +70,17 @@ async function verifyRelease(_, context) {
   });
 
   if (semanticVersion !== expectedVersion) {
-    throw new Error(
-      `calver-plugin: semantic-release computed ${semanticVersion} but calver requires ${expectedVersion}`,
+    context.nextRelease.version = expectedVersion;
+    context.nextRelease.gitTag = formatGitTag(
+      context.options?.tagFormat,
+      expectedVersion,
     );
+    context.nextRelease.name = context.nextRelease.gitTag;
+
+    context.logger.log(
+      `calver-plugin: corrected semantic-release version ${semanticVersion} -> ${expectedVersion}`,
+    );
+    return;
   }
 
   context.logger.log(
@@ -76,6 +90,7 @@ async function verifyRelease(_, context) {
 
 module.exports = {
   analyzeCommits,
+  formatGitTag,
   mapCalverReleaseType,
   verifyRelease,
 };

--- a/tests/unit/release/calver-plugin.test.ts
+++ b/tests/unit/release/calver-plugin.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import {
   analyzeCommits,
+  formatGitTag,
   mapCalverReleaseType,
   verifyRelease,
 } from "../../../scripts/release/calver-plugin.cjs";
@@ -58,6 +59,9 @@ describe("calver plugin", () => {
   });
 
   it("delegates commit analysis and normalizes to patch cadence", async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+
     const pluginConfig = {
       preset: "conventionalcommits",
       releaseRules: [{ type: "chore", release: false }],
@@ -74,6 +78,8 @@ describe("calver plugin", () => {
     };
 
     await expect(analyzeCommits(pluginConfig, context)).resolves.toBe("patch");
+
+    vi.useRealTimers();
   });
 
   it("rolls over to minor on month change during analyzeCommits", async () => {
@@ -100,19 +106,31 @@ describe("calver plugin", () => {
     vi.useRealTimers();
   });
 
-  it("fails when semantic-release next version diverges from calver", async () => {
+  it("corrects semantic-release versions that diverge from calver", async () => {
     vi.useFakeTimers();
-    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+    vi.setSystemTime(new Date("2026-06-16T10:00:00.000Z"));
 
+    const versionToken = `$${"{version}"}`;
     const context = {
-      lastRelease: { version: "2026.4.8-next.6" },
-      branch: { name: "next" },
+      lastRelease: { version: "2026.4.9" },
+      branch: { name: "main" },
       logger: { log: vi.fn<(message: string) => void>() },
-      nextRelease: { version: "2026.5.0-next.1" },
+      options: { tagFormat: `v${versionToken}` },
+      nextRelease: {
+        version: "2026.5.0",
+        gitTag: "v2026.5.0",
+        name: "v2026.5.0",
+      },
     };
 
-    await expect(verifyRelease({}, context)).rejects.toThrow(
-      "semantic-release computed 2026.5.0-next.1 but calver requires 2026.4.8-next.7",
+    await expect(verifyRelease({}, context)).resolves.toBeUndefined();
+    expect(context.nextRelease).toMatchObject({
+      version: "2026.6.0",
+      gitTag: "v2026.6.0",
+      name: "v2026.6.0",
+    });
+    expect(context.logger.log).toHaveBeenCalledWith(
+      "calver-plugin: corrected semantic-release version 2026.5.0 -> 2026.6.0",
     );
 
     vi.useRealTimers();
@@ -132,6 +150,15 @@ describe("calver plugin", () => {
     await expect(verifyRelease({}, context)).resolves.toBeUndefined();
 
     vi.useRealTimers();
+  });
+
+  it("formats semantic-release git tags", () => {
+    const versionToken = `$${"{version}"}`;
+
+    expect(formatGitTag(`release-${versionToken}`, "2026.6.0")).toBe(
+      "release-2026.6.0",
+    );
+    expect(formatGitTag(undefined, "2026.6.0")).toBe("v2026.6.0");
   });
 
   it("passes when semantic-release next version matches calver", async () => {


### PR DESCRIPTION
## What does this PR do?

Fixes the CalVer release plugin so month-rollover releases can correct semantic-release's computed version during verification instead of failing. This addresses the main branch case where semantic-release computed `2026.5.0` but the CalVer policy required `2026.6.0`.

It also makes the date-dependent release test deterministic and adds coverage for corrected versions and tag formatting.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [ ] `npx tsc --noEmit` passes (type check)
- [ ] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `npx vitest run tests/unit/release/calver-plugin.test.ts tests/unit/release/calver.test.ts`
- `npm run check:ci`

Full validation was also run before branching:
- `npx tsc --noEmit`
- `npm test`
- `npm run build`
- `npm run verify:packed-binaries`

## Notes for reviewers

`npm run check:ci` prints a Biome schema version info message, but exits successfully.
