### PR TITLE
ci(conductor): add shared Conductor settings.toml

### DIFF
--- a/.conductor/settings.toml
+++ b/.conductor/settings.toml
@@ -1,0 +1,23 @@
+#:schema https://conductor.build/schemas/settings.repo.schema.json
+"$schema" = "https://conductor.build/schemas/settings.repo.schema.json"
+
+[scripts]
+# `npm install` also runs the `prepare` hook: GraphQL codegen (src/gql/) + lefthook install.
+setup = "npm install"
+# Stateless JSON-output CLI — no shared port/db/stack — so workspaces can run side by side.
+run_mode = "concurrent"
+# Remove per-workspace build output on archive; leaves source untouched.
+archive = "npm run clean"
+
+[scripts.run.test]
+command = "npm test"
+default = true
+icon = "test-tube"
+
+[scripts.run.build]
+command = "npm run build"
+icon = "package"
+
+[scripts.run.check]
+command = "npm run check:ci"
+icon = "wrench"


### PR DESCRIPTION
## What does this PR do?

Adds a shared `.conductor/settings.toml` so every Conductor workspace is prepared and runnable out of the box. It configures `setup = "npm install"` (which also runs codegen + lefthook via the `prepare` hook), `run_mode = "concurrent"` (safe for this stateless CLI), `archive = "npm run clean"`, and `test`/`build`/`check` run scripts mapped to the repo's verification checklist.

## Type of change

- [x] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [ ] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Config-only change (no source/tests affected). Validated the TOML parses with Python's `tomllib`. End-to-end check: create a fresh Conductor workspace from this branch and run **Run → test** — setup runs `npm install` then the vitest suite passes.

## Notes for reviewers

No `CONDUCTOR_PORT` or `file_include_globs`: the tool exposes no server, and the default `.env*` copy already covers the gitignored `LINEAR_API_TOKEN`. Conductor only picks up shared `settings.toml` once merged to the default branch (`next`).