### PR TITLE
refactor(codegen): map GraphQL custom scalars to concrete types

### DIFF
--- a/codegen.config.ts
+++ b/codegen.config.ts
@@ -9,6 +9,25 @@ const config: CodegenConfig = {
       presetConfig: {
         fragmentMasking: false,
       },
+      config: {
+        // Any custom scalar reachable from our operations that is not mapped
+        // below falls back to `unknown` (safe) instead of the codegen default
+        // `any`.
+        defaultScalarType: "unknown",
+        scalars: {
+          DateTime: { input: "string", output: "string" },
+          DateTimeOrDuration: { input: "string", output: "string" },
+          TimelessDate: { input: "string", output: "string" },
+          TimelessDateOrDuration: { input: "string", output: "string" },
+          Duration: { input: "string | number", output: "string" },
+          UUID: { input: "string", output: "string" },
+          JSON: { input: "unknown", output: "unknown" },
+          JSONObject: {
+            input: "Record<string, unknown>",
+            output: "Record<string, unknown>",
+          },
+        },
+      },
     },
   },
 };

--- a/src/commands/initiatives/entity.ts
+++ b/src/commands/initiatives/entity.ts
@@ -311,7 +311,7 @@ function parseSortOrderNumber(value?: string): number | undefined {
 }
 
 function applyNullableDateRange(
-  target: { gte?: string; lte?: string },
+  target: { gte?: string | null; lte?: string | null },
   after?: string,
   before?: string,
 ): void {


### PR DESCRIPTION
## What does this PR do?

Configures GraphQL codegen to map Linear's custom scalars (DateTime, Duration, UUID, JSON, JSONObject, TimelessDate, etc.) to concrete TypeScript types and sets `defaultScalarType: "unknown"` so any unmapped scalar falls back to `unknown` instead of the codegen default `any`. The initiative date-range helper is widened to accept the resulting nullable comparator types (`string | null`).

Closes #199

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [x] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [ ] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Ran `npm run generate` and confirmed the generated `src/gql/graphql.ts` `Scalars` block now maps every reachable custom scalar with no `any` types. Verified `npx tsc --noEmit` (exit 0), `npm run check:ci`, and `npm test` (769 tests pass).

## Notes for reviewers

This is a type-level change only — no runtime behavior changes. `src/gql/` is git-ignored and regenerated at build time, so no generated files appear in the diff. The `entity.ts` change is a required consequence: the comparator types are now `InputMaybe<...>` (`string | null`) rather than `any`, so the helper signature was widened to match.