### PR TITLE
feat: restore document attachment compatibility

### DIFF
--- a/graphql/mutations/documents.graphql
+++ b/graphql/mutations/documents.graphql
@@ -2,8 +2,7 @@
 # GraphQL mutations for Linear documents
 #
 # Documents are standalone entities that can be associated with projects,
-# initiatives, or teams. To link a document to an issue, use the
-# attachments API (see attachments.graphql).
+# initiatives, issues, or teams.
 # ------------------------------------------------------------
 
 # Create a new document mutation

--- a/src/commands/attachments.ts
+++ b/src/commands/attachments.ts
@@ -1,8 +1,12 @@
 import type { Command } from "commander";
 import { createContext, getRootOpts } from "../common/context.js";
+import { invalidParameterError } from "../common/errors.js";
 import { handleCommand, outputSuccess } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
-import type { AttachmentFilter } from "../gql/graphql.js";
+import type {
+  AttachmentCreateInput,
+  AttachmentFilter,
+} from "../gql/graphql.js";
 import { resolveIssueId } from "../resolvers/issue-resolver.js";
 import {
   createAttachment,
@@ -28,6 +32,7 @@ export const ATTACHMENTS_META: DomainMeta = {
 };
 
 interface ListOptions {
+  issue?: string;
   sourceType?: string;
   title?: string;
   createdAfter?: string;
@@ -35,9 +40,31 @@ interface ListOptions {
 }
 
 interface CreateOptions {
+  issue?: string;
   title: string;
   url: string;
   subtitle?: string;
+  comment?: string;
+  iconUrl?: string;
+}
+
+function resolveIssueArgument(
+  positionalIssue: string | undefined,
+  optionIssue: string | undefined,
+): string {
+  if (positionalIssue && optionIssue) {
+    throw invalidParameterError(
+      "--issue",
+      "cannot be combined with positional issue",
+    );
+  }
+
+  const issue = positionalIssue ?? optionIssue;
+  if (!issue) {
+    throw invalidParameterError("issue", "is required");
+  }
+
+  return issue;
 }
 
 function buildAttachmentFilter(
@@ -71,8 +98,9 @@ export function setupAttachmentsCommands(program: Command): void {
   attachments.action(() => attachments.help());
 
   attachments
-    .command("list <issue>")
+    .command("list [issue]")
     .description("list attachments on an issue")
+    .option("--issue <issue>", "issue identifier (alias for positional issue)")
     .option(
       "--source-type <type>",
       "filter by source type (e.g. github, slack)",
@@ -83,12 +111,13 @@ export function setupAttachmentsCommands(program: Command): void {
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [issue, options, command] = args as [
-          string,
+          string | undefined,
           ListOptions,
           Command,
         ];
+        const issueIdentifier = resolveIssueArgument(issue, options.issue);
         const ctx = createContext(getRootOpts(command));
-        const issueId = await resolveIssueId(ctx.sdk, issue);
+        const issueId = await resolveIssueId(ctx.sdk, issueIdentifier);
         const filter = buildAttachmentFilter(options);
         const result = await listAttachments(ctx.gql, issueId, filter);
         outputSuccess(result);
@@ -96,26 +125,33 @@ export function setupAttachmentsCommands(program: Command): void {
     );
 
   attachments
-    .command("create <issue>")
+    .command("create [issue]")
     .description("create an attachment on an issue")
+    .option("--issue <issue>", "issue identifier (alias for positional issue)")
     .requiredOption("--title <title>", "attachment title")
     .requiredOption("--url <url>", "attachment URL")
     .option("--subtitle <text>", "attachment subtitle")
+    .option("--comment <text>", "comment body to create with the attachment")
+    .option("--icon-url <url>", "attachment icon URL")
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [issue, options, command] = args as [
-          string,
+          string | undefined,
           CreateOptions,
           Command,
         ];
+        const issueIdentifier = resolveIssueArgument(issue, options.issue);
         const ctx = createContext(getRootOpts(command));
-        const issueId = await resolveIssueId(ctx.sdk, issue);
-        const result = await createAttachment(ctx.gql, {
+        const issueId = await resolveIssueId(ctx.sdk, issueIdentifier);
+        const input: AttachmentCreateInput = {
           issueId,
           title: options.title,
           url: options.url,
           ...(options.subtitle && { subtitle: options.subtitle }),
-        });
+          ...(options.comment && { commentBody: options.comment }),
+          ...(options.iconUrl && { iconUrl: options.iconUrl }),
+        };
+        const result = await createAttachment(ctx.gql, input);
         outputSuccess(result);
       }),
     );

--- a/src/commands/documents.ts
+++ b/src/commands/documents.ts
@@ -1,21 +1,18 @@
 import type { Command } from "commander";
 import { createContext, getRootOpts } from "../common/context.js";
+import { invalidParameterError } from "../common/errors.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
-import type { DocumentUpdateInput } from "../gql/graphql.js";
+import type { DocumentFilter, DocumentUpdateInput } from "../gql/graphql.js";
 import { resolveIssueId } from "../resolvers/issue-resolver.js";
 import { resolveProjectId } from "../resolvers/project-resolver.js";
 import { resolveTeamId } from "../resolvers/team-resolver.js";
-import {
-  createAttachment,
-  listAttachments,
-} from "../services/attachment-service.js";
+import { listAttachments } from "../services/attachment-service.js";
 import {
   createDocument,
   deleteDocument,
   getDocument,
   listDocuments,
-  listDocumentsBySlugIds,
   updateDocument,
 } from "../services/document-service.js";
 
@@ -27,6 +24,7 @@ interface DocumentCreateOptions {
   icon?: string;
   color?: string;
   issue?: string;
+  attachTo?: string;
 }
 
 interface DocumentUpdateOptions {
@@ -66,9 +64,28 @@ export function extractDocumentIdFromUrl(url: string): string | null {
 
     return docSlug.substring(lastHyphenIndex + 1) || null;
   } catch {
-    // URL constructor throws on malformed input — treat as unresolvable
+    // URL constructor throws on malformed input — treat as unresolvable.
     return null;
   }
+}
+
+function buildIssueDocumentFilter(
+  issueId: string,
+  legacyDocumentSlugIds: string[],
+): DocumentFilter {
+  const issueFilter: DocumentFilter = { issue: { id: { eq: issueId } } };
+  if (legacyDocumentSlugIds.length === 0) {
+    return issueFilter;
+  }
+
+  return {
+    or: [
+      issueFilter,
+      ...legacyDocumentSlugIds.map((slugId) => ({
+        slugId: { eq: slugId },
+      })),
+    ],
+  };
 }
 
 export const DOCUMENTS_META: DomainMeta = {
@@ -115,48 +132,35 @@ export function setupDocumentsCommands(program: Command): void {
 
         const limit = parseLimit(options.limit || "50");
 
-        if (options.issue) {
-          const issueId = await resolveIssueId(ctx.sdk, options.issue);
-          const attachments = await listAttachments(ctx.gql, issueId);
+        let projectId: string | undefined;
+        if (options.project) {
+          projectId = await resolveProjectId(ctx.sdk, options.project);
+        }
 
-          const documentSlugIds = [
+        let issueId: string | undefined;
+        if (options.issue) {
+          issueId = await resolveIssueId(ctx.sdk, options.issue);
+        }
+
+        let filter: DocumentFilter | undefined;
+        if (projectId) {
+          filter = { project: { id: { eq: projectId } } };
+        } else if (issueId) {
+          const attachments = await listAttachments(ctx.gql, issueId);
+          const legacyDocumentSlugIds = [
             ...new Set(
               attachments
                 .map((att) => extractDocumentIdFromUrl(att.url))
                 .filter((id): id is string => id !== null),
             ),
           ];
-
-          if (documentSlugIds.length === 0) {
-            outputSuccess({
-              nodes: [],
-              pageInfo: { hasNextPage: false, endCursor: null },
-            });
-            return;
-          }
-
-          const documents = await listDocumentsBySlugIds(
-            ctx.gql,
-            documentSlugIds,
-          );
-          outputSuccess({
-            nodes: documents,
-            pageInfo: { hasNextPage: false, endCursor: null },
-          });
-          return;
-        }
-
-        let projectId: string | undefined;
-        if (options.project) {
-          projectId = await resolveProjectId(ctx.sdk, options.project);
+          filter = buildIssueDocumentFilter(issueId, legacyDocumentSlugIds);
         }
 
         const documents = await listDocuments(ctx.gql, {
           limit,
           after: options.after,
-          filter: projectId
-            ? { project: { id: { eq: projectId } } }
-            : undefined,
+          filter,
         });
 
         outputSuccess(documents);
@@ -187,9 +191,18 @@ export function setupDocumentsCommands(program: Command): void {
     .option("--icon <icon>", "document icon")
     .option("--color <color>", "icon color")
     .option("--issue <issue>", "also attach document to issue (e.g., ABC-123)")
+    .option("--attach-to <issue>", "alias for --issue")
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [options, command] = args as [DocumentCreateOptions, Command];
+        if (options.issue && options.attachTo) {
+          throw invalidParameterError(
+            "--attach-to",
+            "cannot be combined with --issue",
+          );
+        }
+
+        const issueIdentifier = options.issue ?? options.attachTo;
         const rootOpts = getRootOpts(command);
         const ctx = createContext(rootOpts);
 
@@ -199,35 +212,19 @@ export function setupDocumentsCommands(program: Command): void {
         const teamId = options.team
           ? await resolveTeamId(ctx.sdk, options.team)
           : undefined;
+        const issueId = issueIdentifier
+          ? await resolveIssueId(ctx.sdk, issueIdentifier)
+          : undefined;
 
         const document = await createDocument(ctx.gql, {
           title: options.title,
           content: options.content,
           projectId,
           teamId,
+          issueId,
           icon: options.icon,
           color: options.color,
         });
-
-        if (options.issue) {
-          const issueId = await resolveIssueId(ctx.sdk, options.issue);
-
-          try {
-            await createAttachment(ctx.gql, {
-              issueId,
-              url: document.url,
-              title: document.title,
-            });
-          } catch (attachError) {
-            const errorMessage =
-              attachError instanceof Error
-                ? attachError.message
-                : String(attachError);
-            throw new Error(
-              `Document created (${document.id}) but failed to attach to issue "${options.issue}": ${errorMessage}.`,
-            );
-          }
-        }
 
         outputSuccess(document);
       }),

--- a/src/services/document-service.ts
+++ b/src/services/document-service.ts
@@ -96,27 +96,6 @@ export async function listDocuments(
   };
 }
 
-export async function listDocumentsBySlugIds(
-  client: GraphQLClient,
-  slugIds: string[],
-): Promise<DocumentListItem[]> {
-  if (slugIds.length === 0) {
-    return [];
-  }
-
-  const result = await client.request<ListDocumentsQuery>(
-    ListDocumentsDocument,
-    {
-      first: slugIds.length,
-      filter: {
-        slugId: { in: slugIds },
-      },
-    },
-  );
-
-  return result.documents?.nodes ?? [];
-}
-
 export async function deleteDocument(
   client: GraphQLClient,
   id: string,

--- a/tests/unit/commands/attachments.test.ts
+++ b/tests/unit/commands/attachments.test.ts
@@ -72,6 +72,53 @@ describe("attachments list", () => {
     );
   });
 
+  it("accepts --issue as an alias for the issue argument", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "attachments",
+      "list",
+      "--issue",
+      "ENG-42",
+    ]);
+
+    expect(resolveIssueId).toHaveBeenCalledWith(expect.anything(), "ENG-42");
+    expect(listAttachments).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+      undefined,
+    );
+  });
+
+  it("rejects combining positional issue and --issue", async () => {
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "attachments",
+      "list",
+      "ENG-42",
+      "--issue",
+      "ENG-43",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid --issue: cannot be combined with positional issue",
+      ),
+    );
+    expect(listAttachments).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    exitSpy.mockRestore();
+  });
+
   it("passes source-type filter", async () => {
     const program = createProgram();
     await program.parseAsync([
@@ -175,6 +222,59 @@ describe("attachments create", () => {
       expect.anything(),
       expect.objectContaining({
         subtitle: "merged pull request",
+      }),
+    );
+  });
+
+  it("accepts --issue as an alias for the issue argument", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "attachments",
+      "create",
+      "--issue",
+      "ENG-42",
+      "--title",
+      "My PR",
+      "--url",
+      "https://github.com/org/repo/pull/1",
+    ]);
+
+    expect(resolveIssueId).toHaveBeenCalledWith(expect.anything(), "ENG-42");
+    expect(createAttachment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        issueId: "resolved-issue-uuid",
+        title: "My PR",
+        url: "https://github.com/org/repo/pull/1",
+      }),
+    );
+  });
+
+  it("passes optional comment and icon URL", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "attachments",
+      "create",
+      "ENG-42",
+      "--title",
+      "Build",
+      "--url",
+      "https://ci.example.com/build/1",
+      "--comment",
+      "Build is green",
+      "--icon-url",
+      "https://ci.example.com/icon.png",
+    ]);
+
+    expect(createAttachment).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        commentBody: "Build is green",
+        iconUrl: "https://ci.example.com/icon.png",
       }),
     );
   });

