### PR TITLE
feat(issues): restore relation commands

### DIFF
--- a/graphql/mutations/issue-relations.graphql
+++ b/graphql/mutations/issue-relations.graphql
@@ -6,9 +6,16 @@
 fragment IssueRelationFields on IssueRelation {
   id
   type
+  createdAt
+  issue {
+    id
+    identifier
+    title
+  }
   relatedIssue {
     id
     identifier
+    title
   }
 }
 
@@ -16,9 +23,16 @@ fragment IssueRelationFields on IssueRelation {
 fragment InverseIssueRelationFields on IssueRelation {
   id
   type
+  createdAt
   issue {
     id
     identifier
+    title
+  }
+  relatedIssue {
+    id
+    identifier
+    title
   }
 }
 
@@ -44,6 +58,8 @@ mutation DeleteIssueRelation($id: String!) {
 # Used by --remove-relation to locate the relation ID before deletion
 query GetIssueRelations($issueId: String!) {
   issue(id: $issueId) {
+    id
+    identifier
     relations {
       nodes {
         ...IssueRelationFields

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -58,6 +58,7 @@ import {
   createIssueRelation,
   deleteIssueRelation,
   findIssueRelation,
+  listIssueRelations,
 } from "../services/issue-relation-service.js";
 import {
   archiveIssue,
@@ -107,6 +108,7 @@ interface CreateOptions {
   blockedBy?: string;
   relatesTo?: string;
   duplicateOf?: string;
+  similarTo?: string;
 }
 
 interface UpdateOptions {
@@ -133,6 +135,7 @@ interface UpdateOptions {
   blockedBy?: string;
   relatesTo?: string;
   duplicateOf?: string;
+  similarTo?: string;
   removeRelation?: string;
 }
 
@@ -284,8 +287,21 @@ export const ISSUES_META: DomainMeta = {
 };
 
 interface RelationAction {
-  type: "blocks" | "blockedBy" | "relatesTo" | "duplicateOf" | "remove";
+  type:
+    | "blocks"
+    | "blockedBy"
+    | "relatesTo"
+    | "duplicateOf"
+    | "similarTo"
+    | "remove";
   targets: string[];
+}
+
+interface RelationAddOptions {
+  blocks?: string;
+  related?: string;
+  duplicate?: string;
+  similar?: string;
 }
 
 function parseRelationFlags(flags: {
@@ -293,6 +309,7 @@ function parseRelationFlags(flags: {
   blockedBy?: string;
   relatesTo?: string;
   duplicateOf?: string;
+  similarTo?: string;
   removeRelation?: string;
 }): RelationAction[] {
   const entries: Array<{
@@ -303,6 +320,7 @@ function parseRelationFlags(flags: {
     { type: "blockedBy", raw: flags.blockedBy },
     { type: "relatesTo", raw: flags.relatesTo },
     { type: "duplicateOf", raw: flags.duplicateOf },
+    { type: "similarTo", raw: flags.similarTo },
     { type: "remove", raw: flags.removeRelation },
   ];
 
@@ -327,7 +345,7 @@ function parseRelationFlags(flags: {
     ];
     if (targets.length === 0) {
       throw new Error(
-        `Relation flag --${type === "remove" ? "remove-relation" : type} must not be empty`,
+        `Relation flag ${relationFlagName(type)} must not be empty`,
       );
     }
     actions.push({ type, targets });
@@ -340,17 +358,88 @@ function parseRelationFlags(flags: {
       const prev = seen.get(target);
       if (prev) {
         throw new Error(
-          `${target} appears in multiple relation flags (${prev} and --${action.type === "remove" ? "remove-relation" : action.type})`,
+          `${target} appears in multiple relation flags (${prev} and ${relationFlagName(action.type)})`,
         );
       }
-      seen.set(
-        target,
-        `--${action.type === "remove" ? "remove-relation" : action.type}`,
-      );
+      seen.set(target, relationFlagName(action.type));
     }
   }
 
   return actions;
+}
+
+function relationFlagName(type: RelationAction["type"]): string {
+  switch (type) {
+    case "blocks":
+      return "--blocks";
+    case "blockedBy":
+      return "--blocked-by";
+    case "relatesTo":
+      return "--relates-to";
+    case "duplicateOf":
+      return "--duplicate-of";
+    case "similarTo":
+      return "--similar-to";
+    case "remove":
+      return "--remove-relation";
+  }
+}
+
+function relationTypeFromAddFlag(
+  type: "blocks" | "related" | "duplicate" | "similar",
+): IssueRelationType {
+  switch (type) {
+    case "blocks":
+      return IssueRelationType.Blocks;
+    case "related":
+      return IssueRelationType.Related;
+    case "duplicate":
+      return IssueRelationType.Duplicate;
+    case "similar":
+      return IssueRelationType.Similar;
+  }
+}
+
+function parseRelationAddOptions(options: RelationAddOptions): {
+  type: IssueRelationType;
+  targets: string[];
+} {
+  const typeFlags = [
+    options.blocks ? "blocks" : null,
+    options.related ? "related" : null,
+    options.duplicate ? "duplicate" : null,
+    options.similar ? "similar" : null,
+  ].filter((type): type is keyof RelationAddOptions => type !== null);
+
+  if (typeFlags.length === 0) {
+    throw new Error(
+      "Must specify one of --blocks, --related, --duplicate, or --similar",
+    );
+  }
+
+  if (typeFlags.length > 1) {
+    throw new Error("Cannot specify multiple relation types");
+  }
+
+  const type = typeFlags[0];
+  const rawTargets = options[type] ?? "";
+  const targets = [
+    ...new Set(
+      rawTargets
+        .split(",")
+        .map((target) => target.trim())
+        .filter(Boolean),
+    ),
+  ];
+
+  if (targets.length === 0) {
+    throw new Error("At least one related issue ID must be provided");
+  }
+
+  return {
+    type: relationTypeFromAddFlag(type),
+    targets,
+  };
 }
 
 async function resolveAndApplyRelations(
@@ -398,6 +487,13 @@ async function resolveAndApplyRelations(
             issueId,
             relatedIssueId: targetId,
             type: IssueRelationType.Duplicate,
+          });
+          break;
+        case "similarTo":
+          await createIssueRelation(ctx.gql, {
+            issueId,
+            relatedIssueId: targetId,
+            type: IssueRelationType.Similar,
           });
           break;
         case "remove": {
@@ -449,6 +545,77 @@ export function setupIssuesCommands(program: Command): void {
   const issues = program.command("issues").description("Issue operations");
 
   issues.action(() => issues.help());
+
+  const relations = issues
+    .command("relations")
+    .description("Issue relation operations");
+
+  relations.action(() => relations.help());
+
+  relations
+    .command("list <issue>")
+    .description("list relations for an issue")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [issue, , command] = args as [string, unknown, Command];
+        const ctx = createContext(getRootOpts(command));
+        const issueId = await resolveIssueId(ctx.sdk, issue);
+        const result = await listIssueRelations(ctx.gql, issueId);
+
+        outputSuccess(result);
+      }),
+    );
+
+  relations
+    .command("add <issue>")
+    .description("add relation(s) to an issue")
+    .option("--blocks <issues>", "issues this issue blocks (comma-separated)")
+    .option("--related <issues>", "related issues (comma-separated)")
+    .option(
+      "--duplicate <issues>",
+      "issues this is a duplicate of (comma-separated)",
+    )
+    .option("--similar <issues>", "similar issues (comma-separated)")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [issue, options, command] = args as [
+          string,
+          RelationAddOptions,
+          Command,
+        ];
+        const relation = parseRelationAddOptions(options);
+        const ctx = createContext(getRootOpts(command));
+        const sourceIssueId = await resolveIssueId(ctx.sdk, issue);
+        const targetIds = await Promise.all(
+          relation.targets.map((target) => resolveIssueId(ctx.sdk, target)),
+        );
+
+        const created = await Promise.all(
+          targetIds.map((targetId) =>
+            createIssueRelation(ctx.gql, {
+              issueId: sourceIssueId,
+              relatedIssueId: targetId,
+              type: relation.type,
+            }),
+          ),
+        );
+
+        outputSuccess(created);
+      }),
+    );
+
+  relations
+    .command("remove <relation>")
+    .description("remove a relation by UUID")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [relation, , command] = args as [string, unknown, Command];
+        const ctx = createContext(getRootOpts(command));
+        const result = await deleteIssueRelation(ctx.gql, relation);
+
+        outputSuccess(result);
+      }),
+    );
 
   addFilterOptions(
     issues
@@ -988,6 +1155,7 @@ export function setupIssuesCommands(program: Command): void {
     .option("--blocked-by <issue>", "this issue is blocked by <issue>")
     .option("--relates-to <issue>", "this issue relates to <issue>")
     .option("--duplicate-of <issue>", "this issue duplicates <issue>")
+    .option("--similar-to <issue>", "this issue is similar to <issue>")
     .action(
       handleCommand(async (...args: unknown[]) => {
         const [title, options, command] = args as [
@@ -1140,6 +1308,7 @@ export function setupIssuesCommands(program: Command): void {
     .option("--blocked-by <issue>", "add blocked-by relation")
     .option("--relates-to <issue>", "add relates-to relation")
     .option("--duplicate-of <issue>", "add duplicate relation")
+    .option("--similar-to <issue>", "add similar relation")
     .option("--remove-relation <issue>", "remove relation with <issue>")
     .action(
       handleCommand(async (...args: unknown[]) => {

--- a/src/services/issue-relation-service.ts
+++ b/src/services/issue-relation-service.ts
@@ -11,6 +11,8 @@ import {
   type IssueRelationType,
 } from "../gql/graphql.js";
 
+type IssueRelationsIssue = NonNullable<GetIssueRelationsQuery["issue"]>;
+
 export async function createIssueRelation(
   client: GraphQLClient,
   input: {
@@ -27,6 +29,36 @@ export async function createIssueRelation(
     throw new Error("Failed to create issue relation");
   }
   return result.issueRelationCreate.issueRelation;
+}
+
+export async function listIssueRelations(
+  client: GraphQLClient,
+  issueId: string,
+): Promise<{
+  issueId: string;
+  identifier: string;
+  relations: Array<
+    | IssueRelationsIssue["relations"]["nodes"][0]
+    | IssueRelationsIssue["inverseRelations"]["nodes"][0]
+  >;
+}> {
+  const result = await client.request<GetIssueRelationsQuery>(
+    GetIssueRelationsDocument,
+    { issueId },
+  );
+
+  if (!result.issue) {
+    throw notFoundError("Issue", issueId);
+  }
+
+  return {
+    issueId: result.issue.id,
+    identifier: result.issue.identifier,
+    relations: [
+      ...result.issue.relations.nodes,
+      ...result.issue.inverseRelations.nodes,
+    ],
+  };
 }
 
 export async function findIssueRelation(

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -116,9 +116,17 @@ vi.mock("../../../src/services/issue-service.js", () => ({
 }));
 
 vi.mock("../../../src/services/issue-relation-service.js", () => ({
-  createIssueRelation: vi.fn(),
-  deleteIssueRelation: vi.fn(),
-  findIssueRelation: vi.fn(),
+  createIssueRelation: vi.fn().mockResolvedValue({ id: "relation-uuid" }),
+  deleteIssueRelation: vi.fn().mockResolvedValue({
+    id: "relation-uuid",
+    success: true,
+  }),
+  findIssueRelation: vi.fn().mockResolvedValue("relation-uuid"),
+  listIssueRelations: vi.fn().mockResolvedValue({
+    issueId: "resolved-issue-uuid",
+    identifier: "ENG-42",
+    relations: [],
+  }),
 }));
 
 vi.mock("../../../src/services/reaction-service.js", () => ({
@@ -1915,6 +1923,28 @@ describe("issues create relations", () => {
     );
     expect(createIssueRelation).toHaveBeenCalledTimes(1);
   });
+
+  it("creates similar relation", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "create",
+      "Title",
+      "--team",
+      "ENG",
+      "--similar-to",
+      "DAT-103",
+    ]);
+    const { createIssueRelation } = await import(
+      "../../../src/services/issue-relation-service.js"
+    );
+    expect(createIssueRelation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ type: "similar" }),
+    );
+  });
 });
 
 describe("issues update relations", () => {
@@ -1997,5 +2027,116 @@ describe("issues update relations", () => {
       expect.stringContaining("Cannot mix add and remove relation flags"),
     );
     expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("adds similar relation", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--similar-to",
+      "DAT-103",
+    ]);
+    const { createIssueRelation } = await import(
+      "../../../src/services/issue-relation-service.js"
+    );
+    expect(createIssueRelation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ type: "similar" }),
+    );
+  });
+});
+
+describe("issues relations subcommands", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("lists relations for an issue", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "relations",
+      "list",
+      "ENG-42",
+    ]);
+
+    const { listIssueRelations } = await import(
+      "../../../src/services/issue-relation-service.js"
+    );
+    expect(listIssueRelations).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+    );
+  });
+
+  it("adds comma-separated relations", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "relations",
+      "add",
+      "ENG-42",
+      "--similar",
+      "DAT-103,DAT-104",
+    ]);
+
+    const { createIssueRelation } = await import(
+      "../../../src/services/issue-relation-service.js"
+    );
+    expect(createIssueRelation).toHaveBeenCalledTimes(2);
+    expect(createIssueRelation).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ type: "similar" }),
+    );
+  });
+
+  it("rejects add without relation type", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "relations",
+      "add",
+      "ENG-42",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Must specify one of --blocks, --related, --duplicate, or --similar",
+      ),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("removes relation by UUID", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "relations",
+      "remove",
+      "relation-uuid",
+    ]);
+
+    const { deleteIssueRelation } = await import(
+      "../../../src/services/issue-relation-service.js"
+    );
+    expect(deleteIssueRelation).toHaveBeenCalledWith(
+      expect.anything(),
+      "relation-uuid",
+    );
   });
 });

