### PR TITLE
feat(labels): add issue label CRUD commands

### DIFF
--- a/graphql/mutations/labels.graphql
+++ b/graphql/mutations/labels.graphql
@@ -1,0 +1,28 @@
+# ------------------------------------------------------------
+# GraphQL mutations for Linear issue labels
+# ------------------------------------------------------------
+
+mutation CreateIssueLabel($input: IssueLabelCreateInput!) {
+  issueLabelCreate(input: $input) {
+    success
+    issueLabel {
+      ...LabelFields
+    }
+  }
+}
+
+mutation UpdateIssueLabel($id: String!, $input: IssueLabelUpdateInput!) {
+  issueLabelUpdate(id: $id, input: $input) {
+    success
+    issueLabel {
+      ...LabelFields
+    }
+  }
+}
+
+mutation DeleteIssueLabel($id: String!) {
+  issueLabelDelete(id: $id) {
+    success
+    entityId
+  }
+}

--- a/graphql/queries/labels.graphql
+++ b/graphql/queries/labels.graphql
@@ -29,6 +29,12 @@ fragment ProjectLabelFields on ProjectLabel {
   description
 }
 
+query GetIssueLabel($id: String!) {
+  issueLabel(id: $id) {
+    ...LabelFields
+  }
+}
+
 # List labels in the workspace
 #
 # Fetches a list of issue labels with optional team filtering.

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -1,7 +1,6 @@
 import type { Command } from "commander";
 import type { CommandContext } from "../common/context.js";
 import { createContext, getRootOpts } from "../common/context.js";
-import { parseLabelMode } from "../common/domain-values.js";
 import { resolveReactionEmojiInput } from "../common/emoji.js";
 import { invalidParameterError } from "../common/errors.js";
 import { validateEstimateAgainstTeamConfig } from "../common/estimate-validation.js";