--- a/tests/unit/commands/documents.test.ts
+++ b/tests/unit/commands/documents.test.ts
@@ -1,0 +1,218 @@
+import { Command } from "commander";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("../../../src/common/context.js", () => ({
+  createContext: vi.fn(() => ({
+    gql: { request: vi.fn() },
+    sdk: { sdk: {} },
+  })),
+  getRootOpts: vi.fn(() => ({ apiToken: "test-token" })),
+}));
+
+vi.mock("../../../src/common/output.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<typeof import("../../../src/common/output.js")>();
+  return {
+    ...actual,
+    outputSuccess: vi.fn(),
+  };
+});
+
+vi.mock("../../../src/resolvers/issue-resolver.js", () => ({
+  resolveIssueId: vi.fn().mockResolvedValue("resolved-issue-uuid"),
+}));
+
+vi.mock("../../../src/resolvers/project-resolver.js", () => ({
+  resolveProjectId: vi.fn().mockResolvedValue("resolved-project-uuid"),
+}));
+
+vi.mock("../../../src/resolvers/team-resolver.js", () => ({
+  resolveTeamId: vi.fn().mockResolvedValue("resolved-team-uuid"),
+}));
+
+vi.mock("../../../src/services/attachment-service.js", () => ({
+  listAttachments: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("../../../src/services/document-service.js", () => ({
+  createDocument: vi.fn().mockResolvedValue({
+    id: "doc-1",
+    title: "Runbook",
+    url: "https://linear.app/example/document/runbook-abc123",
+  }),
+  deleteDocument: vi.fn().mockResolvedValue({ id: "doc-1", success: true }),
+  getDocument: vi.fn().mockResolvedValue({ id: "doc-1", title: "Runbook" }),
+  listDocuments: vi.fn().mockResolvedValue({
+    nodes: [{ id: "doc-1", title: "Runbook" }],
+    pageInfo: { hasNextPage: false, endCursor: null },
+  }),
+  updateDocument: vi.fn().mockResolvedValue({ id: "doc-1", title: "Runbook" }),
+}));
+
+import { setupDocumentsCommands } from "../../../src/commands/documents.js";
+import { resolveIssueId } from "../../../src/resolvers/issue-resolver.js";
+import { resolveTeamId } from "../../../src/resolvers/team-resolver.js";
+import { listAttachments } from "../../../src/services/attachment-service.js";
+import {
+  createDocument,
+  listDocuments,
+} from "../../../src/services/document-service.js";
+
+function createProgram(): Command {
+  const program = new Command();
+  program.option("--api-token <token>");
+  setupDocumentsCommands(program);
+  return program;
+}
+
+describe("documents list", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("uses the document issue filter for --issue", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "documents",
+      "list",
+      "--issue",
+      "ENG-42",
+    ]);
+
+    expect(resolveIssueId).toHaveBeenCalledWith(expect.anything(), "ENG-42");
+    expect(listDocuments).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        filter: { issue: { id: { eq: "resolved-issue-uuid" } } },
+      }),
+    );
+  });
+
+  it("includes legacy document URL attachments in the issue filter", async () => {
+    vi.mocked(listAttachments).mockResolvedValueOnce([
+      {
+        id: "att-1",
+        title: "Runbook",
+        subtitle: null,
+        url: "https://linear.app/example/document/runbook-abc123",
+        sourceType: null,
+        metadata: {},
+        source: null,
+        createdAt: "2026-01-01T00:00:00.000Z",
+        updatedAt: "2026-01-01T00:00:00.000Z",
+      },
+    ]);
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "documents",
+      "list",
+      "--issue",
+      "ENG-42",
+    ]);
+
+    expect(listDocuments).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        filter: {
+          or: [
+            { issue: { id: { eq: "resolved-issue-uuid" } } },
+            { slugId: { eq: "abc123" } },
+          ],
+        },
+      }),
+    );
+  });
+});
+
+describe("documents create", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  it("passes issueId directly when --issue is provided", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "documents",
+      "create",
+      "--title",
+      "Runbook",
+      "--issue",
+      "ENG-42",
+    ]);
+
+    expect(resolveIssueId).toHaveBeenCalledWith(expect.anything(), "ENG-42");
+    expect(createDocument).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        title: "Runbook",
+        issueId: "resolved-issue-uuid",
+      }),
+    );
+  });
+
+  it("accepts --attach-to as an alias for --issue", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "documents",
+      "create",
+      "--title",
+      "Runbook",
+      "--team",
+      "ENG",
+      "--attach-to",
+      "ENG-42",
+    ]);
+
+    expect(resolveTeamId).toHaveBeenCalledWith(expect.anything(), "ENG");
+    expect(resolveIssueId).toHaveBeenCalledWith(expect.anything(), "ENG-42");
+    expect(createDocument).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        teamId: "resolved-team-uuid",
+        issueId: "resolved-issue-uuid",
+      }),
+    );
+  });
+
+  it("rejects combining --issue and --attach-to before creating", async () => {
+    const exitSpy = vi
+      .spyOn(process, "exit")
+      .mockImplementation(() => undefined as never);
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "documents",
+      "create",
+      "--title",
+      "Runbook",
+      "--issue",
+      "ENG-42",
+      "--attach-to",
+      "ENG-43",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Invalid --attach-to: cannot be combined with --issue",
+      ),
+    );
+    expect(createDocument).not.toHaveBeenCalled();
+    expect(exitSpy).toHaveBeenCalledWith(1);
+
+    exitSpy.mockRestore();
+  });
+});

