### PR TITLE
test(milestone): guard against input-wrapped variable regression (#228)

### DIFF
--- a/tests/unit/helpers/assert-variables.ts
+++ b/tests/unit/helpers/assert-variables.ts
@@ -1,0 +1,39 @@
+import { type DocumentNode, Kind } from "graphql";
+import { expect } from "vitest";
+
+/**
+ * Collect the names of every variable declared by the operation(s) in a
+ * GraphQL document (e.g. `$projectId`, `$name` → "projectId", "name").
+ */
+export function declaredVariableNames(doc: DocumentNode): Set<string> {
+  const names = new Set<string>();
+  for (const definition of doc.definitions) {
+    if (definition.kind !== Kind.OPERATION_DEFINITION) {
+      continue;
+    }
+    for (const variable of definition.variableDefinitions ?? []) {
+      names.add(variable.variable.name.value);
+    }
+  }
+  return names;
+}
+
+/**
+ * Assert that every top-level key of the variables object passed to
+ * `client.request` corresponds to a variable actually declared by the
+ * document. This catches the `{ input }`-vs-flat-variable class of bug
+ * (see issue #228): passing `{ input: {...} }` against a mutation that
+ * declares flat `$projectId`/`$name`/... variables would surface an
+ * undeclared "input" key here.
+ */
+export function assertVariablesMatchDocument(
+  doc: DocumentNode,
+  variables: Record<string, unknown>,
+): void {
+  const declared = declaredVariableNames(doc);
+  const undeclared = Object.keys(variables).filter((key) => !declared.has(key));
+  expect(
+    undeclared,
+    `Variables ${JSON.stringify(undeclared)} are not declared by the document (declared: ${JSON.stringify([...declared])})`,
+  ).toEqual([]);
+}

--- a/tests/unit/services/milestone-service.variables.test.ts
+++ b/tests/unit/services/milestone-service.variables.test.ts
@@ -1,0 +1,75 @@
+import type { DocumentNode } from "graphql";
+import { describe, expect, it, vi } from "vitest";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import {
+  createMilestone,
+  updateMilestone,
+} from "../../../src/services/milestone-service.js";
+import { assertVariablesMatchDocument } from "../helpers/assert-variables.js";
+
+/**
+ * Regression guard for issue #228: the milestone mutations declare flat
+ * variables (`$projectId`, `$name`, ...), so the service must pass flat
+ * variables — not `{ input }` / `{ id, input }`. These tests capture the
+ * variables object actually handed to `client.request` and assert every key
+ * is a variable the document declares.
+ */
+function mockGqlClient(response: Record<string, unknown>): {
+  client: GraphQLClient;
+  request: ReturnType<typeof vi.fn>;
+} {
+  const request = vi.fn().mockResolvedValue(response);
+  return { client: { request } as unknown as GraphQLClient, request };
+}
+
+function lastCallVariables(
+  request: ReturnType<typeof vi.fn>,
+): [DocumentNode, Record<string, unknown>] {
+  const [document, variables] = request.mock.calls[0] as [
+    DocumentNode,
+    Record<string, unknown>,
+  ];
+  return [document, variables];
+}
+
+describe("milestone service variable shapes (issue #228)", () => {
+  it("createMilestone passes only declared variables", async () => {
+    const { client, request } = mockGqlClient({
+      projectMilestoneCreate: {
+        success: true,
+        projectMilestone: { id: "ms-new", name: "v2.0" },
+      },
+    });
+
+    await createMilestone(client, {
+      projectId: "proj-1",
+      name: "v2.0",
+      description: "Second release",
+      targetDate: "2025-12-01",
+    });
+
+    const [document, variables] = lastCallVariables(request);
+    assertVariablesMatchDocument(document, variables);
+    expect(variables).not.toHaveProperty("input");
+  });
+
+  it("updateMilestone passes only declared variables", async () => {
+    const { client, request } = mockGqlClient({
+      projectMilestoneUpdate: {
+        success: true,
+        projectMilestone: { id: "ms-1", name: "v1.1" },
+      },
+    });
+
+    await updateMilestone(client, "ms-1", {
+      name: "v1.1",
+      description: "Updated",
+      targetDate: "2026-01-01",
+      sortOrder: 2,
+    });
+
+    const [document, variables] = lastCallVariables(request);
+    assertVariablesMatchDocument(document, variables);
+    expect(variables).not.toHaveProperty("input");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds regression tests for issue #228: the milestone GraphQL mutations declare flat variables (`$projectId`, `$name`, ...) and wrap them into `input:` internally, so `createMilestone`/`updateMilestone` must pass flat variables rather than an `{ input }`-wrapped object. A new `assertVariablesMatchDocument` helper captures the variables handed to `client.request` and asserts every key is actually declared by the document, and the milestone service tests exercise both mutations against it.

Closes #228

## Type of change

- [x] Tests

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

`npx vitest run tests/unit/services/milestone-service.variables.test.ts` — 2 passing. `npx tsc --noEmit` clean.

## Notes for reviewers

Test-only change; no production code is modified. The helper's undeclared-key check is one-directional (it catches extra/wrong keys such as `input`, not missing ones), which is sufficient for the #228 regression class.
