### PR TITLE
feat(cli): add passive update notifier and version command

### DIFF
--- a/src/commands/version.ts
+++ b/src/commands/version.ts
@@ -1,0 +1,65 @@
+import type { Command } from "commander";
+import pkg from "../../package.json" with { type: "json" };
+import { handleCommand, outputSuccess } from "../common/output.js";
+import {
+  channelFor,
+  fetchLatestVersion,
+  isNewer,
+  writeCache,
+} from "../common/update-notifier.js";
+import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
+
+export const VERSION_META: DomainMeta = {
+  name: "version",
+  summary: "show the installed version and check for updates",
+  context: [
+    "reports the installed linearis version and its release channel (latest or",
+    "next). `version check` queries the npm registry for the newest version on",
+    "that channel and reports whether an update is available. interactive runs",
+    "also print a one-line hint to stderr; set NO_UPDATE_NOTIFIER=1 to silence.",
+  ].join("\n"),
+  arguments: {},
+  seeAlso: [],
+};
+
+export function setupVersionCommands(program: Command): void {
+  const version = program
+    .command("version")
+    .description("show the installed version");
+
+  version.action(
+    handleCommand(async () => {
+      outputSuccess({
+        version: pkg.version,
+        channel: channelFor(pkg.version),
+      });
+    }),
+  );
+
+  version
+    .command("check")
+    .description("check the npm registry for a newer version")
+    .action(
+      handleCommand(async () => {
+        const channel = channelFor(pkg.version);
+        const latest = await fetchLatestVersion(channel);
+        const updateAvailable = latest ? isNewer(latest, pkg.version) : false;
+        if (latest) {
+          writeCache({ channel, latest, checkedAt: Date.now() });
+        }
+        outputSuccess({
+          current: pkg.version,
+          latest,
+          channel,
+          updateAvailable,
+        });
+      }),
+    );
+
+  version
+    .command("usage")
+    .description("show detailed usage for version")
+    .action(() => {
+      console.log(formatDomainUsage(version, VERSION_META));
+    });
+}