@@ -1278,7 +1277,7 @@ export function setupIssuesCommands(program: Command): void {
     .option("--assignee <user>", "new assignee")
     .option("--project <project>", "new project")
     .option("--labels <labels>", "labels to apply (comma-separated)")
-    .option("--label-mode <mode>", "add | overwrite")
+    .option("--label-mode <mode>", "add | remove | overwrite")
     .option("--clear-labels", "remove all labels")
     .option("--parent-ticket <issue>", "set parent issue")
     .option("--clear-parent-ticket", "clear parent")
@@ -1343,7 +1342,14 @@ export function setupIssuesCommands(program: Command): void {
           throw new Error("--clear-labels cannot be used with --label-mode");
         }
 
-        const labelMode = parseLabelMode(options.labelMode);
+        if (
+          options.labelMode &&
+          !["add", "remove", "overwrite"].includes(options.labelMode)
+        ) {
+          throw new Error(
+            "--label-mode must be one of 'add', 'remove', or 'overwrite'",
+          );
+        }
 
         const parsedPriority =
           options.priority !== undefined
@@ -1382,7 +1388,8 @@ export function setupIssuesCommands(program: Command): void {
           options.status ||
           options.projectMilestone ||
           options.cycle ||
-          (options.labels && labelMode === "add");
+          (options.labels &&
+            (options.labelMode === "add" || options.labelMode === "remove"));
         const issueContext = needsContext
           ? await getIssue(ctx.gql, resolvedIssueId)
           : undefined;
@@ -1433,7 +1440,7 @@ export function setupIssuesCommands(program: Command): void {
           const labelNames = options.labels.split(",").map((l) => l.trim());
           const labelIds = await resolveLabelIds(ctx.sdk, labelNames);
 
-          if (labelMode === "add") {
+          if (options.labelMode === "add") {
             const currentLabels =
               issueContext &&
               "labels" in issueContext &&
@@ -1441,6 +1448,16 @@ export function setupIssuesCommands(program: Command): void {
                 ? issueContext.labels.nodes.map((l) => l.id)
                 : [];
             input.labelIds = [...new Set([...currentLabels, ...labelIds])];
+          } else if (options.labelMode === "remove") {
+            const currentLabels =
+              issueContext &&
+              "labels" in issueContext &&
+              issueContext.labels?.nodes
+                ? issueContext.labels.nodes.map((l) => l.id)
+                : [];
+            input.labelIds = currentLabels.filter(
+              (id) => !labelIds.includes(id),
+            );
           } else {
             input.labelIds = labelIds;
           }

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import type { CommandContext } from "../common/context.js";
 import { createContext, getRootOpts } from "../common/context.js";
+import { parseLabelMode } from "../common/domain-values.js";
 import { resolveReactionEmojiInput } from "../common/emoji.js";
 import { invalidParameterError } from "../common/errors.js";
 import { validateEstimateAgainstTeamConfig } from "../common/estimate-validation.js";
@@ -1342,14 +1343,7 @@ export function setupIssuesCommands(program: Command): void {
           throw new Error("--clear-labels cannot be used with --label-mode");
         }
 
-        if (
-          options.labelMode &&
-          !["add", "remove", "overwrite"].includes(options.labelMode)
-        ) {
-          throw new Error(
-            "--label-mode must be one of 'add', 'remove', or 'overwrite'",
-          );
-        }
+        const labelMode = parseLabelMode(options.labelMode);
 
         const parsedPriority =
           options.priority !== undefined
@@ -1388,8 +1382,7 @@ export function setupIssuesCommands(program: Command): void {
           options.status ||
           options.projectMilestone ||
           options.cycle ||
-          (options.labels &&
-            (options.labelMode === "add" || options.labelMode === "remove"));
+          (options.labels && (labelMode === "add" || labelMode === "remove"));
         const issueContext = needsContext
           ? await getIssue(ctx.gql, resolvedIssueId)
           : undefined;
@@ -1440,7 +1433,7 @@ export function setupIssuesCommands(program: Command): void {
           const labelNames = options.labels.split(",").map((l) => l.trim());
           const labelIds = await resolveLabelIds(ctx.sdk, labelNames);
 
-          if (options.labelMode === "add") {
+          if (labelMode === "add") {
             const currentLabels =
               issueContext &&
               "labels" in issueContext &&
@@ -1448,7 +1441,7 @@ export function setupIssuesCommands(program: Command): void {
                 ? issueContext.labels.nodes.map((l) => l.id)
                 : [];
             input.labelIds = [...new Set([...currentLabels, ...labelIds])];
-          } else if (options.labelMode === "remove") {
+          } else if (labelMode === "remove") {
             const currentLabels =
               issueContext &&
               "labels" in issueContext &&

--- a/src/commands/labels.ts
+++ b/src/commands/labels.ts
@@ -7,12 +7,24 @@ import {
 import { invalidParameterError } from "../common/errors.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
+import type {
+  IssueLabelCreateInput,
+  IssueLabelUpdateInput,
+} from "../gql/graphql.js";
+import {
+  type LabelResolverScope,
+  resolveLabelId,
+} from "../resolvers/label-resolver.js";
 import { resolveTeamId } from "../resolvers/team-resolver.js";
 import {
+  createLabel,
+  deleteLabel,
+  getLabel,
   type LabelScope,
   type LabelType,
   listLabels,
   listProjectLabels,
+  updateLabel,
 } from "../services/label-service.js";
 
 interface ListLabelsOptions extends CommandOptions {
@@ -21,6 +33,23 @@ interface ListLabelsOptions extends CommandOptions {
   scope?: string;
   limit: string;
   after?: string;
+}
+
+interface LabelLookupOptions extends CommandOptions {
+  team?: string;
+  scope?: string;
+}
+
+interface CreateLabelOptions extends CommandOptions {
+  team?: string;
+  color?: string;
+  description?: string;
+}
+
+interface UpdateLabelOptions extends LabelLookupOptions {
+  name?: string;
+  color?: string;
+  description?: string;
 }
 
 function parseLabelType(value?: string): LabelType {
@@ -42,16 +71,89 @@ function parseLabelScope(value?: string): LabelScope | undefined {
   );
 }
 
+function parseLabelColor(value?: string): string | undefined {
+  if (value === undefined) {
+    return undefined;
+  }
+
+  if (!/^#[0-9a-fA-F]{6}$/.test(value)) {
+    throw invalidParameterError("--color", "must be a hex color like #B45309");
+  }
+
+  return value;
+}
+
+async function resolveIssueLabelLookup(
+  command: Command,
+  label: string,
+  options: LabelLookupOptions,
+): Promise<{ ctx: ReturnType<typeof createContext>; labelId: string }> {
+  const ctx = createContext(getRootOpts(command));
+  const scope = parseLabelScope(options.scope);
+
+  if (scope === "team" && !options.team) {
+    throw invalidParameterError("--scope", "team scope requires --team");
+  }
+
+  if (scope === "workspace" && options.team) {
+    throw invalidParameterError(
+      "--team",
+      "cannot be used with --scope workspace",
+    );
+  }
+
+  const teamId = options.team
+    ? await resolveTeamId(ctx.sdk, options.team)
+    : undefined;
+  const labelId = await resolveLabelId(ctx.sdk, label, {
+    teamId,
+    scope: scope as LabelResolverScope | undefined,
+  });
+
+  return { ctx, labelId };
+}
+
+function buildUpdateInput(options: UpdateLabelOptions): IssueLabelUpdateInput {
+  const input: IssueLabelUpdateInput = {};
+  const color = parseLabelColor(options.color);
+
+  if (options.name) {
+    input.name = options.name;
+  }
+
+  if (color) {
+    input.color = color;
+  }
+
+  if (options.description) {
+    input.description = options.description;
+  }
+
+  if (Object.keys(input).length === 0) {
+    throw invalidParameterError(
+      "label update",
+      "at least one option must be provided",
+    );
+  }
+
+  return input;
+}
+
 export const LABELS_META: DomainMeta = {
   name: "labels",
   summary: "categorization tags for issues and projects",
   context: [
     "issue labels can exist at workspace level or be scoped to a specific",
-    "team. project labels are workspace-level only. use with issues",
-    "create/update --labels and projects create/update --labels.",
+    "team. project labels are workspace-level only. use labels list to",
+    "inspect existing labels, labels create/read/update/delete for issue",
+    "labels, and issues/projects create/update --labels to apply them.",
   ].join("\n"),
-  arguments: {},
+  arguments: { name: "label name or UUID" },
   seeAlso: [
+    "labels create <name>",
+    "labels read <label>",
+    "labels update <label>",
+    "labels delete <label>",
     "issues create --labels",
     "issues update --labels",
     "projects create --labels",
@@ -119,6 +221,119 @@ export function setupLabelsCommands(program: Command): void {
           : undefined;
 
         outputSuccess(await listLabels(ctx.gql, teamId, pagination));
+      }),
+    );
+
+  labels
+    .command("create <name>")
+    .description("create an issue label")
+    .option("--team <team>", "create a team-scoped label (key, name, or UUID)")
+    .option("--color <hex>", "label color as a hex code (for example #B45309)")
+    .option("--description <text>", "label description")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [name, options, command] = args as [
+          string,
+          CreateLabelOptions,
+          Command,
+        ];
+        const ctx = createContext(getRootOpts(command));
+
+        const input: IssueLabelCreateInput = { name };
+        const color = parseLabelColor(options.color);
+
+        if (options.team) {
+          input.teamId = await resolveTeamId(ctx.sdk, options.team);
+        }
+
+        if (color) {
+          input.color = color;
+        }
+
+        if (options.description) {
+          input.description = options.description;
+        }
+
+        outputSuccess(await createLabel(ctx.gql, input));
+      }),
+    );
+
+  labels
+    .command("read <label>")
+    .description("read an issue label")
+    .option(
+      "--team <team>",
+      "resolve a team-scoped label by team (key, name, or UUID)",
+    )
+    .option("--scope <scope>", "resolve within workspace or team scope")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [label, options, command] = args as [
+          string,
+          LabelLookupOptions,
+          Command,
+        ];
+        const { ctx, labelId } = await resolveIssueLabelLookup(
+          command,
+          label,
+          options,
+        );
+
+        outputSuccess(await getLabel(ctx.gql, labelId));
+      }),
+    );
+
+  labels
+    .command("update <label>")
+    .description("update an issue label")
+    .option(
+      "--team <team>",
+      "resolve a team-scoped label by team (key, name, or UUID)",
+    )
+    .option("--scope <scope>", "resolve within workspace or team scope")
+    .option("--name <name>", "new label name")
+    .option("--color <hex>", "new label color as a hex code")
+    .option("--description <text>", "new label description")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [label, options, command] = args as [
+          string,
+          UpdateLabelOptions,
+          Command,
+        ];
+        const input = buildUpdateInput(options);
+        const { ctx, labelId } = await resolveIssueLabelLookup(
+          command,
+          label,
+          options,
+        );
+
+        outputSuccess(await updateLabel(ctx.gql, labelId, input));
+      }),
+    );
+
+  labels
+    .command("delete <label>")
+    .description("delete an issue label")
+    .option(
+      "--team <team>",
+      "resolve a team-scoped label by team (key, name, or UUID)",
+    )
+    .option("--scope <scope>", "resolve within workspace or team scope")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [label, options, command] = args as [
+          string,
+          LabelLookupOptions,
+          Command,
+        ];
+        const { ctx, labelId } = await resolveIssueLabelLookup(
+          command,
+          label,
+          options,
+        );
+
+        outputSuccess(await deleteLabel(ctx.gql, labelId));
       }),
     );
 

