### PR TITLE
feat(output): add --compact and --fields flags for token-efficient output

### DIFF
--- a/src/common/auth.ts
+++ b/src/common/auth.ts
@@ -5,6 +5,8 @@ import { getStoredToken } from "./token-storage.js";
 
 export interface CommandOptions {
   apiToken?: string;
+  compact?: boolean;
+  fields?: string[];
 }
 
 export type TokenSource = "flag" | "env" | "stored" | "legacy";

--- a/src/common/output.ts
+++ b/src/common/output.ts
@@ -1,13 +1,13 @@
+import type { CommandOptions } from "./auth.js";
 import {
   AUTH_ERROR_CODE,
   AuthenticationError,
   invalidParameterError,
 } from "./errors.js";
 
-interface OutputOptions {
-  compact?: boolean;
-  fields?: string[]; // raw dot-paths, e.g. ["identifier", "state.name"]
-}
+// Derived from CommandOptions so the two can never drift; `fields` holds raw
+// dot-paths, e.g. ["identifier", "state.name"].
+type OutputOptions = Pick<CommandOptions, "compact" | "fields">;
 
 let currentOutputOptions: OutputOptions = {};
 
@@ -29,8 +29,11 @@ export function parseFieldsList(value: string): string[] {
 
 /**
  * Recursively project `value` down to the given dot-path segments, preserving
- * nested object shape and traversing arrays mid-path. Missing keys are skipped
- * silently; a path that stops at a subtree keeps that whole subtree.
+ * nested object shape and traversing arrays mid-path. Only own properties are
+ * matched (inherited members like `toString`/`constructor` are never picked),
+ * and results are written with `Object.defineProperty` so a user-supplied
+ * `--fields __proto__` cannot invoke the prototype setter. Missing keys are
+ * skipped silently; a path that stops at a subtree keeps that whole subtree.
  */
 export function pickFields(value: unknown, paths: string[][]): unknown {
   if (Array.isArray(value)) {
@@ -49,8 +52,14 @@ export function pickFields(value: unknown, paths: string[][]): unknown {
   }
   const out: Record<string, unknown> = {};
   for (const [head, tails] of byHead) {
-    if (!(head in src)) continue;
-    out[head] = tails.length > 0 ? pickFields(src[head], tails) : src[head];
+    if (!Object.hasOwn(src, head)) continue;
+    const picked = tails.length > 0 ? pickFields(src[head], tails) : src[head];
+    Object.defineProperty(out, head, {
+      value: picked,
+      enumerable: true,
+      writable: true,
+      configurable: true,
+    });
   }
   return out;
 }

--- a/src/common/output.ts
+++ b/src/common/output.ts
@@ -4,8 +4,67 @@ import {
   invalidParameterError,
 } from "./errors.js";
 
+interface OutputOptions {
+  compact?: boolean;
+  fields?: string[]; // raw dot-paths, e.g. ["identifier", "state.name"]
+}
+
+let currentOutputOptions: OutputOptions = {};
+
+/**
+ * Set once per process by the preAction hook in main.ts. Also used to reset
+ * state between unit tests.
+ */
+export function setOutputOptions(opts: OutputOptions): void {
+  currentOutputOptions = opts;
+}
+
+/** Commander option parser for `--fields`: "a, b ,, c" -> ["a","b","c"]. */
+export function parseFieldsList(value: string): string[] {
+  return value
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Recursively project `value` down to the given dot-path segments, preserving
+ * nested object shape and traversing arrays mid-path. Missing keys are skipped
+ * silently; a path that stops at a subtree keeps that whole subtree.
+ */
+export function pickFields(value: unknown, paths: string[][]): unknown {
+  if (Array.isArray(value)) {
+    return value.map((item) => pickFields(item, paths));
+  }
+  if (value === null || typeof value !== "object") {
+    return value; // path descends past a scalar; nothing to pick
+  }
+  const src = value as Record<string, unknown>;
+  const byHead = new Map<string, string[][]>();
+  for (const [head, ...tail] of paths) {
+    if (head === undefined) continue;
+    const tails = byHead.get(head) ?? [];
+    if (tail.length > 0) tails.push(tail);
+    byHead.set(head, tails);
+  }
+  const out: Record<string, unknown> = {};
+  for (const [head, tails] of byHead) {
+    if (!(head in src)) continue;
+    out[head] = tails.length > 0 ? pickFields(src[head], tails) : src[head];
+  }
+  return out;
+}
+
 export function outputSuccess(data: unknown): void {
-  console.log(JSON.stringify(data, null, 2));
+  const { compact, fields } = currentOutputOptions;
+  const shaped =
+    fields && fields.length > 0
+      ? pickFields(
+          data,
+          fields.map((p) => p.split(".")),
+        )
+      : data;
+  console.log(JSON.stringify(shaped, null, compact ? undefined : 2));
 }
 
 export function outputError(error: Error): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,6 +27,8 @@ import {
 import { PROJECTS_META, setupProjectsCommands } from "./commands/projects.js";
 import { setupTeamsCommands, TEAMS_META } from "./commands/teams.js";
 import { setupUsersCommands, USERS_META } from "./commands/users.js";
+import { getRootOpts } from "./common/context.js";
+import { parseFieldsList, setOutputOptions } from "./common/output.js";
 import {
   type DomainMeta,
   formatDomainUsage,
@@ -37,7 +39,17 @@ program
   .name("linearis")
   .description("CLI for Linear.app with JSON output")
   .version(pkg.version)
-  .option("--api-token <token>", "Linear API token");
+  .option("--api-token <token>", "Linear API token")
+  .option("--compact", "emit single-line JSON (no indentation)")
+  .option(
+    "--fields <list>",
+    "comma-separated dot-paths to include (e.g. identifier,title,state.name)",
+    parseFieldsList,
+  );
+
+program.hook("preAction", (_thisCommand, actionCommand) => {
+  setOutputOptions(getRootOpts(actionCommand));
+});
 
 const allMetas: DomainMeta[] = [
   AUTH_META,

--- a/tests/unit/common/output.test.ts
+++ b/tests/unit/common/output.test.ts
@@ -1,22 +1,145 @@
 // tests/unit/common/output.test.ts
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthenticationError } from "../../../src/common/errors.js";
 import {
   handleCommand,
   outputAuthError,
   outputError,
   outputSuccess,
+  parseFieldsList,
   parseLimit,
+  pickFields,
+  setOutputOptions,
 } from "../../../src/common/output.js";
 
 describe("outputSuccess", () => {
-  it("writes JSON to stdout", () => {
+  beforeEach(() => setOutputOptions({}));
+
+  it("writes indented JSON to stdout by default", () => {
     const spy = vi.spyOn(console, "log").mockImplementation(() => {});
     outputSuccess({ id: "123", title: "Test" });
     expect(spy).toHaveBeenCalledWith(
       JSON.stringify({ id: "123", title: "Test" }, null, 2),
     );
     spy.mockRestore();
+  });
+
+  it("emits single-line JSON when compact is set", () => {
+    setOutputOptions({ compact: true });
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    outputSuccess({ id: "123", title: "Test" });
+    expect(spy).toHaveBeenCalledWith('{"id":"123","title":"Test"}');
+    spy.mockRestore();
+  });
+
+  it("filters shape when fields are set", () => {
+    setOutputOptions({ fields: ["identifier", "state.name"] });
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    outputSuccess({
+      identifier: "ENG-1",
+      title: "Fix login bug",
+      state: { id: "s1", name: "In Progress", type: "started" },
+    });
+    expect(spy).toHaveBeenCalledWith(
+      JSON.stringify(
+        { identifier: "ENG-1", state: { name: "In Progress" } },
+        null,
+        2,
+      ),
+    );
+    spy.mockRestore();
+  });
+
+  it("combines compact and fields (issue example)", () => {
+    setOutputOptions({
+      compact: true,
+      fields: ["identifier", "title", "state.name"],
+    });
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    outputSuccess([
+      {
+        identifier: "ENG-1",
+        title: "Fix login bug",
+        state: { id: "s1", name: "In Progress", type: "started" },
+        assignee: { id: "u1" },
+      },
+    ]);
+    expect(spy).toHaveBeenCalledWith(
+      '[{"identifier":"ENG-1","title":"Fix login bug","state":{"name":"In Progress"}}]',
+    );
+    spy.mockRestore();
+  });
+});
+
+describe("parseFieldsList", () => {
+  it("splits on comma", () => {
+    expect(parseFieldsList("identifier,title,state.name")).toEqual([
+      "identifier",
+      "title",
+      "state.name",
+    ]);
+  });
+
+  it("trims whitespace and drops empty entries", () => {
+    expect(parseFieldsList(" a , b ,, c ")).toEqual(["a", "b", "c"]);
+  });
+});
+
+describe("pickFields", () => {
+  it("picks a single top-level field", () => {
+    expect(pickFields({ a: 1, b: 2 }, [["a"]])).toEqual({ a: 1 });
+  });
+
+  it("picks a nested field", () => {
+    expect(
+      pickFields({ state: { name: "Todo", type: "unstarted" } }, [
+        ["state", "name"],
+      ]),
+    ).toEqual({ state: { name: "Todo" } });
+  });
+
+  it("merges sibling paths under one head", () => {
+    expect(
+      pickFields({ state: { id: "s1", name: "Todo", type: "unstarted" } }, [
+        ["state", "name"],
+        ["state", "type"],
+      ]),
+    ).toEqual({ state: { name: "Todo", type: "unstarted" } });
+  });
+
+  it("traverses arrays mid-path", () => {
+    expect(
+      pickFields(
+        { labels: { nodes: [{ name: "bug", id: "1" }, { name: "ux" }] } },
+        [["labels", "nodes", "name"]],
+      ),
+    ).toEqual({ labels: { nodes: [{ name: "bug" }, { name: "ux" }] } });
+  });
+
+  it("projects each element of a top-level array", () => {
+    expect(
+      pickFields(
+        [
+          { id: "1", x: 1 },
+          { id: "2", x: 2 },
+        ],
+        [["id"]],
+      ),
+    ).toEqual([{ id: "1" }, { id: "2" }]);
+  });
+
+  it("keeps the whole subtree when a path stops at an object", () => {
+    const state = { id: "s1", name: "Todo" };
+    expect(pickFields({ state, title: "t" }, [["state"]])).toEqual({ state });
+  });
+
+  it("skips missing keys silently", () => {
+    expect(pickFields({ a: 1 }, [["a"], ["missing"]])).toEqual({ a: 1 });
+  });
+
+  it("returns scalars unchanged when a path over-descends", () => {
+    expect(pickFields({ a: 5 }, [["a", "deep"]])).toEqual({ a: 5 });
+    expect(pickFields({ a: null }, [["a", "deep"]])).toEqual({ a: null });
   });
 });
 

--- a/tests/unit/common/output.test.ts
+++ b/tests/unit/common/output.test.ts
@@ -141,6 +141,26 @@ describe("pickFields", () => {
     expect(pickFields({ a: 5 }, [["a", "deep"]])).toEqual({ a: 5 });
     expect(pickFields({ a: null }, [["a", "deep"]])).toEqual({ a: null });
   });
+
+  it("never matches inherited (non-own) properties", () => {
+    const result = pickFields({ a: 1 }, [["toString"], ["constructor"]]);
+    expect(result).toEqual({});
+    expect(Object.hasOwn(result as object, "toString")).toBe(false);
+  });
+
+  it("does not invoke the prototype setter for a __proto__ path", () => {
+    const result = pickFields({ a: 1 }, [["__proto__", "x"]]);
+    expect(result).toEqual({});
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+  });
+
+  it("preserves a legitimate own __proto__ key without polluting the result", () => {
+    const input = JSON.parse('{"__proto__":{"x":9},"a":1}') as unknown;
+    const result = pickFields(input, [["__proto__", "x"], ["a"]]);
+    expect(Object.getPrototypeOf(result)).toBe(Object.prototype);
+    expect((result as { a: number }).a).toBe(1);
+    expect((result as Record<string, { x: number }>).__proto__.x).toBe(9);
+  });
 });
 
 describe("outputError", () => {


### PR DESCRIPTION
## What does this PR do?

Adds two global output-shaping flags for token-efficient stdout: `--compact` emits single-line JSON, and `--fields <list>` keeps only comma-separated dot-paths while preserving nested object shape and traversing arrays mid-path (e.g. `labels.nodes.name`). Options are set once per process via a Commander `preAction` hook reading root opts through the existing `getRootOpts()` helper, so none of the ~120 `outputSuccess()` call sites change; error envelopes stay pretty-printed. New `pickFields` / `parseFieldsList` helpers live in `src/common/output.ts` with unit tests.

Closes #220

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `npm run check:ci`, `npx tsc --noEmit`, `npm run build` all pass.
- `npm test` — 747 tests pass (56 files), including 12 new cases for `parseFieldsList`, `pickFields`, and `outputSuccess`.
- Smoke: `node dist/main.js --help` lists both flags; the issue's example `--compact --fields identifier,title,state.name issues list` output is asserted in the unit tests.

## Notes for reviewers

Plumbing uses a preAction hook + module state (`setOutputOptions`) to keep the change surgical (2 source files) rather than threading opts through every command. `--fields` v1 has no wildcard/array-index syntax and error output is intentionally left indented.