--- a/tests/unit/services/document-service.test.ts
+++ b/tests/unit/services/document-service.test.ts
@@ -6,7 +6,6 @@ import {
   deleteDocument,
   getDocument,
   listDocuments,
-  listDocumentsBySlugIds,
   updateDocument,
 } from "../../../src/services/document-service.js";
 
@@ -128,27 +127,6 @@ describe("listDocuments", () => {
       hasNextPage: true,
       endCursor: "nextCursor",
     });
-  });
-});
-
-describe("listDocumentsBySlugIds", () => {
-  it("returns empty array for empty input", async () => {
-    const client = mockGqlClient({});
-    const result = await listDocumentsBySlugIds(client, []);
-    expect(result).toEqual([]);
-  });
-
-  it("returns documents matching slugIds", async () => {
-    const client = mockGqlClient({
-      documents: {
-        nodes: [
-          { id: "1", slugId: "abc" },
-          { id: "2", slugId: "def" },
-        ],
-      },
-    });
-    const result = await listDocumentsBySlugIds(client, ["abc", "def"]);
-    expect(result).toHaveLength(2);
   });
 });
 


### PR DESCRIPTION
## Summary
- restore `attachments list/create --issue` compatibility while preserving positional issue syntax
- add `attachments create --comment` and `--icon-url`, backed by current Linear `AttachmentCreateInput` fields
- use current Linear `DocumentCreateInput.issueId` for `documents create --issue/--attach-to` and keep `documents list --issue` compatible with legacy document URL attachments

## Verification
- checked Linear official attachment docs and refreshed GraphQL codegen from `https://api.linear.app/graphql`
- `npm test`
- `npm run check:ci` (passes with existing Biome schema-version info)
- `npm run build`