--- a/src/commands/labels.ts
+++ b/src/commands/labels.ts
@@ -125,7 +125,7 @@ function buildUpdateInput(options: UpdateLabelOptions): IssueLabelUpdateInput {
     input.color = color;
   }
 
-  if (options.description) {
+  if (options.description !== undefined) {
     input.description = options.description;
   }
 

--- a/src/commands/labels.ts
+++ b/src/commands/labels.ts
@@ -146,7 +146,8 @@ export const LABELS_META: DomainMeta = {
     "issue labels can exist at workspace level or be scoped to a specific",
     "team. project labels are workspace-level only. use labels list to",
     "inspect existing labels, labels create/read/update/delete for issue",
-    "labels, and issues/projects create/update --labels to apply them.",
+    "labels, and issues/projects create/update --labels plus update",
+    "--label-mode remove or --clear-labels to apply or remove them.",
   ].join("\n"),
   arguments: { name: "label name or UUID" },
   seeAlso: [

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -178,6 +178,8 @@ interface UpdateOptions {
   teams?: string;
   team?: string;
   labels?: string;
+  labelMode?: string;
+  clearLabels?: boolean;
 }
 
 export const PROJECTS_META: DomainMeta = {
@@ -700,6 +702,8 @@ export function setupProjectsCommands(program: Command): void {
     .option("--teams <teams>", "comma-separated team names or UUIDs")
     .option("--team <team>", "team name or UUID (alias for --teams)")
     .option("--labels <labels>", "comma-separated label names or UUIDs")
+    .option("--label-mode <mode>", "add | remove | overwrite")
+    .option("--clear-labels", "remove all labels")
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [project, options, command] = args as [
@@ -730,7 +734,44 @@ export function setupProjectsCommands(program: Command): void {
           );
         }
 
+        if (options.labelMode && !options.labels) {
+          throw invalidParameterError(
+            "--label-mode",
+            "requires --labels to be specified",
+          );
+        }
+
+        if (options.clearLabels && options.labels) {
+          throw invalidParameterError(
+            "--clear-labels",
+            "cannot be used with --labels",
+          );
+        }
+
+        if (options.clearLabels && options.labelMode) {
+          throw invalidParameterError(
+            "--clear-labels",
+            "cannot be used with --label-mode",
+          );
+        }
+
+        if (
+          options.labelMode &&
+          !["add", "remove", "overwrite"].includes(options.labelMode)
+        ) {
+          throw invalidParameterError(
+            "--label-mode",
+            "must be one of 'add', 'remove', or 'overwrite'",
+          );
+        }
+
         const projectId = await resolveProjectId(ctx.sdk, project);
+        const needsLabelContext =
+          options.labels &&
+          (options.labelMode === "add" || options.labelMode === "remove");
+        const projectContext = needsLabelContext
+          ? await getProject(ctx.gql, projectId)
+          : undefined;
 
         const input: ProjectUpdateInput = {};
 
@@ -800,12 +841,30 @@ export function setupProjectsCommands(program: Command): void {
           );
         }
 
-        if (options.labels) {
+        if (options.clearLabels) {
+          input.labelIds = [];
+        } else if (options.labels) {
           const labelNames = options.labels
             .split(",")
             .map((l) => l.trim())
             .filter(Boolean);
-          input.labelIds = await resolveProjectLabelIds(ctx.sdk, labelNames);
+          const labelIds = await resolveProjectLabelIds(ctx.sdk, labelNames);
+
+          if (options.labelMode === "add") {
+            const currentLabels = projectContext?.labels?.nodes
+              ? projectContext.labels.nodes.map((l) => l.id)
+              : [];
+            input.labelIds = [...new Set([...currentLabels, ...labelIds])];
+          } else if (options.labelMode === "remove") {
+            const currentLabels = projectContext?.labels?.nodes
+              ? projectContext.labels.nodes.map((l) => l.id)
+              : [];
+            input.labelIds = currentLabels.filter(
+              (id) => !labelIds.includes(id),
+            );
+          } else {
+            input.labelIds = labelIds;
+          }
         }
 
         if (Object.keys(input).length === 0) {

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -1,6 +1,6 @@
 import type { Command } from "commander";
 import { createContext, getRootOpts } from "../common/context.js";
-import type { Priority } from "../common/domain-values.js";
+import { type Priority, parseLabelMode } from "../common/domain-values.js";
 import { resolveReactionEmojiInput } from "../common/emoji.js";
 import { invalidParameterError } from "../common/errors.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
@@ -755,20 +755,11 @@ export function setupProjectsCommands(program: Command): void {
           );
         }
 
-        if (
-          options.labelMode &&
-          !["add", "remove", "overwrite"].includes(options.labelMode)
-        ) {
-          throw invalidParameterError(
-            "--label-mode",
-            "must be one of 'add', 'remove', or 'overwrite'",
-          );
-        }
+        const labelMode = parseLabelMode(options.labelMode);
 
         const projectId = await resolveProjectId(ctx.sdk, project);
         const needsLabelContext =
-          options.labels &&
-          (options.labelMode === "add" || options.labelMode === "remove");
+          options.labels && (labelMode === "add" || labelMode === "remove");
         const projectContext = needsLabelContext
           ? await getProject(ctx.gql, projectId)
           : undefined;
@@ -850,12 +841,12 @@ export function setupProjectsCommands(program: Command): void {
             .filter(Boolean);
           const labelIds = await resolveProjectLabelIds(ctx.sdk, labelNames);
 
-          if (options.labelMode === "add") {
+          if (labelMode === "add") {
             const currentLabels = projectContext?.labels?.nodes
               ? projectContext.labels.nodes.map((l) => l.id)
               : [];
             input.labelIds = [...new Set([...currentLabels, ...labelIds])];
-          } else if (options.labelMode === "remove") {
+          } else if (labelMode === "remove") {
             const currentLabels = projectContext?.labels?.nodes
               ? projectContext.labels.nodes.map((l) => l.id)
               : [];

--- a/src/common/domain-values.ts
+++ b/src/common/domain-values.ts
@@ -4,15 +4,16 @@ import { invalidParameterError } from "./errors.js";
 export type Priority = 0 | 1 | 2 | 3 | 4;
 
 /** How `issues update --labels` combines with existing labels. */
-export type LabelMode = "add" | "overwrite";
+export type LabelMode = "add" | "remove" | "overwrite";
 
 export function parseLabelMode(
   value: string | undefined,
 ): LabelMode | undefined {
   if (value === undefined) return undefined;
-  if (value === "add" || value === "overwrite") return value;
+  if (value === "add" || value === "remove" || value === "overwrite")
+    return value;
   throw invalidParameterError(
     "--label-mode",
-    "must be either 'add' or 'overwrite'",
+    "must be one of 'add', 'remove', or 'overwrite'",
   );
 }

--- a/src/resolvers/label-resolver.ts
+++ b/src/resolvers/label-resolver.ts
@@ -2,14 +2,50 @@ import type { LinearSdkClient } from "../client/linear-client.js";
 import { notFoundError } from "../common/errors.js";
 import { isUuid } from "../common/identifier.js";
 
+export type LabelResolverScope = "workspace" | "team";
+
+export interface ResolveLabelOptions {
+  teamId?: string;
+  scope?: LabelResolverScope;
+}
+
+function buildLabelFilter(
+  nameOrId: string,
+  options: ResolveLabelOptions,
+): Record<string, unknown> {
+  if (options.scope === "workspace") {
+    return {
+      name: { eqIgnoreCase: nameOrId },
+      team: { null: true },
+    };
+  }
+
+  if (options.scope === "team" && options.teamId) {
+    return {
+      name: { eqIgnoreCase: nameOrId },
+      team: { id: { eq: options.teamId }, null: false },
+    };
+  }
+
+  if (options.teamId) {
+    return {
+      name: { eqIgnoreCase: nameOrId },
+      team: { id: { eq: options.teamId } },
+    };
+  }
+
+  return { name: { eqIgnoreCase: nameOrId } };
+}
+
 export async function resolveLabelId(
   client: LinearSdkClient,
   nameOrId: string,
+  options: ResolveLabelOptions = {},
 ): Promise<string> {
   if (isUuid(nameOrId)) return nameOrId;
 
   const result = await client.sdk.issueLabels({
-    filter: { name: { eqIgnoreCase: nameOrId } },
+    filter: buildLabelFilter(nameOrId, options),
     first: 1,
   });
 

--- a/src/services/label-service.ts
+++ b/src/services/label-service.ts
@@ -1,9 +1,19 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
 import type { PaginatedResult, PaginationOptions } from "../common/types.js";
 import {
+  CreateIssueLabelDocument,
+  type CreateIssueLabelMutation,
+  DeleteIssueLabelDocument,
+  type DeleteIssueLabelMutation,
+  GetIssueLabelDocument,
+  type GetIssueLabelQuery,
   GetLabelsDocument,
   GetProjectLabelsDocument,
+  type IssueLabelCreateInput,
   type IssueLabelFilter,
+  type IssueLabelUpdateInput,
+  UpdateIssueLabelDocument,
+  type UpdateIssueLabelMutation,
 } from "../gql/graphql.js";
 
 export type LabelType = "issue" | "project";
@@ -17,8 +27,98 @@ export interface Label {
   type: LabelType;
 }
 
+export interface DeleteLabelResult {
+  id: string;
+  success: true;
+}
+
 export interface ListLabelOptions extends PaginationOptions {
   scope?: LabelScope;
+}
+
+function mapIssueLabel(label: {
+  id: string;
+  name: string;
+  color: string;
+  description?: string | null;
+}): Label {
+  return {
+    id: label.id,
+    name: label.name,
+    color: label.color,
+    description: label.description ?? undefined,
+    type: "issue",
+  };
+}
+
+export async function getLabel(
+  client: GraphQLClient,
+  id: string,
+): Promise<Label> {
+  const result = await client.request<GetIssueLabelQuery>(
+    GetIssueLabelDocument,
+    {
+      id,
+    },
+  );
+
+  if (!result.issueLabel) {
+    throw new Error(`Label with ID "${id}" not found`);
+  }
+
+  return mapIssueLabel(result.issueLabel);
+}
+
+export async function createLabel(
+  client: GraphQLClient,
+  input: IssueLabelCreateInput,
+): Promise<Label> {
+  const result = await client.request<CreateIssueLabelMutation>(
+    CreateIssueLabelDocument,
+    { input },
+  );
+
+  if (!result.issueLabelCreate.success) {
+    throw new Error(`Failed to create label "${input.name}"`);
+  }
+
+  return mapIssueLabel(result.issueLabelCreate.issueLabel);
+}
+
+export async function updateLabel(
+  client: GraphQLClient,
+  id: string,
+  input: IssueLabelUpdateInput,
+): Promise<Label> {
+  const result = await client.request<UpdateIssueLabelMutation>(
+    UpdateIssueLabelDocument,
+    { id, input },
+  );
+
+  if (!result.issueLabelUpdate.success) {
+    throw new Error(`Failed to update label "${id}"`);
+  }
+
+  return mapIssueLabel(result.issueLabelUpdate.issueLabel);
+}
+
+export async function deleteLabel(
+  client: GraphQLClient,
+  id: string,
+): Promise<DeleteLabelResult> {
+  const result = await client.request<DeleteIssueLabelMutation>(
+    DeleteIssueLabelDocument,
+    { id },
+  );
+
+  if (!result.issueLabelDelete.success) {
+    throw new Error(`Failed to delete label "${id}"`);
+  }
+
+  return {
+    id: result.issueLabelDelete.entityId,
+    success: true,
+  };
 }
 
 function buildIssueLabelFilter(
@@ -55,13 +155,7 @@ export async function listLabels(
   });
 
   return {
-    nodes: result.issueLabels.nodes.map((label) => ({
-      id: label.id,
-      name: label.name,
-      color: label.color,
-      description: label.description ?? undefined,
-      type: "issue",
-    })),
+    nodes: result.issueLabels.nodes.map((label) => mapIssueLabel(label)),
     pageInfo: result.issueLabels.pageInfo,
   };
 }

--- a/src/services/label-service.ts
+++ b/src/services/label-service.ts
@@ -2,18 +2,14 @@ import type { GraphQLClient } from "../client/graphql-client.js";
 import type { PaginatedResult, PaginationOptions } from "../common/types.js";
 import {
   CreateIssueLabelDocument,
-  type CreateIssueLabelMutation,
   DeleteIssueLabelDocument,
-  type DeleteIssueLabelMutation,
   GetIssueLabelDocument,
-  type GetIssueLabelQuery,
   GetLabelsDocument,
   GetProjectLabelsDocument,
   type IssueLabelCreateInput,
   type IssueLabelFilter,
   type IssueLabelUpdateInput,
   UpdateIssueLabelDocument,
-  type UpdateIssueLabelMutation,
 } from "../gql/graphql.js";
 
 export type LabelType = "issue" | "project";
@@ -55,12 +51,9 @@ export async function getLabel(
   client: GraphQLClient,
   id: string,
 ): Promise<Label> {
-  const result = await client.request<GetIssueLabelQuery>(
-    GetIssueLabelDocument,
-    {
-      id,
-    },
-  );
+  const result = await client.request(GetIssueLabelDocument, {
+    id,
+  });
 
   if (!result.issueLabel) {
     throw new Error(`Label with ID "${id}" not found`);
@@ -73,10 +66,7 @@ export async function createLabel(
   client: GraphQLClient,
   input: IssueLabelCreateInput,
 ): Promise<Label> {
-  const result = await client.request<CreateIssueLabelMutation>(
-    CreateIssueLabelDocument,
-    { input },
-  );
+  const result = await client.request(CreateIssueLabelDocument, { input });
 
   if (!result.issueLabelCreate.success) {
     throw new Error(`Failed to create label "${input.name}"`);
@@ -90,10 +80,7 @@ export async function updateLabel(
   id: string,
   input: IssueLabelUpdateInput,
 ): Promise<Label> {
-  const result = await client.request<UpdateIssueLabelMutation>(
-    UpdateIssueLabelDocument,
-    { id, input },
-  );
+  const result = await client.request(UpdateIssueLabelDocument, { id, input });
 
   if (!result.issueLabelUpdate.success) {
     throw new Error(`Failed to update label "${id}"`);
@@ -106,10 +93,7 @@ export async function deleteLabel(
   client: GraphQLClient,
   id: string,
 ): Promise<DeleteLabelResult> {
-  const result = await client.request<DeleteIssueLabelMutation>(
-    DeleteIssueLabelDocument,
-    { id },
-  );
+  const result = await client.request(DeleteIssueLabelDocument, { id });
 
   if (!result.issueLabelDelete.success) {
     throw new Error(`Failed to delete label "${id}"`);

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -209,6 +209,7 @@ import {
   resolveIssueEstimateContext,
   resolveIssueId,
 } from "../../../src/resolvers/issue-resolver.js";
+import { resolveLabelIds } from "../../../src/resolvers/label-resolver.js";
 import {
   resolveTeamEstimateContext,
   resolveTeamId,
@@ -1944,6 +1945,65 @@ describe("issues create relations", () => {
       expect.anything(),
       expect.objectContaining({ type: "similar" }),
     );
+  });
+});
+
+describe("issues update --labels", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("removes selected labels without clearing all labels", async () => {
+    vi.mocked(getIssue).mockResolvedValueOnce({
+      id: "resolved-issue-uuid",
+      team: { id: "team-uuid", key: "ENG" },
+      labels: {
+        nodes: [{ id: "keep-label-uuid" }, { id: "resolved-label-uuid" }],
+      },
+    } as Awaited<ReturnType<typeof getIssue>>);
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-123",
+      "--labels",
+      "bug",
+      "--label-mode",
+      "remove",
+    ]);
+
+    expect(resolveLabelIds).toHaveBeenCalledWith(expect.anything(), ["bug"]);
+    expect(updateIssue).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+      expect.objectContaining({ labelIds: ["keep-label-uuid"] }),
+    );
+  });
+
+  it("rejects invalid issue label mode", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-123",
+      "--labels",
+      "bug",
+      "--label-mode",
+      "append",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("must be one of 'add', 'remove', or 'overwrite'"),
+    );
+    expect(updateIssue).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/commands/labels.test.ts
+++ b/tests/unit/commands/labels.test.ts
@@ -367,6 +367,28 @@ describe("labels update", () => {
       },
     );
   });
+
+  it("clears the description when passed an empty string", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "update",
+      "branch:merged",
+      "--description",
+      "",
+    ]);
+
+    expect(updateLabel).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-label-uuid",
+      {
+        description: "",
+      },
+    );
+  });
 });
 
 describe("labels delete", () => {

--- a/tests/unit/commands/labels.test.ts
+++ b/tests/unit/commands/labels.test.ts
@@ -22,7 +22,33 @@ vi.mock("../../../src/resolvers/team-resolver.js", () => ({
   resolveTeamId: vi.fn().mockResolvedValue("resolved-team-uuid"),
 }));
 
+vi.mock("../../../src/resolvers/label-resolver.js", () => ({
+  resolveLabelId: vi.fn().mockResolvedValue("resolved-label-uuid"),
+}));
+
 vi.mock("../../../src/services/label-service.js", () => ({
+  createLabel: vi.fn().mockResolvedValue({
+    id: "lbl-new",
+    name: "branch:unmerged",
+    color: "#B45309",
+    type: "issue",
+  }),
+  getLabel: vi.fn().mockResolvedValue({
+    id: "resolved-label-uuid",
+    name: "branch:unmerged",
+    color: "#B45309",
+    type: "issue",
+  }),
+  updateLabel: vi.fn().mockResolvedValue({
+    id: "resolved-label-uuid",
+    name: "branch:merged",
+    color: "#1D4ED8",
+    type: "issue",
+  }),
+  deleteLabel: vi.fn().mockResolvedValue({
+    id: "resolved-label-uuid",
+    success: true,
+  }),
   listLabels: vi.fn().mockResolvedValue({
     nodes: [{ id: "lbl-1", name: "Bug", color: "#ff0000", type: "issue" }],
     pageInfo: { hasNextPage: false, endCursor: null },
@@ -42,10 +68,15 @@ vi.mock("../../../src/services/label-service.js", () => ({
 
 import { setupLabelsCommands } from "../../../src/commands/labels.js";
 import { outputSuccess } from "../../../src/common/output.js";
+import { resolveLabelId } from "../../../src/resolvers/label-resolver.js";
 import { resolveTeamId } from "../../../src/resolvers/team-resolver.js";
 import {
+  createLabel,
+  deleteLabel,
+  getLabel,
   listLabels,
   listProjectLabels,
+  updateLabel,
 } from "../../../src/services/label-service.js";
 
 function createProgram(): Command {
@@ -216,7 +247,162 @@ describe("labels list", () => {
   });
 });
 
-describe("labels list validation", () => {
+describe("labels create", () => {
+  it("creates a workspace issue label by default", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "create",
+      "branch:unmerged",
+    ]);
+
+    expect(resolveTeamId).not.toHaveBeenCalled();
+    expect(createLabel).toHaveBeenCalledWith(expect.anything(), {
+      name: "branch:unmerged",
+    });
+    expect(outputSuccess).toHaveBeenCalledWith({
+      id: "lbl-new",
+      name: "branch:unmerged",
+      color: "#B45309",
+      type: "issue",
+    });
+  });
+
+  it("creates a team-scoped issue label with optional fields", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "create",
+      "branch:unmerged",
+      "--team",
+      "DBL",
+      "--color",
+      "#B45309",
+      "--description",
+      "Created from DBL branch workflow",
+    ]);
+
+    expect(resolveTeamId).toHaveBeenCalledWith(expect.anything(), "DBL");
+    expect(createLabel).toHaveBeenCalledWith(expect.anything(), {
+      name: "branch:unmerged",
+      teamId: "resolved-team-uuid",
+      color: "#B45309",
+      description: "Created from DBL branch workflow",
+    });
+  });
+});
+
+describe("labels read", () => {
+  it("reads a label by resolved id", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "read",
+      "branch:unmerged",
+      "--team",
+      "DBL",
+    ]);
+
+    expect(resolveTeamId).toHaveBeenCalledWith(expect.anything(), "DBL");
+    expect(resolveLabelId).toHaveBeenCalledWith(
+      expect.anything(),
+      "branch:unmerged",
+      {
+        teamId: "resolved-team-uuid",
+        scope: undefined,
+      },
+    );
+    expect(getLabel).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-label-uuid",
+    );
+  });
+});
+
+describe("labels update", () => {
+  it("updates a resolved label", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "update",
+      "branch:unmerged",
+      "--team",
+      "DBL",
+      "--name",
+      "branch:merged",
+      "--color",
+      "#1D4ED8",
+      "--description",
+      "Updated from DBL branch workflow",
+    ]);
+
+    expect(resolveTeamId).toHaveBeenCalledWith(expect.anything(), "DBL");
+    expect(resolveLabelId).toHaveBeenCalledWith(
+      expect.anything(),
+      "branch:unmerged",
+      {
+        teamId: "resolved-team-uuid",
+        scope: undefined,
+      },
+    );
+    expect(updateLabel).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-label-uuid",
+      {
+        name: "branch:merged",
+        color: "#1D4ED8",
+        description: "Updated from DBL branch workflow",
+      },
+    );
+  });
+});
+
+describe("labels delete", () => {
+  it("deletes a resolved label", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "delete",
+      "branch:unmerged",
+      "--scope",
+      "workspace",
+    ]);
+
+    expect(resolveLabelId).toHaveBeenCalledWith(
+      expect.anything(),
+      "branch:unmerged",
+      {
+        teamId: undefined,
+        scope: "workspace",
+      },
+    );
+    expect(deleteLabel).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-label-uuid",
+    );
+    expect(outputSuccess).toHaveBeenCalledWith({
+      id: "resolved-label-uuid",
+      success: true,
+    });
+  });
+});
+
+describe("labels validation", () => {
   it("rejects unsupported label types", async () => {
     const program = createProgram();
 
@@ -365,5 +551,95 @@ describe("labels list validation", () => {
     expect(listLabels).not.toHaveBeenCalled();
     expect(listProjectLabels).not.toHaveBeenCalled();
     expect(resolveTeamId).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid label colors on create", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "create",
+      "branch:unmerged",
+      "--color",
+      "B45309",
+    ]);
+
+    const errorOutput = JSON.parse(
+      vi.mocked(console.error).mock.calls[0][0] as string,
+    ) as { error: string };
+
+    expect(errorOutput.error).toBe(
+      "Invalid --color: must be a hex color like #B45309",
+    );
+    expect(createLabel).not.toHaveBeenCalled();
+  });
+
+  it("rejects invalid label colors on update", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "update",
+      "branch:unmerged",
+      "--color",
+      "B45309",
+    ]);
+
+    const errorOutput = JSON.parse(
+      vi.mocked(console.error).mock.calls[0][0] as string,
+    ) as { error: string };
+
+    expect(errorOutput.error).toBe(
+      "Invalid --color: must be a hex color like #B45309",
+    );
+    expect(updateLabel).not.toHaveBeenCalled();
+  });
+
+  it("rejects update with no fields", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "update",
+      "branch:unmerged",
+    ]);
+
+    const errorOutput = JSON.parse(
+      vi.mocked(console.error).mock.calls[0][0] as string,
+    ) as { error: string };
+
+    expect(errorOutput.error).toBe(
+      "Invalid label update: at least one option must be provided",
+    );
+    expect(updateLabel).not.toHaveBeenCalled();
+  });
+
+  it("rejects team scope without a team filter for read", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "labels",
+      "read",
+      "branch:unmerged",
+      "--scope",
+      "team",
+    ]);
+
+    const errorOutput = JSON.parse(
+      vi.mocked(console.error).mock.calls[0][0] as string,
+    ) as { error: string };
+
+    expect(errorOutput.error).toBe(
+      "Invalid --scope: team scope requires --team",
+    );
+    expect(resolveLabelId).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/commands/projects.test.ts
+++ b/tests/unit/commands/projects.test.ts
@@ -113,7 +113,10 @@ vi.mock("../../../src/services/discussion-service.js", () => ({
 
 import { setupProjectsCommands } from "../../../src/commands/projects.js";
 import { outputSuccess } from "../../../src/common/output.js";
-import { resolveProjectId } from "../../../src/resolvers/project-resolver.js";
+import {
+  resolveProjectId,
+  resolveProjectLabelIds,
+} from "../../../src/resolvers/project-resolver.js";
 import { resolveTeamId } from "../../../src/resolvers/team-resolver.js";
 import {
   createDiscussionCommentReaction,
@@ -1051,5 +1054,106 @@ describe("projects update", () => {
       "resolved-project-uuid",
       expect.objectContaining({ name: "New Name" }),
     );
+  });
+
+  it("adds labels without dropping existing project labels", async () => {
+    vi.mocked(getProject).mockResolvedValueOnce({
+      id: "proj-1",
+      labels: { nodes: [{ id: "existing-label-uuid" }] },
+    } as Awaited<ReturnType<typeof getProject>>);
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "update",
+      "My Project",
+      "--labels",
+      "Q3",
+      "--label-mode",
+      "add",
+    ]);
+
+    expect(getProject).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-project-uuid",
+    );
+    expect(resolveProjectLabelIds).toHaveBeenCalledWith(expect.anything(), [
+      "Q3",
+    ]);
+    expect(updateProject).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-project-uuid",
+      expect.objectContaining({
+        labelIds: ["existing-label-uuid", "resolved-label-uuid"],
+      }),
+    );
+  });
+
+  it("removes selected project labels without clearing all labels", async () => {
+    vi.mocked(getProject).mockResolvedValueOnce({
+      id: "proj-1",
+      labels: {
+        nodes: [{ id: "keep-label-uuid" }, { id: "resolved-label-uuid" }],
+      },
+    } as Awaited<ReturnType<typeof getProject>>);
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "update",
+      "My Project",
+      "--labels",
+      "Q3",
+      "--label-mode",
+      "remove",
+    ]);
+
+    expect(updateProject).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-project-uuid",
+      expect.objectContaining({ labelIds: ["keep-label-uuid"] }),
+    );
+  });
+
+  it("clears all project labels", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "update",
+      "My Project",
+      "--clear-labels",
+    ]);
+
+    expect(updateProject).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-project-uuid",
+      expect.objectContaining({ labelIds: [] }),
+    );
+  });
+
+  it("rejects invalid project label mode", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "update",
+      "My Project",
+      "--labels",
+      "Q3",
+      "--label-mode",
+      "append",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("must be one of 'add', 'remove', or 'overwrite'"),
+    );
+    expect(updateProject).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/common/domain-values.test.ts
+++ b/tests/unit/common/domain-values.test.ts
@@ -8,15 +8,16 @@ describe("parseLabelMode", () => {
 
   it("returns the narrowed mode for valid values", () => {
     expect(parseLabelMode("add")).toBe("add");
+    expect(parseLabelMode("remove")).toBe("remove");
     expect(parseLabelMode("overwrite")).toBe("overwrite");
   });
 
   it("throws for invalid values", () => {
     expect(() => parseLabelMode("replace")).toThrow(
-      "Invalid --label-mode: must be either 'add' or 'overwrite'",
+      "Invalid --label-mode: must be one of 'add', 'remove', or 'overwrite'",
     );
     expect(() => parseLabelMode("")).toThrow(
-      "Invalid --label-mode: must be either 'add' or 'overwrite'",
+      "Invalid --label-mode: must be one of 'add', 'remove', or 'overwrite'",
     );
   });
 });

