### PR TITLE
feat(projects): restore project workflow options

### DIFF
--- a/graphql/mutations/projects.graphql
+++ b/graphql/mutations/projects.graphql
@@ -13,7 +13,7 @@ mutation CreateProject($input: ProjectCreateInput!) {
   projectCreate(input: $input) {
     success
     project {
-      ...ProjectDetailFields
+      ...ProjectDetailWithDefaultConnectionsFields
     }
   }
 }
@@ -25,7 +25,7 @@ mutation UpdateProject($id: String!, $input: ProjectUpdateInput!) {
   projectUpdate(id: $id, input: $input) {
     success
     project {
-      ...ProjectDetailFields
+      ...ProjectDetailWithDefaultConnectionsFields
     }
   }
 }
@@ -34,7 +34,7 @@ mutation ArchiveProject($id: String!) {
   projectArchive(id: $id) {
     success
     entity {
-      ...ProjectDetailFields
+      ...ProjectDetailWithDefaultConnectionsFields
     }
   }
 }
@@ -43,7 +43,7 @@ mutation UnarchiveProject($id: String!) {
   projectUnarchive(id: $id) {
     success
     entity {
-      ...ProjectDetailFields
+      ...ProjectDetailWithDefaultConnectionsFields
     }
   }
 }
@@ -52,7 +52,7 @@ mutation DeleteProject($id: String!) {
   projectDelete(id: $id) {
     success
     entity {
-      ...ProjectDetailFields
+      ...ProjectDetailWithDefaultConnectionsFields
     }
   }
 }

--- a/graphql/queries/projects.graphql
+++ b/graphql/queries/projects.graphql
@@ -75,17 +75,21 @@ fragment ProjectDetailFields on Project {
       name
     }
   }
+  initiatives {
+    nodes {
+      id
+      name
+    }
+  }
+}
+
+fragment ProjectDetailWithDefaultConnectionsFields on Project {
+  ...ProjectDetailFields
   projectMilestones {
     nodes {
       id
       name
       targetDate
-    }
-  }
-  initiatives {
-    nodes {
-      id
-      name
     }
   }
 }
