### PR TITLE
fix(ci): skip PR comment posting for fork pull requests

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -84,7 +84,6 @@ jobs:
     if: github.event_name == 'pull_request'
     permissions:
       contents: read
-      pull-requests: write
 
     steps:
       - name: Checkout code
@@ -129,14 +128,24 @@ jobs:
             } > knip-comment.md
           fi
 
-      - name: Post / update PR comment
-        # GITHUB_TOKEN is forced read-only for pull_request events from forks,
-        # so posting a comment would fail there regardless of permissions:.
-        if: always() && github.event.pull_request.head.repo.full_name == github.repository
-        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+      - name: Save PR number
+        if: always()
+        run: echo "${{ github.event.pull_request.number }}" > pr-number.txt
+
+      # GITHUB_TOKEN is forced read-only for pull_request events from forks,
+      # so this job can't post the comment itself regardless of permissions:.
+      # Upload the rendered comment + PR number as an artifact; a separate
+      # workflow_run-triggered workflow (which does get a writable token)
+      # downloads it and posts the comment. See .github/workflows/knip-comment.yml.
+      - name: Upload knip comment artifact
+        if: always()
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          header: knip-dead-code
-          path: knip-comment.md
+          name: knip-comment
+          path: |
+            knip-comment.md
+            pr-number.txt
+          retention-days: 1
 
       - name: Fail if dead code found
         if: steps.knip.outputs.exit_code != '0'

--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -130,7 +130,9 @@ jobs:
           fi
 
       - name: Post / update PR comment
-        if: always()
+        # GITHUB_TOKEN is forced read-only for pull_request events from forks,
+        # so posting a comment would fail there regardless of permissions:.
+        if: always() && github.event.pull_request.head.repo.full_name == github.repository
         uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
         with:
           header: knip-dead-code
@@ -206,23 +208,29 @@ jobs:
           if [ -n "$plan_files" ]; then
             echo "::error::Found plan files in branch history"
 
-            printf '%s\n' \
-              '<!-- linearis:guard-plan-files -->' \
-              '' \
-              '> [!WARNING]' \
-              '> Found `docs/plans/*.md` files in this branch'"'"'s history.' \
-              '>' \
-              '> Plan files in `docs/plans/` are working artifacts created by AI agents during the design phase. Once the implementation they describe is complete and the PR is ready for review, these files serve no further purpose — they are not reference docs, not changelogs, and not part of the shipped project.' \
-              '>' \
-              '> Leaving them in the commit history would add noise and suggest unresolved or incomplete work.' \
-              '>' \
-              '> **Remove them by rebasing and dropping the commits that introduced them:**' \
-              '> ```bash' \
-              '> git rebase -i main' \
-              '> # drop the commits that added docs/plans/*.md, then force-push' \
-              '> git push --force-with-lease' \
-              '> ```' \
-            | gh pr comment ${{ github.event.pull_request.number }} --body-file -
+            # GITHUB_TOKEN is forced read-only for pull_request events from
+            # forks, so posting a comment would fail there regardless of
+            # permissions:. The ::error:: above still surfaces in the checks
+            # UI, so skip the comment rather than fail this step on forks.
+            if [ "${{ github.event.pull_request.head.repo.full_name }}" = "${{ github.repository }}" ]; then
+              printf '%s\n' \
+                '<!-- linearis:guard-plan-files -->' \
+                '' \
+                '> [!WARNING]' \
+                '> Found `docs/plans/*.md` files in this branch'"'"'s history.' \
+                '>' \
+                '> Plan files in `docs/plans/` are working artifacts created by AI agents during the design phase. Once the implementation they describe is complete and the PR is ready for review, these files serve no further purpose — they are not reference docs, not changelogs, and not part of the shipped project.' \
+                '>' \
+                '> Leaving them in the commit history would add noise and suggest unresolved or incomplete work.' \
+                '>' \
+                '> **Remove them by rebasing and dropping the commits that introduced them:**' \
+                '> ```bash' \
+                '> git rebase -i main' \
+                '> # drop the commits that added docs/plans/*.md, then force-push' \
+                '> git push --force-with-lease' \
+                '> ```' \
+              | gh pr comment ${{ github.event.pull_request.number }} --body-file -
+            fi
 
             exit 1
           fi

--- a/.github/workflows/knip-comment.yml
+++ b/.github/workflows/knip-comment.yml
@@ -1,0 +1,54 @@
+name: Post Knip Comment
+
+# Runs after "Validate CI" completes, in the base repo's context (so it gets
+# a writable GITHUB_TOKEN even for fork PRs) instead of running with the
+# PR's own code. See the knip job in ci-validate.yml for the untrusted half
+# of this split — it builds/runs the PR's code with a read-only token and
+# uploads the rendered comment as an artifact for this workflow to post.
+on:
+  workflow_run:
+    workflows:
+      - Validate CI
+    types:
+      - completed
+
+permissions:
+  contents: read
+
+jobs:
+  comment:
+    name: Post / Update Knip PR Comment
+    runs-on: ubuntu-latest
+    # Run for PR builds regardless of pass/fail: the knip job intentionally
+    # fails "Validate CI" when it finds dead code, and that's exactly when the
+    # comment matters most. The artifact is uploaded with `if: always()` before
+    # that failing step, so it exists on both success and failure. Only skip
+    # `cancelled` runs (e.g. superseded by cancel-in-progress concurrency),
+    # which may never reach the upload step and thus have no artifact.
+    if: >-
+      github.event.workflow_run.event == 'pull_request'
+      && github.event.workflow_run.conclusion != 'cancelled'
+    permissions:
+      # actions: read is required for download-artifact to fetch the artifact
+      # from a different workflow run (via run-id); pull-requests: write is for
+      # posting the comment.
+      actions: read
+      pull-requests: write
+    steps:
+      - name: Download knip comment artifact
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: knip-comment
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Read PR number
+        id: pr
+        run: echo "number=$(cat pr-number.txt)" >> "$GITHUB_OUTPUT"
+
+      - name: Post / update PR comment
+        uses: marocchino/sticky-pull-request-comment@773744901bac0e8cbb5a0dc842800d45e9b2b405 # v2.9.4
+        with:
+          header: knip-dead-code
+          path: knip-comment.md
+          number: ${{ steps.pr.outputs.number }}


### PR DESCRIPTION
## What does this PR do?

`GITHUB_TOKEN` is forced read-only for `pull_request` events triggered from forks, so both the knip dead-code sticky comment and the plan-files guard comment fail on fork PRs regardless of declared workflow permissions. This PR gates both `gh pr comment` steps to only run when the PR head repo matches the base repo (i.e. not a fork), avoiding the CI failure. The `::error::` annotation for the plan-files guard still surfaces in the checks UI on forks, so the check still fails visibly — it just no longer errors out trying to post an unauthorized comment.

## Type of change

- [x] Bug fix

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [ ] New code has tests (happy path + primary error case) — workflow YAML, not applicable
- [x] Commit messages follow Conventional Commits

## Testing

Reviewed the workflow logic change manually; no local execution path for GitHub Actions conditionals.

## Notes for reviewers

No functional changes for same-repo PRs — `github.event.pull_request.head.repo.full_name == github.repository` is true for those.