### PR TITLE
fix(milestones): use $input convention for milestone mutations

### DIFF
--- a/graphql/mutations/project-milestones.graphql
+++ b/graphql/mutations/project-milestones.graphql
@@ -7,20 +7,8 @@
 # Create a new project milestone
 #
 # Creates a new project milestone and returns the created project milestone data.
-mutation CreateProjectMilestone(
-  $projectId: String!
-  $name: String!
-  $description: String
-  $targetDate: TimelessDate
-) {
-  projectMilestoneCreate(
-    input: {
-      projectId: $projectId
-      name: $name
-      description: $description
-      targetDate: $targetDate
-    }
-  ) {
+mutation CreateProjectMilestone($input: ProjectMilestoneCreateInput!) {
+  projectMilestoneCreate(input: $input) {
     success
     projectMilestone {
       id
@@ -43,20 +31,9 @@ mutation CreateProjectMilestone(
 # Updates an existing project milestone and returns the updated project milestone data.
 mutation UpdateProjectMilestone(
   $id: String!
-  $name: String
-  $description: String
-  $targetDate: TimelessDate
-  $sortOrder: Float
+  $input: ProjectMilestoneUpdateInput!
 ) {
-  projectMilestoneUpdate(
-    id: $id
-    input: {
-      name: $name
-      description: $description
-      targetDate: $targetDate
-      sortOrder: $sortOrder
-    }
-  ) {
+  projectMilestoneUpdate(id: $id, input: $input) {
     success
     projectMilestone {
       id

--- a/src/services/milestone-service.ts
+++ b/src/services/milestone-service.ts
@@ -63,7 +63,7 @@ export async function createMilestone(
 ): Promise<CreatedMilestone> {
   const result = await client.request<CreateProjectMilestoneMutation>(
     CreateProjectMilestoneDocument,
-    input,
+    { input },
   );
 
   if (
@@ -83,7 +83,7 @@ export async function updateMilestone(
 ): Promise<UpdatedMilestone> {
   const result = await client.request<UpdateProjectMilestoneMutation>(
     UpdateProjectMilestoneDocument,
-    { id, ...input },
+    { id, input },
   );
 
   if (

--- a/tests/unit/helpers/assert-variables.ts
+++ b/tests/unit/helpers/assert-variables.ts
@@ -21,10 +21,11 @@ export function declaredVariableNames(doc: DocumentNode): Set<string> {
 /**
  * Assert that every top-level key of the variables object passed to
  * `client.request` corresponds to a variable actually declared by the
- * document. This catches the `{ input }`-vs-flat-variable class of bug
- * (see issue #228): passing `{ input: {...} }` against a mutation that
- * declares flat `$projectId`/`$name`/... variables would surface an
- * undeclared "input" key here.
+ * document. This catches the input-shape-vs-declared-variable class of bug
+ * (see issues #223 / #228): passing variables whose keys do not match the
+ * mutation's declared variables (e.g. flat `$projectId`/`$name`/... against a
+ * document declaring `$input`, or vice versa) would surface an undeclared key
+ * here.
  */
 export function assertVariablesMatchDocument(
   doc: DocumentNode,

--- a/tests/unit/services/milestone-service.test.ts
+++ b/tests/unit/services/milestone-service.test.ts
@@ -134,6 +134,29 @@ describe("createMilestone", () => {
     expect(result.name).toBe("v2.0");
   });
 
+  it("passes input as a single GraphQL variable", async () => {
+    const client = mockGqlClient({
+      projectMilestoneCreate: {
+        success: true,
+        projectMilestone: {
+          id: "ms-new",
+          name: "v2.0",
+          description: null,
+          targetDate: null,
+          sortOrder: 0,
+        },
+      },
+    });
+    const input = {
+      projectId: "proj-1",
+      name: "v2.0",
+      description: "desc",
+      targetDate: "2025-12-01",
+    };
+    await createMilestone(client, input);
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), { input });
+  });
+
   it("throws on failure", async () => {
     const client = mockGqlClient({
       projectMilestoneCreate: {
@@ -164,6 +187,27 @@ describe("updateMilestone", () => {
     const result = await updateMilestone(client, "ms-1", { name: "v1.1" });
     expect(result.id).toBe("ms-1");
     expect(result.name).toBe("v1.1");
+  });
+
+  it("passes id and input as GraphQL variables", async () => {
+    const client = mockGqlClient({
+      projectMilestoneUpdate: {
+        success: true,
+        projectMilestone: {
+          id: "ms-1",
+          name: "v1.1",
+          description: null,
+          targetDate: null,
+          sortOrder: 0,
+        },
+      },
+    });
+    const input = { name: "v1.1", description: "updated" };
+    await updateMilestone(client, "ms-1", input);
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      id: "ms-1",
+      input,
+    });
   });
 
   it("throws on failure", async () => {

--- a/tests/unit/services/milestone-service.variables.test.ts
+++ b/tests/unit/services/milestone-service.variables.test.ts
@@ -8,11 +8,11 @@ import {
 import { assertVariablesMatchDocument } from "../helpers/assert-variables.js";
 
 /**
- * Regression guard for issue #228: the milestone mutations declare flat
- * variables (`$projectId`, `$name`, ...), so the service must pass flat
- * variables — not `{ input }` / `{ id, input }`. These tests capture the
- * variables object actually handed to `client.request` and assert every key
- * is a variable the document declares.
+ * Regression guard for the milestone mutation variable shapes (issues #223 /
+ * #228): the milestone mutations follow the `$input` convention used by every
+ * other mutation in the codebase, so the service must pass `{ input }` /
+ * `{ id, input }`. These tests capture the variables object actually handed to
+ * `client.request` and assert every key is a variable the document declares.
  */
 function mockGqlClient(response: Record<string, unknown>): {
   client: GraphQLClient;
@@ -32,7 +32,7 @@ function lastCallVariables(
   return [document, variables];
 }
 
-describe("milestone service variable shapes (issue #228)", () => {
+describe("milestone service variable shapes (issues #223 / #228)", () => {
   it("createMilestone passes only declared variables", async () => {
     const { client, request } = mockGqlClient({
       projectMilestoneCreate: {
@@ -50,7 +50,7 @@ describe("milestone service variable shapes (issue #228)", () => {
 
     const [document, variables] = lastCallVariables(request);
     assertVariablesMatchDocument(document, variables);
-    expect(variables).not.toHaveProperty("input");
+    expect(variables).toHaveProperty("input");
   });
 
   it("updateMilestone passes only declared variables", async () => {
@@ -70,6 +70,6 @@ describe("milestone service variable shapes (issue #228)", () => {
 
     const [document, variables] = lastCallVariables(request);
     assertVariablesMatchDocument(document, variables);
-    expect(variables).not.toHaveProperty("input");
+    expect(variables).toHaveProperty("input");
   });
 });


### PR DESCRIPTION
## What does this PR do?

`linearis milestones create` failed at runtime with a GraphQL variable error and `milestones update` sent incorrect variables, because `project-milestones.graphql` was the only mutation file declaring top-level scalar variables while the service passed them under the `$input` convention used everywhere else. This aligns both `CreateProjectMilestone` and `UpdateProjectMilestone` to take a single `$input: ...Input!` argument and updates the service to pass `{ input }` / `{ id, input }` accordingly.

Closes #223

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

`npx tsc --noEmit` is clean and `npx vitest run tests/unit/services/milestone-service.test.ts` passes (12 tests), including two new assertions that create/update forward inputs as single GraphQL variables (`{ input }` and `{ id, input }`).

## Notes for reviewers

`src/gql/` is regenerated via `npm run generate` (gitignored) so the change is type-correct end-to-end.