@@ -98,8 +102,9 @@ fragment ProjectDetailFields on Project {
 # Variables:
 #   $first: Maximum number of projects to return (default: 50)
 #   $after: Cursor for pagination
-query GetProjects($first: Int = 50, $after: String) {
-  projects(first: $first, after: $after) {
+#   $includeArchived: Include archived projects
+query GetProjects($first: Int = 50, $after: String, $includeArchived: Boolean) {
+  projects(first: $first, after: $after, includeArchived: $includeArchived) {
     nodes {
       ...ProjectListFields
     }
@@ -137,9 +142,33 @@ fragment ProjectDetailFieldsWithReactions on Project {
 #
 # Variables:
 #   $id: Project UUID
-query GetProject($id: String!) {
+#   $milestonesFirst: Maximum number of milestones to return
+#   $skipMilestones: Omit projectMilestones from the response
+#   $issuesFirst: Maximum number of issues to return
+#   $skipIssues: Omit issues from the response
+query GetProject(
+  $id: String!
+  $milestonesFirst: Int!
+  $skipMilestones: Boolean!
+  $issuesFirst: Int!
+  $skipIssues: Boolean!
+) {
   project(id: $id) {
     ...ProjectDetailFields
+    projectMilestones(first: $milestonesFirst) @skip(if: $skipMilestones) {
+      nodes {
+        id
+        name
+        description
+        targetDate
+        sortOrder
+      }
+    }
+    issues(first: $issuesFirst) @skip(if: $skipIssues) {
+      nodes {
+        ...CompleteIssueFields
+      }
+    }
   }
 }
 

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -42,6 +42,12 @@ import {
 interface ListOptions {
   limit: string;
   after?: string;
+  includeArchived?: boolean;
+}
+
+interface ReadOptions {
+  milestonesFirst: string;
+  issuesFirst: string;
 }
 
 interface DiscussionsOptions {
@@ -138,9 +144,12 @@ function addCommentReactionCommands(
 }
 
 interface CreateOptions {
-  teams: string;
+  teams?: string;
+  team?: string;
   description?: string;
   content?: string;
+  icon?: string;
+  color?: string;
   lead?: string;
   members?: string;
   priority?: string;
@@ -154,13 +163,19 @@ interface UpdateOptions {
   name?: string;
   description?: string;
   content?: string;
+  icon?: string;
+  color?: string;
   lead?: string;
+  clearLead?: boolean;
   members?: string;
   priority?: string;
   status?: string;
   startDate?: string;
+  clearStartDate?: boolean;
   targetDate?: string;
+  clearTargetDate?: boolean;
   teams?: string;
+  team?: string;
   labels?: string;
 }
 
@@ -193,6 +208,52 @@ function parsePriority(value: string): number {
   return priority;
 }
 
+function parseNonNegativeIntegerOption(name: string, value: string): number {
+  if (!/^\d+$/.test(value)) {
+    throw invalidParameterError(name, `must be a non-negative integer`);
+  }
+  return Number.parseInt(value, 10);
+}
+
+function parseCommaSeparatedOption(name: string, value: string): string[] {
+  const values = value
+    .split(",")
+    .map((v) => v.trim())
+    .filter(Boolean);
+
+  if (values.length === 0) {
+    throw invalidParameterError(name, "must include at least one value");
+  }
+
+  return values;
+}
+
+function getCreateTeamNames(options: CreateOptions): string[] {
+  if (options.team && options.teams) {
+    throw invalidParameterError("--team", "cannot be combined with --teams");
+  }
+
+  const teams = options.teams ?? options.team;
+  if (!teams) {
+    throw invalidParameterError("--teams", "is required");
+  }
+
+  return parseCommaSeparatedOption(options.teams ? "--teams" : "--team", teams);
+}
+
+function getUpdateTeamNames(options: UpdateOptions): string[] | undefined {
+  if (options.team && options.teams) {
+    throw invalidParameterError("--team", "cannot be combined with --teams");
+  }
+
+  const teams = options.teams ?? options.team;
+  if (!teams) {
+    return undefined;
+  }
+
+  return parseCommaSeparatedOption(options.teams ? "--teams" : "--team", teams);
+}
+
 export function setupProjectsCommands(program: Command): void {
   const projects = program
     .command("projects")
@@ -205,6 +266,7 @@ export function setupProjectsCommands(program: Command): void {
     .description("list projects")
     .option("-l, --limit <n>", "max results", "100")
     .option("--after <cursor>", "cursor for next page")
+    .option("--include-archived", "include archived projects")
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [options, command] = args as [ListOptions, Command];
@@ -212,6 +274,7 @@ export function setupProjectsCommands(program: Command): void {
         const result = await listProjects(ctx.gql, {
           limit: parseLimit(options.limit),
           after: options.after,
+          includeArchived: options.includeArchived,
         });
         outputSuccess(result);
       }),
@@ -220,12 +283,35 @@ export function setupProjectsCommands(program: Command): void {
   projects
     .command("read <project>")
     .description("get full project details")
+    .option(
+      "--milestones-first <n>",
+      "how many milestones to fetch; 0 omits milestones",
+      "25",
+    )
+    .option(
+      "--issues-first <n>",
+      "how many issues to fetch; 0 omits issues",
+      "50",
+    )
     .action(
       handleCommand(async (...args: unknown[]) => {
-        const [project, , command] = args as [string, unknown, Command];
+        const [project, options, command] = args as [
+          string,
+          ReadOptions,
+          Command,
+        ];
         const ctx = createContext(getRootOpts(command));
         const projectId = await resolveProjectId(ctx.sdk, project);
-        const result = await getProject(ctx.gql, projectId);
+        const result = await getProject(ctx.gql, projectId, {
+          milestonesFirst: parseNonNegativeIntegerOption(
+            "--milestones-first",
+            options.milestonesFirst,
+          ),
+          issuesFirst: parseNonNegativeIntegerOption(
+            "--issues-first",
+            options.issuesFirst,
+          ),
+        });
         outputSuccess(result);
       }),
     );
@@ -499,9 +585,12 @@ export function setupProjectsCommands(program: Command): void {
   projects
     .command("create <name>")
     .description("create a new project")
-    .requiredOption("--teams <teams>", "comma-separated team names or UUIDs")
+    .option("--teams <teams>", "comma-separated team names or UUIDs")
+    .option("--team <team>", "team name or UUID (alias for --teams)")
     .option("--description <text>", "project description")
     .option("--content <text>", "project content (markdown)")
+    .option("--icon <icon>", "project icon")
+    .option("--color <color>", "project color")
     .option("--lead <user>", "project lead (name, email, or UUID)")
     .option("--members <users>", "comma-separated member names or UUIDs")
     .option("--priority <0-4>", "0=none 1=urgent 2=high 3=medium 4=low")
@@ -518,10 +607,7 @@ export function setupProjectsCommands(program: Command): void {
         ];
         const ctx = createContext(getRootOpts(command));
 
-        const teamNames = options.teams
-          .split(",")
-          .map((t) => t.trim())
-          .filter(Boolean);
+        const teamNames = getCreateTeamNames(options);
         const teamIds = await Promise.all(
           teamNames.map((t) => resolveTeamId(ctx.sdk, t)),
         );
@@ -537,6 +623,14 @@ export function setupProjectsCommands(program: Command): void {
 
         if (options.content) {
           input.content = options.content;
+        }
+
+        if (options.icon !== undefined) {
+          input.icon = options.icon;
+        }
+
+        if (options.color !== undefined) {
+          input.color = options.color;
         }
 
         if (options.lead) {
@@ -591,13 +685,19 @@ export function setupProjectsCommands(program: Command): void {
     .option("--name <name>", "new name")
     .option("--description <text>", "new description")
     .option("--content <text>", "new content (markdown)")
+    .option("--icon <icon>", "new icon")
+    .option("--color <color>", "new color")
     .option("--lead <user>", "new lead (name, email, or UUID)")
+    .option("--clear-lead", "remove project lead")
     .option("--members <users>", "comma-separated member names or UUIDs")
     .option("--priority <0-4>", "new priority")
     .option("--status <status>", "new status name or UUID")
     .option("--start-date <date>", "new start date (YYYY-MM-DD)")
+    .option("--clear-start-date", "remove start date")
     .option("--target-date <date>", "new target date (YYYY-MM-DD)")
+    .option("--clear-target-date", "remove target date")
     .option("--teams <teams>", "comma-separated team names or UUIDs")
+    .option("--team <team>", "team name or UUID (alias for --teams)")
     .option("--labels <labels>", "comma-separated label names or UUIDs")
     .action(
       handleCommand(async (...args: unknown[]) => {
@@ -607,6 +707,27 @@ export function setupProjectsCommands(program: Command): void {
           Command,
         ];
         const ctx = createContext(getRootOpts(command));
+
+        if (options.lead && options.clearLead) {
+          throw invalidParameterError(
+            "--lead",
+            "cannot be combined with --clear-lead",
+          );
+        }
+
+        if (options.startDate && options.clearStartDate) {
+          throw invalidParameterError(
+            "--start-date",
+            "cannot be combined with --clear-start-date",
+          );
+        }
+
+        if (options.targetDate && options.clearTargetDate) {
+          throw invalidParameterError(
+            "--target-date",
+            "cannot be combined with --clear-target-date",
+          );
+        }
 
         const projectId = await resolveProjectId(ctx.sdk, project);
 
@@ -624,7 +745,17 @@ export function setupProjectsCommands(program: Command): void {
           input.content = options.content;
         }
 
-        if (options.lead) {
+        if (options.icon !== undefined) {
+          input.icon = options.icon;
+        }
+
+        if (options.color !== undefined) {
+          input.color = options.color;
+        }
+
+        if (options.clearLead) {
+          input.leadId = null;
+        } else if (options.lead) {
           input.leadId = await resolveUserId(ctx.sdk, options.lead);
         }
 
@@ -649,19 +780,20 @@ export function setupProjectsCommands(program: Command): void {
           );
         }
 
-        if (options.startDate) {
+        if (options.clearStartDate) {
+          input.startDate = null;
+        } else if (options.startDate) {
           input.startDate = options.startDate;
         }
 
-        if (options.targetDate) {
+        if (options.clearTargetDate) {
+          input.targetDate = null;
+        } else if (options.targetDate) {
           input.targetDate = options.targetDate;
         }
 
-        if (options.teams) {
-          const teamNames = options.teams
-            .split(",")
-            .map((t) => t.trim())
-            .filter(Boolean);
+        const teamNames = getUpdateTeamNames(options);
+        if (teamNames) {
           input.teamIds = await Promise.all(
             teamNames.map((t) => resolveTeamId(ctx.sdk, t)),
           );

--- a/src/services/project-service.ts
+++ b/src/services/project-service.ts
@@ -29,14 +29,31 @@ import {
   type UpdateProjectMutation,
 } from "../gql/graphql.js";
 
+export interface ProjectListOptions extends PaginationOptions {
+  includeArchived?: boolean;
+}
+
+export interface ProjectDetailOptions {
+  milestonesFirst?: number;
+  issuesFirst?: number;
+}
+
+const DEFAULT_PROJECT_MILESTONES_FIRST = 25;
+const DEFAULT_PROJECT_ISSUES_FIRST = 50;
+
+function connectionFirstOrOneWhenSkipped(value: number): number {
+  return value === 0 ? 1 : value;
+}
+
 export async function listProjects(
   client: GraphQLClient,
-  options: PaginationOptions = {},
+  options: ProjectListOptions = {},
 ): Promise<PaginatedResult<ProjectListItem>> {
-  const { limit = 50, after } = options;
+  const { limit = 50, after, includeArchived } = options;
   const result = await client.request<GetProjectsQuery>(GetProjectsDocument, {
     first: limit,
     after,
+    includeArchived,
   });
 
   return {
@@ -48,9 +65,18 @@ export async function listProjects(
 export async function getProject(
   client: GraphQLClient,
   id: string,
+  options: ProjectDetailOptions = {},
 ): Promise<ProjectDetail> {
+  const milestonesFirst =
+    options.milestonesFirst ?? DEFAULT_PROJECT_MILESTONES_FIRST;
+  const issuesFirst = options.issuesFirst ?? DEFAULT_PROJECT_ISSUES_FIRST;
+
   const result = await client.request<GetProjectQuery>(GetProjectDocument, {
     id,
+    milestonesFirst: connectionFirstOrOneWhenSkipped(milestonesFirst),
+    skipMilestones: milestonesFirst === 0,
+    issuesFirst: connectionFirstOrOneWhenSkipped(issuesFirst),
+    skipIssues: issuesFirst === 0,
   });
 
   if (!result.project) {

--- a/tests/unit/commands/projects.test.ts
+++ b/tests/unit/commands/projects.test.ts
@@ -114,6 +114,7 @@ vi.mock("../../../src/services/discussion-service.js", () => ({
 import { setupProjectsCommands } from "../../../src/commands/projects.js";
 import { outputSuccess } from "../../../src/common/output.js";
 import { resolveProjectId } from "../../../src/resolvers/project-resolver.js";
+import { resolveTeamId } from "../../../src/resolvers/team-resolver.js";
 import {
   createDiscussionCommentReaction,
   deleteDiscussionComment,
@@ -136,6 +137,7 @@ import {
   createProject,
   deleteProject,
   getProject,
+  listProjects,
   unarchiveProject,
   updateProject,
 } from "../../../src/services/project-service.js";
@@ -146,6 +148,34 @@ function createProgram(): Command {
   setupProjectsCommands(program);
   return program;
 }
+
+describe("projects list", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("passes includeArchived to project listing", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "list",
+      "--include-archived",
+      "--limit",
+      "25",
+    ]);
+
+    expect(listProjects).toHaveBeenCalledWith(expect.anything(), {
+      limit: 25,
+      after: undefined,
+      includeArchived: true,
+    });
+  });
+});
 
 describe("projects read", () => {
   beforeEach(() => {
@@ -172,8 +202,48 @@ describe("projects read", () => {
     expect(getProject).toHaveBeenCalledWith(
       expect.anything(),
       "resolved-project-uuid",
+      { milestonesFirst: 25, issuesFirst: 50 },
     );
     expect(outputSuccess).toHaveBeenCalledWith({ id: "proj-1" });
+  });
+
+  it("passes project detail expansion limits including zero", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "read",
+      "My Project",
+      "--milestones-first",
+      "0",
+      "--issues-first",
+      "10",
+    ]);
+
+    expect(getProject).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-project-uuid",
+      { milestonesFirst: 0, issuesFirst: 10 },
+    );
+  });
+
+  it("rejects negative project detail expansion limits", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "read",
+      "My Project",
+      "--issues-first",
+      "-1",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("Invalid --issues-first"),
+    );
+    expect(getProject).not.toHaveBeenCalled();
   });
 });
 
@@ -346,6 +416,141 @@ describe("projects create --priority", () => {
       expect.stringContaining("must be 0-4"),
     );
     expect(createProject).not.toHaveBeenCalled();
+  });
+});
+
+describe("projects create compatibility options", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("accepts singular --team and forwards icon and color", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "create",
+      "My Project",
+      "--team",
+      "ENG",
+      "--icon",
+      "rocket",
+      "--color",
+      "#ff0000",
+    ]);
+
+    expect(resolveTeamId).toHaveBeenCalledWith(expect.anything(), "ENG");
+    expect(createProject).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        teamIds: ["resolved-team-uuid"],
+        icon: "rocket",
+        color: "#ff0000",
+      }),
+    );
+  });
+
+  it("rejects combining --team and --teams", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "create",
+      "My Project",
+      "--team",
+      "ENG",
+      "--teams",
+      "DES",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("cannot be combined with --teams"),
+    );
+    expect(createProject).not.toHaveBeenCalled();
+  });
+});
+
+describe("projects update compatibility options", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("clears lead and lifecycle dates", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "update",
+      "My Project",
+      "--clear-lead",
+      "--clear-start-date",
+      "--clear-target-date",
+    ]);
+
+    expect(updateProject).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-project-uuid",
+      expect.objectContaining({
+        leadId: null,
+        startDate: null,
+        targetDate: null,
+      }),
+    );
+  });
+
+  it("updates icon, color, and singular team alias", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "update",
+      "My Project",
+      "--icon",
+      "target",
+      "--color",
+      "#00ff00",
+      "--team",
+      "ENG",
+    ]);
+
+    expect(updateProject).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-project-uuid",
+      expect.objectContaining({
+        icon: "target",
+        color: "#00ff00",
+        teamIds: ["resolved-team-uuid"],
+      }),
+    );
+  });
+
+  it("rejects clear flags combined with replacement values", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "projects",
+      "update",
+      "My Project",
+      "--lead",
+      "Ada",
+      "--clear-lead",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("cannot be combined with --clear-lead"),
+    );
+    expect(updateProject).not.toHaveBeenCalled();
   });
 });
 

--- a/tests/unit/services/project-service.test.ts
+++ b/tests/unit/services/project-service.test.ts
@@ -177,6 +177,7 @@ describe("listProjects", () => {
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       first: 50,
       after: "cur1",
+      includeArchived: undefined,
     });
   });
 