--- a/tests/unit/services/issue-relation-service.test.ts
+++ b/tests/unit/services/issue-relation-service.test.ts
@@ -5,6 +5,7 @@ import {
   createIssueRelation,
   deleteIssueRelation,
   findIssueRelation,
+  listIssueRelations,
 } from "../../../src/services/issue-relation-service.js";
 
 function mockGqlClient(response: Record<string, unknown>): GraphQLClient {
@@ -109,6 +110,62 @@ describe("findIssueRelation", () => {
     await expect(
       findIssueRelation(client, "source-id", "target-id"),
     ).rejects.toThrow("not found");
+  });
+});
+
+describe("listIssueRelations", () => {
+  it("returns issue metadata with forward and inverse relations", async () => {
+    const client = mockGqlClient({
+      issue: {
+        id: "source-id",
+        identifier: "ENG-1",
+        relations: {
+          nodes: [
+            {
+              id: "rel-1",
+              type: IssueRelationType.Blocks,
+              relatedIssue: { id: "target-id", identifier: "ENG-2" },
+            },
+          ],
+        },
+        inverseRelations: {
+          nodes: [
+            {
+              id: "rel-2",
+              type: IssueRelationType.Related,
+              issue: { id: "other-id", identifier: "ENG-3" },
+            },
+          ],
+        },
+      },
+    });
+
+    const result = await listIssueRelations(client, "source-id");
+
+    expect(result).toEqual({
+      issueId: "source-id",
+      identifier: "ENG-1",
+      relations: [
+        {
+          id: "rel-1",
+          type: IssueRelationType.Blocks,
+          relatedIssue: { id: "target-id", identifier: "ENG-2" },
+        },
+        {
+          id: "rel-2",
+          type: IssueRelationType.Related,
+          issue: { id: "other-id", identifier: "ENG-3" },
+        },
+      ],
+    });
+  });
+
+  it("throws when issue is not found", async () => {
+    const client = mockGqlClient({ issue: null });
+
+    await expect(listIssueRelations(client, "missing")).rejects.toThrow(
+      "not found",
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- restore `issues relations list/add/remove` compatibility on the new command architecture
- add `similar` relation support via `issues relations add --similar` and direct `--similar-to` flags
- expand relation GraphQL output with source/target issue details and expose `listIssueRelations` service helper

## Verification
- refreshed GraphQL codegen from Linear live schema at `https://api.linear.app/graphql`; current `IssueRelationType` includes `blocks`, `duplicate`, `related`, and `similar`
- `npm test`
- `npm run check:ci` (passes with existing Biome schema-version info)
- `npm run build`