--- a/src/common/update-notifier.ts
+++ b/src/common/update-notifier.ts
@@ -1,0 +1,197 @@
+import fs from "node:fs";
+import path from "node:path";
+import { ensureTokenDir, getTokenDir } from "./token-storage.js";
+
+/**
+ * Passive "update available" notifier, run inline before every command.
+ *
+ * Design constraints (Linearis emits JSON on stdout for agents):
+ * - The hint is written to **stderr only**, never stdout, so it can never
+ *   corrupt the JSON contract that agents parse.
+ * - It is shown only on interactive runs (`process.stdout.isTTY`). Agents and
+ *   scripts pipe stdout, so they are never nagged and make no network calls.
+ * - The registry lookup is cached on disk; only a stale cache (older than
+ *   CHECK_INTERVAL_MS) triggers a network call, so the common path is instant.
+ * - Every operation fails silently; a version check must never affect a command.
+ */
+
+const CACHE_FILE = "update-check.json";
+const CHECK_INTERVAL_MS = 24 * 60 * 60 * 1000; // 24h
+const NPM_DIST_TAGS_URL =
+  "https://registry.npmjs.org/-/package/linearis/dist-tags";
+const FETCH_TIMEOUT_MS = 3000;
+
+export type Channel = "latest" | "next";
+
+export interface UpdateCacheData {
+  channel: Channel;
+  latest: string;
+  checkedAt: number;
+}
+
+/** "next" when the installed version carries a `-next` prerelease, else "latest". */
+export function channelFor(version: string): Channel {
+  return /-next\b/.test(version) ? "next" : "latest";
+}
+
+function cachePath(): string {
+  return path.join(getTokenDir(), CACHE_FILE);
+}
+
+/** Read the last cached registry lookup, or null if missing/corrupt. */
+export function readCache(): UpdateCacheData | null {
+  try {
+    const data = JSON.parse(fs.readFileSync(cachePath(), "utf8")) as
+      | UpdateCacheData
+      | undefined;
+    if (
+      data &&
+      typeof data.latest === "string" &&
+      typeof data.checkedAt === "number" &&
+      (data.channel === "latest" || data.channel === "next")
+    ) {
+      return data;
+    }
+  } catch {
+    // missing or corrupt cache — treat as absent
+  }
+  return null;
+}
+
+/** Persist a registry lookup for the next invocation to read. */
+export function writeCache(data: UpdateCacheData): void {
+  ensureTokenDir();
+  fs.writeFileSync(cachePath(), JSON.stringify(data), "utf8");
+}
+
+/**
+ * Compare two versions of the form `YYYY.M.P` with an optional `-tag.N`
+ * prerelease suffix. Returns >0 if `a` > `b`, <0 if `a` < `b`, 0 if equal.
+ * A release (no prerelease) outranks a prerelease sharing the same core.
+ */
+export function compareVersions(a: string, b: string): number {
+  const [coreA, preA = ""] = a.split("-");
+  const [coreB, preB = ""] = b.split("-");
+  const numsA = coreA.split(".").map((n) => Number.parseInt(n, 10) || 0);
+  const numsB = coreB.split(".").map((n) => Number.parseInt(n, 10) || 0);
+  const len = Math.max(numsA.length, numsB.length);
+  for (let i = 0; i < len; i++) {
+    const diff = (numsA[i] ?? 0) - (numsB[i] ?? 0);
+    if (diff !== 0) return Math.sign(diff);
+  }
+  if (preA === preB) return 0;
+  if (preA === "") return 1; // a is a release, b a prerelease of same core
+  if (preB === "") return -1;
+  return comparePrerelease(preA, preB);
+}
+
+function comparePrerelease(a: string, b: string): number {
+  const as = a.split(".");
+  const bs = b.split(".");
+  const len = Math.max(as.length, bs.length);
+  for (let i = 0; i < len; i++) {
+    const x = as[i];
+    const y = bs[i];
+    if (x === undefined) return -1; // shorter prerelease sorts lower
+    if (y === undefined) return 1;
+    const nx = Number.parseInt(x, 10);
+    const ny = Number.parseInt(y, 10);
+    if (!Number.isNaN(nx) && !Number.isNaN(ny)) {
+      if (nx !== ny) return Math.sign(nx - ny);
+    } else if (x !== y) {
+      return x < y ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+/** True when `candidate` is a strictly newer version than `current`. */
+export function isNewer(candidate: string, current: string): boolean {
+  return compareVersions(candidate, current) > 0;
+}
+
+/** Respect the de-facto `NO_UPDATE_NOTIFIER`, a project escape hatch, and CI. */
+export function updateChecksDisabled(
+  env: NodeJS.ProcessEnv = process.env,
+): boolean {
+  return Boolean(
+    env.NO_UPDATE_NOTIFIER || env.LINEARIS_NO_UPDATE_CHECK || env.CI,
+  );
+}
+
+/** The one-line stderr hint shown when an update is available. */
+export function formatUpdateNotice(
+  current: string,
+  latest: string,
+  channel: Channel,
+): string {
+  const tag = channel === "next" ? "@next" : "@latest";
+  return [
+    `▲ linearis update available: ${current} → ${latest}`,
+    `  run: npm install -g linearis${tag}`,
+    "  silence: set NO_UPDATE_NOTIFIER=1",
+  ].join("\n");
+}
+
+/** Query the npm registry for the newest version on a dist-tag channel. */
+export async function fetchLatestVersion(
+  channel: Channel,
+): Promise<string | null> {
+  try {
+    const res = await fetch(NPM_DIST_TAGS_URL, {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    const tags = (await res.json()) as Record<string, string>;
+    const version = tags[channel];
+    return typeof version === "string" ? version : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * On interactive runs, print a one-line hint to stderr when a newer version is
+ * available. Reads from the on-disk cache; refreshes it inline only when stale.
+ * Never blocks agents/scripts, never throws.
+ */
+export async function maybeNotifyUpdate(currentVersion: string): Promise<void> {
+  try {
+    // Agents/scripts consume stdout non-interactively — never nag them, and
+    // never make a network call on their behalf.
+    if (!process.stdout.isTTY) return;
+    if (updateChecksDisabled()) return;
+
+    const channel = channelFor(currentVersion);
+    let cache = readCache();
+    const stale =
+      !cache ||
+      cache.channel !== channel ||
+      Date.now() - cache.checkedAt > CHECK_INTERVAL_MS;
+    if (stale) {
+      const latest = await fetchLatestVersion(channel);
+      // Advance checkedAt even when the lookup fails so a failed check backs
+      // off for CHECK_INTERVAL_MS instead of re-fetching on every command.
+      // Carry the prior latest when the registry is unreachable, falling back
+      // to the current version (which never triggers a notice) when there is
+      // no prior cache to reuse.
+      const resolvedLatest =
+        latest ?? (cache?.channel === channel ? cache.latest : currentVersion);
+      cache = { channel, latest: resolvedLatest, checkedAt: Date.now() };
+      writeCache(cache);
+    }
+
+    if (
+      cache &&
+      cache.channel === channel &&
+      isNewer(cache.latest, currentVersion)
+    ) {
+      process.stderr.write(
+        `${formatUpdateNotice(currentVersion, cache.latest, channel)}\n`,
+      );
+    }
+  } catch {
+    // Update checks must never affect the command outcome.
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -27,8 +27,10 @@ import {
 import { PROJECTS_META, setupProjectsCommands } from "./commands/projects.js";
 import { setupTeamsCommands, TEAMS_META } from "./commands/teams.js";
 import { setupUsersCommands, USERS_META } from "./commands/users.js";
+import { setupVersionCommands, VERSION_META } from "./commands/version.js";
 import { getRootOpts } from "./common/context.js";
 import { parseFieldsList, setOutputOptions } from "./common/output.js";
+import { maybeNotifyUpdate } from "./common/update-notifier.js";
 import {
   type DomainMeta,
   formatDomainUsage,
@@ -47,8 +49,9 @@ program
     parseFieldsList,
   );
 
-program.hook("preAction", (_thisCommand, actionCommand) => {
+program.hook("preAction", async (_thisCommand, actionCommand) => {
   setOutputOptions(getRootOpts(actionCommand));
+  await maybeNotifyUpdate(pkg.version);
 });
 
 const allMetas: DomainMeta[] = [
@@ -65,6 +68,7 @@ const allMetas: DomainMeta[] = [
   TEAMS_META,
   USERS_META,
   INITIATIVES_META,
+  VERSION_META,
 ];
 
 program.action(() => console.log(formatOverview(pkg.version, allMetas)));
@@ -82,6 +86,7 @@ setupTeamsCommands(program);
 setupUsersCommands(program);
 setupInitiativesCommands(program);
 setupDocumentsCommands(program);
+setupVersionCommands(program);
 
 program
   .command("usage")
@@ -104,4 +109,4 @@ program
     }
   });
 
-program.parse();
+program.parseAsync();

--- a/tests/unit/common/update-notifier.test.ts
+++ b/tests/unit/common/update-notifier.test.ts
@@ -1,0 +1,205 @@
+import fs from "node:fs";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+vi.mock("node:fs");
+
+vi.mock("../../../src/common/token-storage.js", () => ({
+  getTokenDir: vi.fn(() => "/tmp/linearis-test"),
+  ensureTokenDir: vi.fn(),
+}));
+
+import {
+  channelFor,
+  compareVersions,
+  formatUpdateNotice,
+  isNewer,
+  maybeNotifyUpdate,
+  readCache,
+  type UpdateCacheData,
+  updateChecksDisabled,
+} from "../../../src/common/update-notifier.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("channelFor", () => {
+  it("returns 'next' for prerelease versions", () => {
+    expect(channelFor("2026.6.0-next.5")).toBe("next");
+  });
+
+  it("returns 'latest' for stable versions", () => {
+    expect(channelFor("2026.6.0")).toBe("latest");
+  });
+});
+
+describe("compareVersions", () => {
+  it("orders by calver core", () => {
+    expect(compareVersions("2026.7.0", "2026.6.0")).toBeGreaterThan(0);
+    expect(compareVersions("2026.6.1", "2026.6.0")).toBeGreaterThan(0);
+    expect(compareVersions("2027.1.0", "2026.12.0")).toBeGreaterThan(0);
+    expect(compareVersions("2026.6.0", "2026.6.0")).toBe(0);
+  });
+
+  it("ranks a release above a prerelease of the same core", () => {
+    expect(compareVersions("2026.6.0", "2026.6.0-next.5")).toBeGreaterThan(0);
+    expect(compareVersions("2026.6.0-next.5", "2026.6.0")).toBeLessThan(0);
+  });
+
+  it("orders prerelease counters numerically", () => {
+    expect(
+      compareVersions("2026.6.0-next.10", "2026.6.0-next.9"),
+    ).toBeGreaterThan(0);
+    expect(compareVersions("2026.6.0-next.2", "2026.6.0-next.2")).toBe(0);
+  });
+});
+
+describe("isNewer", () => {
+  it("is true only for strictly newer candidates", () => {
+    expect(isNewer("2026.6.0-next.6", "2026.6.0-next.5")).toBe(true);
+    expect(isNewer("2026.6.0-next.5", "2026.6.0-next.5")).toBe(false);
+    expect(isNewer("2026.6.0-next.4", "2026.6.0-next.5")).toBe(false);
+  });
+});
+
+describe("updateChecksDisabled", () => {
+  it("respects the standard and project-specific opt-out env vars", () => {
+    expect(updateChecksDisabled({ NO_UPDATE_NOTIFIER: "1" })).toBe(true);
+    expect(updateChecksDisabled({ LINEARIS_NO_UPDATE_CHECK: "1" })).toBe(true);
+    expect(updateChecksDisabled({ CI: "true" })).toBe(true);
+    expect(updateChecksDisabled({})).toBe(false);
+  });
+});
+
+describe("formatUpdateNotice", () => {
+  it("uses the channel-specific install tag", () => {
+    const next = formatUpdateNotice(
+      "2026.6.0-next.5",
+      "2026.6.0-next.6",
+      "next",
+    );
+    expect(next).toContain("2026.6.0-next.5 → 2026.6.0-next.6");
+    expect(next).toContain("npm install -g linearis@next");
+    expect(next).toContain("NO_UPDATE_NOTIFIER=1");
+
+    const latest = formatUpdateNotice("2026.6.0", "2026.7.0", "latest");
+    expect(latest).toContain("npm install -g linearis@latest");
+  });
+});
+
+describe("readCache", () => {
+  it("returns parsed cache data when valid", () => {
+    const cache: UpdateCacheData = {
+      channel: "next",
+      latest: "2026.6.0-next.6",
+      checkedAt: 123,
+    };
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(cache));
+    expect(readCache()).toEqual(cache);
+  });
+
+  it("returns null on a missing file", () => {
+    vi.mocked(fs.readFileSync).mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    expect(readCache()).toBeNull();
+  });
+
+  it("returns null on corrupt or malformed cache", () => {
+    vi.mocked(fs.readFileSync).mockReturnValue("not json");
+    expect(readCache()).toBeNull();
+    vi.mocked(fs.readFileSync).mockReturnValue(
+      JSON.stringify({ channel: "bogus", latest: 1 }),
+    );
+    expect(readCache()).toBeNull();
+  });
+});
+
+describe("maybeNotifyUpdate", () => {
+  const originalIsTTY = process.stdout.isTTY;
+  let stderrSpy: ReturnType<typeof vi.spyOn>;
+
+  function setStdoutTTY(value: boolean): void {
+    Object.defineProperty(process.stdout, "isTTY", {
+      value,
+      configurable: true,
+    });
+  }
+
+  beforeEach(() => {
+    stderrSpy = vi.spyOn(process.stderr, "write").mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process.stdout, "isTTY", {
+      value: originalIsTTY,
+      configurable: true,
+    });
+    stderrSpy.mockRestore();
+  });
+
+  it("stays silent when stdout is not a TTY (agent/piped use)", async () => {
+    setStdoutTTY(false);
+    await maybeNotifyUpdate("2026.6.0-next.5");
+    expect(stderrSpy).not.toHaveBeenCalled();
+  });
+
+  it("stays silent when update checks are disabled", async () => {
+    setStdoutTTY(true);
+    vi.stubEnv("NO_UPDATE_NOTIFIER", "1");
+    await maybeNotifyUpdate("2026.6.0-next.5");
+    expect(stderrSpy).not.toHaveBeenCalled();
+    vi.unstubAllEnvs();
+  });
+
+  it("prints a hint from a fresh cache without hitting the network", async () => {
+    setStdoutTTY(true);
+    vi.stubEnv("NO_UPDATE_NOTIFIER", "");
+    vi.stubEnv("LINEARIS_NO_UPDATE_CHECK", "");
+    vi.stubEnv("CI", "");
+    const fetchSpy = vi.spyOn(globalThis, "fetch");
+    const cache: UpdateCacheData = {
+      channel: "next",
+      latest: "2026.6.0-next.9",
+      checkedAt: Date.now(),
+    };
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(cache));
+    await maybeNotifyUpdate("2026.6.0-next.5");
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(stderrSpy).toHaveBeenCalledOnce();
+    expect(String(stderrSpy.mock.calls[0]?.[0])).toContain("update available");
+    fetchSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+
+  it("backs off by refreshing the cache when a stale lookup fails", async () => {
+    setStdoutTTY(true);
+    vi.stubEnv("NO_UPDATE_NOTIFIER", "");
+    vi.stubEnv("LINEARIS_NO_UPDATE_CHECK", "");
+    vi.stubEnv("CI", "");
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockRejectedValue(new Error("offline"));
+    const staleCache: UpdateCacheData = {
+      channel: "next",
+      latest: "2026.6.0-next.9",
+      checkedAt: 0, // older than CHECK_INTERVAL_MS → stale
+    };
+    vi.mocked(fs.readFileSync).mockReturnValue(JSON.stringify(staleCache));
+    const before = Date.now();
+
+    await maybeNotifyUpdate("2026.6.0-next.5");
+
+    // checkedAt is advanced (so the next command backs off) while the prior
+    // latest is carried, so the notice still shows from cached data.
+    expect(fs.writeFileSync).toHaveBeenCalledOnce();
+    const written = JSON.parse(
+      String(vi.mocked(fs.writeFileSync).mock.calls[0]?.[1]),
+    ) as UpdateCacheData;
+    expect(written.latest).toBe("2026.6.0-next.9");
+    expect(written.checkedAt).toBeGreaterThanOrEqual(before);
+    expect(stderrSpy).toHaveBeenCalledOnce();
+    fetchSpy.mockRestore();
+    vi.unstubAllEnvs();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds a `version` command (with a `version check` subcommand) plus an inline, stderr-only "update available" notifier that runs before every command. The notifier fires only on interactive TTY runs, caches the npm registry dist-tag lookup on disk for 24h, and fails silently so it never touches stdout or the JSON contract that agents parse. It honors `NO_UPDATE_NOTIFIER`, `LINEARIS_NO_UPDATE_CHECK`, and `CI`, and picks the `latest`/`next` release channel from the installed version.

Closes #

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build / CI

## Checklist

- [x] \`npm run check:ci\` passes (lint + format)
- [x] \`npx tsc --noEmit\` passes (type check)
- [x] \`npm test\` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Ran \`npm run check:ci\`, \`npx tsc --noEmit\`, and \`npm test\` — all pass. New unit tests in \`tests/unit/common/update-notifier.test.ts\` cover version comparison, channel selection, cache read/write, the disable env vars, and the notice formatting.

## Notes for reviewers

The `preAction` hook and `program.parse()` became async (`parseAsync`) so the notifier can await the registry lookup only when the cache is stale.