@@ -191,6 +192,22 @@ describe("listProjects", () => {
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       first: 50,
       after: undefined,
+      includeArchived: undefined,
+    });
+  });
+
+  it("passes includeArchived when requested", async () => {
+    const client = mockGqlClient({
+      projects: {
+        nodes: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      },
+    });
+    await listProjects(client, { includeArchived: true });
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      first: 50,
+      after: undefined,
+      includeArchived: true,
     });
   });
 
@@ -267,6 +284,57 @@ describe("getProject", () => {
     expect(result.status.name).toBe("Started");
     expect(result.content).toBe("# Project Alpha\nDetailed content here.");
     expect(result.members.nodes).toHaveLength(1);
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      id: "proj-1",
+      milestonesFirst: 25,
+      skipMilestones: false,
+      issuesFirst: 50,
+      skipIssues: false,
+    });
+  });
+
+  it("supports bounded detail expansion and zero skips", async () => {
+    const client = mockGqlClient({
+      project: {
+        id: "proj-1",
+        name: "Project Alpha",
+      },
+    });
+
+    await getProject(client, "proj-1", {
+      milestonesFirst: 0,
+      issuesFirst: 0,
+    });
+
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      id: "proj-1",
+      milestonesFirst: 1,
+      skipMilestones: true,
+      issuesFirst: 1,
+      skipIssues: true,
+    });
+  });
+
+  it("passes custom milestone and issue limits", async () => {
+    const client = mockGqlClient({
+      project: {
+        id: "proj-1",
+        name: "Project Alpha",
+      },
+    });
+
+    await getProject(client, "proj-1", {
+      milestonesFirst: 5,
+      issuesFirst: 10,
+    });
+
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      id: "proj-1",
+      milestonesFirst: 5,
+      skipMilestones: false,
+      issuesFirst: 10,
+      skipIssues: false,
+    });
   });
 
   it("throws when project not found", async () => {


### PR DESCRIPTION
## Summary
- restore `projects list --include-archived`
- restore bounded `projects read` expansion with `--milestones-first` and `--issues-first`, including `0` skip semantics
- restore project icon/color create/update options, clear lead/date flags, and singular `--team` compatibility

## Verification
- npm run test -- tests/unit/services/project-service.test.ts tests/unit/commands/projects.test.ts
- npm test
- npm run check:ci
- npm run build