### PR TITLE
refactor(common): centralize Priority and LabelMode domain values

### DIFF
--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import type { CommandContext } from "../common/context.js";
 import { createContext, getRootOpts } from "../common/context.js";
+import { parseLabelMode } from "../common/domain-values.js";
 import { resolveReactionEmojiInput } from "../common/emoji.js";
 import { invalidParameterError } from "../common/errors.js";
 import { validateEstimateAgainstTeamConfig } from "../common/estimate-validation.js";
@@ -1342,12 +1343,7 @@ export function setupIssuesCommands(program: Command): void {
           throw new Error("--clear-labels cannot be used with --label-mode");
         }
 
-        if (
-          options.labelMode &&
-          !["add", "overwrite"].includes(options.labelMode)
-        ) {
-          throw new Error("--label-mode must be either 'add' or 'overwrite'");
-        }
+        const labelMode = parseLabelMode(options.labelMode);
 
         const parsedPriority =
           options.priority !== undefined
@@ -1386,7 +1382,7 @@ export function setupIssuesCommands(program: Command): void {
           options.status ||
           options.projectMilestone ||
           options.cycle ||
-          (options.labels && options.labelMode === "add");
+          (options.labels && labelMode === "add");
         const issueContext = needsContext
           ? await getIssue(ctx.gql, resolvedIssueId)
           : undefined;
@@ -1437,7 +1433,7 @@ export function setupIssuesCommands(program: Command): void {
           const labelNames = options.labels.split(",").map((l) => l.trim());
           const labelIds = await resolveLabelIds(ctx.sdk, labelNames);
 
-          if (options.labelMode === "add") {
+          if (labelMode === "add") {
             const currentLabels =
               issueContext &&
               "labels" in issueContext &&

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -1,5 +1,6 @@
 import type { Command } from "commander";
 import { createContext, getRootOpts } from "../common/context.js";
+import type { Priority } from "../common/domain-values.js";
 import { resolveReactionEmojiInput } from "../common/emoji.js";
 import { invalidParameterError } from "../common/errors.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
@@ -200,12 +201,12 @@ export const PROJECTS_META: DomainMeta = {
   ],
 };
 
-function parsePriority(value: string): number {
+function parsePriority(value: string): Priority {
   const priority = Number.parseInt(value, 10);
   if (Number.isNaN(priority) || priority < 0 || priority > 4) {
     throw invalidParameterError("priority", `must be 0-4, got "${value}"`);
   }
-  return priority;
+  return priority as Priority;
 }
 
 function parseNonNegativeIntegerOption(name: string, value: string): number {

--- a/src/common/domain-values.ts
+++ b/src/common/domain-values.ts
@@ -1,0 +1,18 @@
+import { invalidParameterError } from "./errors.js";
+
+/** Linear priority scale: 0=none, 1=urgent, 2=high, 3=medium, 4=low. */
+export type Priority = 0 | 1 | 2 | 3 | 4;
+
+/** How `issues update --labels` combines with existing labels. */
+export type LabelMode = "add" | "overwrite";
+
+export function parseLabelMode(
+  value: string | undefined,
+): LabelMode | undefined {
+  if (value === undefined) return undefined;
+  if (value === "add" || value === "overwrite") return value;
+  throw invalidParameterError(
+    "--label-mode",
+    "must be either 'add' or 'overwrite'",
+  );
+}

--- a/src/common/number-options.ts
+++ b/src/common/number-options.ts
@@ -1,3 +1,4 @@
+import type { Priority } from "./domain-values.js";
 import { invalidParameterError } from "./errors.js";
 
 function parseStrictNonNegativeInteger(raw: string): number | null {
@@ -8,7 +9,7 @@ function parseStrictNonNegativeInteger(raw: string): number | null {
   return Number.parseInt(raw, 10);
 }
 
-export function parsePriorityOption(raw: string): number {
+export function parsePriorityOption(raw: string): Priority {
   const value = parseStrictNonNegativeInteger(raw);
   if (value === null || value < 1 || value > 4) {
     throw invalidParameterError(
@@ -17,7 +18,7 @@ export function parsePriorityOption(raw: string): number {
     );
   }
 
-  return value;
+  return value as Priority;
 }
 
 export function parseEstimateOption(raw: string): number {

--- a/tests/unit/common/domain-values.test.ts
+++ b/tests/unit/common/domain-values.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from "vitest";
+import { parseLabelMode } from "../../../src/common/domain-values.js";
+
+describe("parseLabelMode", () => {
+  it("returns undefined when value is undefined", () => {
+    expect(parseLabelMode(undefined)).toBeUndefined();
+  });
+
+  it("returns the narrowed mode for valid values", () => {
+    expect(parseLabelMode("add")).toBe("add");
+    expect(parseLabelMode("overwrite")).toBe("overwrite");
+  });
+
+  it("throws for invalid values", () => {
+    expect(() => parseLabelMode("replace")).toThrow(
+      "Invalid --label-mode: must be either 'add' or 'overwrite'",
+    );
+    expect(() => parseLabelMode("")).toThrow(
+      "Invalid --label-mode: must be either 'add' or 'overwrite'",
+    );
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Introduces `src/common/domain-values.ts` as the single source of truth for two Linear domain value types: `Priority` (`0 | 1 | 2 | 3 | 4`) and `LabelMode` (`"add" | "overwrite"`), plus a `parseLabelMode` helper. The priority parsers in `projects.ts` and `number-options.ts` now return the narrowed `Priority` type, and the `issues update` command uses `parseLabelMode` instead of inline string validation. No behavior change.

Part of #205

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

`npm run check:ci`, `npx tsc --noEmit`, and `npm test` (799 tests, 60 files) all pass. Added `tests/unit/common/domain-values.test.ts` covering `parseLabelMode` for the undefined, valid, and invalid cases.

## Notes for reviewers

The pre-existing Biome warning about `__proto__` in an unrelated test file is untouched by this change.