--- a/tests/unit/resolvers/label-resolver.test.ts
+++ b/tests/unit/resolvers/label-resolver.test.ts
@@ -28,6 +28,55 @@ describe("resolveLabelId", () => {
     const client = mockSdkClient([{ id: "label-uuid" }]);
     const result = await resolveLabelId(client, "Bug");
     expect(result).toBe("label-uuid");
+    expect(client.sdk.issueLabels).toHaveBeenCalledWith({
+      filter: { name: { eqIgnoreCase: "Bug" } },
+      first: 1,
+    });
+  });
+
+  it("resolves workspace label by name", async () => {
+    const client = mockSdkClient([{ id: "label-uuid" }]);
+
+    await resolveLabelId(client, "Bug", { scope: "workspace" });
+
+    expect(client.sdk.issueLabels).toHaveBeenCalledWith({
+      filter: {
+        name: { eqIgnoreCase: "Bug" },
+        team: { null: true },
+      },
+      first: 1,
+    });
+  });
+
+  it("resolves team-scoped label by name", async () => {
+    const client = mockSdkClient([{ id: "label-uuid" }]);
+
+    await resolveLabelId(client, "Bug", {
+      teamId: "team-uuid",
+      scope: "team",
+    });
+
+    expect(client.sdk.issueLabels).toHaveBeenCalledWith({
+      filter: {
+        name: { eqIgnoreCase: "Bug" },
+        team: { id: { eq: "team-uuid" }, null: false },
+      },
+      first: 1,
+    });
+  });
+
+  it("filters by team when teamId is provided without explicit scope", async () => {
+    const client = mockSdkClient([{ id: "label-uuid" }]);
+
+    await resolveLabelId(client, "Bug", { teamId: "team-uuid" });
+
+    expect(client.sdk.issueLabels).toHaveBeenCalledWith({
+      filter: {
+        name: { eqIgnoreCase: "Bug" },
+        team: { id: { eq: "team-uuid" } },
+      },
+      first: 1,
+    });
   });
 
   it("throws when label not found", async () => {

--- a/tests/unit/services/label-service.test.ts
+++ b/tests/unit/services/label-service.test.ts
@@ -1,8 +1,12 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import {
+  createLabel,
+  deleteLabel,
+  getLabel,
   listLabels,
   listProjectLabels,
+  updateLabel,
 } from "../../../src/services/label-service.js";
 
 function mockGqlClient(response: Record<string, unknown>): GraphQLClient {
@@ -10,6 +14,200 @@ function mockGqlClient(response: Record<string, unknown>): GraphQLClient {
     request: vi.fn().mockResolvedValue(response),
   } as unknown as GraphQLClient;
 }
+
+describe("getLabel", () => {
+  it("returns a label by id", async () => {
+    const client = mockGqlClient({
+      issueLabel: {
+        id: "lbl-1",
+        name: "Bug",
+        color: "#ff0000",
+        description: "A bug",
+      },
+    });
+
+    const result = await getLabel(client, "lbl-1");
+
+    expect(result).toEqual({
+      id: "lbl-1",
+      name: "Bug",
+      color: "#ff0000",
+      description: "A bug",
+      type: "issue",
+    });
+  });
+
+  it("throws when label not found", async () => {
+    const client = mockGqlClient({ issueLabel: null });
+
+    await expect(getLabel(client, "lbl-1")).rejects.toThrow(
+      'Label with ID "lbl-1" not found',
+    );
+  });
+});
+
+describe("createLabel", () => {
+  it("returns created issue label with type", async () => {
+    const client = mockGqlClient({
+      issueLabelCreate: {
+        success: true,
+        issueLabel: {
+          id: "lbl-new",
+          name: "branch:unmerged",
+          color: "#B45309",
+          description: "Created from DBL branch workflow",
+        },
+      },
+    });
+
+    const result = await createLabel(client, {
+      name: "branch:unmerged",
+      teamId: "team-1",
+      color: "#B45309",
+      description: "Created from DBL branch workflow",
+    });
+
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      input: {
+        name: "branch:unmerged",
+        teamId: "team-1",
+        color: "#B45309",
+        description: "Created from DBL branch workflow",
+      },
+    });
+    expect(result).toEqual({
+      id: "lbl-new",
+      name: "branch:unmerged",
+      color: "#B45309",
+      description: "Created from DBL branch workflow",
+      type: "issue",
+    });
+  });
+
+  it("throws on create failure", async () => {
+    const client = mockGqlClient({
+      issueLabelCreate: {
+        success: false,
+        issueLabel: {
+          id: "lbl-new",
+          name: "branch:unmerged",
+          color: "#B45309",
+          description: null,
+        },
+      },
+    });
+
+    await expect(
+      createLabel(client, { name: "branch:unmerged" }),
+    ).rejects.toThrow('Failed to create label "branch:unmerged"');
+  });
+
+  it("converts null create description to undefined", async () => {
+    const client = mockGqlClient({
+      issueLabelCreate: {
+        success: true,
+        issueLabel: {
+          id: "lbl-new",
+          name: "branch:unmerged",
+          color: "#B45309",
+          description: null,
+        },
+      },
+    });
+
+    const result = await createLabel(client, { name: "branch:unmerged" });
+
+    expect(result.description).toBeUndefined();
+    expect(result.type).toBe("issue");
+  });
+});
+
+describe("updateLabel", () => {
+  it("returns updated issue label", async () => {
+    const client = mockGqlClient({
+      issueLabelUpdate: {
+        success: true,
+        issueLabel: {
+          id: "lbl-1",
+          name: "branch:merged",
+          color: "#1D4ED8",
+          description: "Updated from DBL branch workflow",
+        },
+      },
+    });
+
+    const result = await updateLabel(client, "lbl-1", {
+      name: "branch:merged",
+      color: "#1D4ED8",
+      description: "Updated from DBL branch workflow",
+    });
+
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      id: "lbl-1",
+      input: {
+        name: "branch:merged",
+        color: "#1D4ED8",
+        description: "Updated from DBL branch workflow",
+      },
+    });
+    expect(result).toEqual({
+      id: "lbl-1",
+      name: "branch:merged",
+      color: "#1D4ED8",
+      description: "Updated from DBL branch workflow",
+      type: "issue",
+    });
+  });
+
+  it("throws on update failure", async () => {
+    const client = mockGqlClient({
+      issueLabelUpdate: {
+        success: false,
+        issueLabel: {
+          id: "lbl-1",
+          name: "branch:merged",
+          color: "#1D4ED8",
+          description: null,
+        },
+      },
+    });
+
+    await expect(
+      updateLabel(client, "lbl-1", { name: "branch:merged" }),
+    ).rejects.toThrow('Failed to update label "lbl-1"');
+  });
+});
+
+describe("deleteLabel", () => {
+  it("returns deleted label id", async () => {
+    const client = mockGqlClient({
+      issueLabelDelete: {
+        success: true,
+        entityId: "lbl-1",
+      },
+    });
+
+    const result = await deleteLabel(client, "lbl-1");
+
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      id: "lbl-1",
+    });
+    expect(result).toEqual({ id: "lbl-1", success: true });
+  });
+
+  it("throws on delete failure", async () => {
+    const client = mockGqlClient({
+      issueLabelDelete: {
+        success: false,
+        entityId: "lbl-1",
+      },
+    });
+
+    await expect(deleteLabel(client, "lbl-1")).rejects.toThrow(
+      'Failed to delete label "lbl-1"',
+    );
+  });
+});
 
 describe("listLabels", () => {
   it("returns issue labels with type", async () => {


### PR DESCRIPTION
### Bug Description

`linearis labels list` can discover labels, but the CLI could not create or manage issue labels. It also lacked precise label detachment coverage on the objects that can receive labels.

### Changes Made

- Adds issue-label `create`, `read`, `update`, and `delete` subcommands under `linearis labels`.
- Adds generated GraphQL label mutations plus a single-label issue-label query.
- Adds selective issue-label removal with `issues update --labels <labels> --label-mode remove` while preserving `add`, `overwrite`, and `--clear-labels`.
- Adds matching project-label attachment/removal controls for managed projects: `projects create --labels`, `projects update --labels`, `projects update --labels --label-mode add|remove|overwrite`, and `projects update --clear-labels`.
- Keeps project-label CRUD out of this PR; project-label listing/application is covered, but creating/updating/deleting project-label definitions remains a non-goal.

### Scope / Non-goals

This PR implements issue-label CRUD plus attach/remove coverage for the two managed labelable object contexts currently exposed by Linearis: issues and projects. It does not add project-label definition CRUD, parent-label management, or hierarchy editing.

### Tests

- `npm run check:ci`
- `npx tsc --noEmit`
- `npm test`
- `npm run build`
- `node dist/main.js labels usage`
- `node dist/main.js issues usage`
- `node dist/main.js projects usage`

### Review Note

The command path follows the existing Linearis layering: command -> resolver -> service -> generated GraphQL operation. Services accept pre-resolved UUIDs only; commands keep validation and output handling at the CLI boundary.

Refs #117
