### PR TITLE
docs: add comments-to-discussions migration guide and restructure README

### DIFF
--- a/MIGRATION_2026.4.9.md
+++ b/MIGRATION_2026.4.9.md
@@ -1,0 +1,46 @@
+# Migration Guide — v2026.4.9: `comments` → discussions
+
+**Introduced in:** v2026.4.9 (2026-04-27) · **Status of `comments`:** deprecated compatibility facade
+
+## What changed
+
+Before v2026.4.9, Linearis exposed a flat `comments` domain: a single list of comments per issue, with replies that were hard to relate back to their parent.
+
+v2026.4.9 replaces that with **discussions** — threaded conversations modeled the way Linear itself models them. A discussion is a **root thread** with a body, and each root thread has an ordered list of **replies** (which may themselves be nested). Discussions are available across multiple domains (`issues`, `projects`, `initiatives`), not just issues.
+
+The old `comments` commands still work — they now route through the discussion service as a **deprecated compatibility facade** — so existing scripts keep running. New automation and agent prompts should use the discussion commands directly.
+
+## Why the change
+
+- **Faithful data model.** Linear's API represents conversations as threads with replies. The old flat `comments` view flattened that structure and lost the parent/child relationship. Discussions expose it directly.
+- **Nested replies.** Deep reply chains are now represented correctly instead of being collapsed into one level.
+- **Consistency across domains.** The same discussion model applies to issues, projects, and initiatives, so agents learn one pattern instead of an issue-only special case.
+- **Reactions.** v2026.4.9 also added reaction workflows on discussions, which the flat comment model could not express cleanly.
+
+## Command mapping
+
+| Deprecated (`comments`) | Preferred (`issues`) |
+|---|---|
+| `linearis comments create <issue> --body <text>` | `linearis issues discuss <issue> --body <text>` |
+| `linearis comments list <issue>` | `linearis issues discussions <issue>` |
+| `linearis comments reply <thread> --body <text>` | `linearis issues reply <thread> --body <text>` |
+| `linearis comments edit <reply> --body <text>` | `linearis issues edit-reply <reply> --body <text>` |
+| `linearis comments delete <reply>` | `linearis issues delete-reply <reply>` |
+
+Projects and initiatives expose the equivalent discussion subcommands in their own domains — run `linearis projects usage` or `linearis initiatives usage` for the exact commands.
+
+## What to respect
+
+- **Root threads vs. replies are distinct.** `issues discussions <issue>` lists **root** threads. Replying with `issues reply <thread>` requires a **root discussion thread ID**, not a reply ID. Passing a reply ID where a root thread ID is expected will fail.
+- **Fetch replies explicitly.** `issues discussions <issue>` returns root threads only. Use `issues replies <thread>` to load the replies within one thread, including nested replies.
+- **Discussions are domain-scoped.** A thread belongs to the domain it was created in. Operating on a thread through the wrong domain is rejected.
+- **Compatibility facade is more lenient.** The deprecated `comments edit`/`delete` commands accept both root thread IDs and reply IDs. The new discussion commands are strict about which ID they expect — do not assume the facade's leniency carries over.
+- **Prefer discussions over description edits for progress.** For anything beyond simple checkbox updates, start or continue a discussion thread rather than rewriting an issue's description.
+
+## Timeline
+
+- **v2026.4.9 (2026-04-27)** — discussion commands added across `issues`, `projects`, and `initiatives`; `comments` deprecated as a compatibility facade.
+- **A future release** — the `comments` facade may be removed. Migrate before then.
+
+> [!TIP]
+> Run `linearis issues usage` for the full, always-current discussion command reference.

--- a/README.md
+++ b/README.md
@@ -1,12 +1,44 @@
+<div align="center">
+
 # Linearis
 
-CLI tool for [Linear.app](https://linear.app) optimized for AI agents. JSON output, smart ID resolution, token-efficient usage commands, and a discover-then-act workflow that keeps agent context small. Works just as well for humans who prefer structured data on the command line.
+**A token-efficient [Linear.app](https://linear.app) CLI built for AI agents — and humans who like structured data.**
 
-## Why?
+[![NPM version](https://img.shields.io/npm/v/linearis.svg)](https://www.npmjs.com/package/linearis)
+[![Node version](https://img.shields.io/node/v/linearis.svg)](https://nodejs.org)
+[![CI](https://github.com/linearis-oss/linearis/actions/workflows/ci.yml/badge.svg)](https://github.com/linearis-oss/linearis/actions/workflows/ci.yml)
+[![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.md)
 
-The official Linear MCP works fine, but it eats up ~13k tokens just by being connected -- before the agent does anything. Linearis takes a different approach: instead of exposing the full API surface upfront, agents discover what they need through a two-tier usage system. `linearis usage` gives an overview in ~200 tokens, then `linearis <domain> usage` provides the full reference for one area in ~300-500 tokens. A typical agent interaction costs ~500-700 tokens of context, not ~13k.
+</div>
 
-The trade-off is coverage. An MCP exposes the entire Linear API; Linearis covers the operations that matter for day-to-day work with issues, discussions, cycles, documents, and files. If you need to manage custom workflows, integrations, or workspace settings, the MCP is the better choice.
+Linearis is a command-line interface for Linear that speaks **JSON only**. It resolves human-friendly IDs (like `ENG-42` or a team name) to UUIDs for you, and exposes a two-tier `usage` system so an agent can discover exactly the commands it needs without loading the whole API surface into context.
+
+```bash
+npm install -g linearis
+linearis auth login
+linearis issues list --limit 10
+```
+
+## Why Linearis?
+
+The official Linear MCP works well, but it costs ~13k tokens just by being connected — before an agent does anything. Linearis takes a different approach: agents discover capabilities on demand through a two-tier usage system.
+
+- `linearis usage` — a compact overview of every domain (~200 tokens).
+- `linearis <domain> usage` — the full reference for one domain (~300–500 tokens).
+
+A typical agent interaction costs **~500–700 tokens** of context instead of ~13k. The agent pays only for what it uses, one domain at a time.
+
+> [!NOTE]
+> The trade-off is coverage. Linearis focuses on the operations that matter for day-to-day work — issues, discussions, cycles, projects, documents, and files. For custom workflows, integrations, or workspace settings, the MCP is the better choice.
+
+## Features
+
+- **JSON-only output** — pipe into `jq`, no parsing of tables or prose.
+- **Smart ID resolution** — pass `ENG-42`, a team name, or a UUID interchangeably.
+- **Two-tier discovery** — self-documenting `usage` commands keep agent context small.
+- **Discussion threads** — first-class root/reply modeling on issues.
+- **File attachments** — upload and download with signed URLs.
+- **Broad domain coverage** — issues, projects, cycles, milestones, initiatives, documents, labels, teams, users, and more.
 
 ## Installation
 
@@ -14,58 +46,54 @@ The trade-off is coverage. An MCP exposes the entire Linear API; Linearis covers
 npm install -g linearis
 ```
 
-`linearis` is the canonical documented command; `linear` is a fully supported alias that runs the same CLI.
-
-Requires Node.js >= 22.
+Requires **Node.js ≥ 22**. The `linearis` command is canonical; `linear` is a fully supported alias that runs the same CLI.
 
 ## Authentication
+
+The interactive flow opens Linear in your browser, walks you through creating an API key, and stores it encrypted in `~/.linearis/token`:
 
 ```bash
 linearis auth login
 ```
 
-This opens Linear in your browser, guides you through creating an API key, and stores the token encrypted in `~/.linearis/token`.
-
-Alternatively, provide a token directly:
+Or provide a token directly:
 
 ```bash
-# Via CLI flag
-linearis --api-token <token> issues list
-
-# Via environment variable
-LINEAR_API_TOKEN=<token> linearis issues list
+linearis --api-token <token> issues list        # via flag
+LINEAR_API_TOKEN=<token> linearis issues list    # via environment variable
 ```
 
-Token resolution order: `--api-token` flag > `LINEAR_API_TOKEN` env > `~/.linearis/token` > `~/.linear_api_token` (deprecated).
+Token resolution order: `--api-token` flag → `LINEAR_API_TOKEN` env → `~/.linearis/token` → `~/.linear_api_token` (deprecated).
 
 ## Usage
 
-All output is JSON. Pipe through `jq` or similar for formatting.
+All output is JSON. Start with discovery, then act.
 
 ```bash
-# Discovery
-linearis usage                # overview of all domains
-linearis issues usage         # detailed usage for one domain
-```
-
-### Quick Start
-
-```bash
-# Discover available commands
+# Discover what's available (~200 tokens)
 linearis usage
 
-# Drill into a domain
+# Drill into one domain for its full command reference
 linearis issues usage
 
-# List recent issues
+# List and search
 linearis issues list --limit 10
-
-# Search for issues
 linearis issues search "authentication bug"
 
 # Create an issue
 linearis issues create "Fix login flow" --team Platform --priority 2
 
+# Read an issue (includes embeds with signed download URLs)
+linearis issues read ENG-42
+```
+
+For the complete reference of every command and flag, run `linearis <domain> usage`.
+
+### Discussions
+
+Discussions are modeled as root threads with replies, rather than a flat comment list:
+
+```bash
 # Start a discussion thread on an issue
 linearis issues discuss ENG-42 --body "Investigating this now"
 
@@ -73,122 +101,95 @@ linearis issues discuss ENG-42 --body "Investigating this now"
 linearis issues discussions ENG-42
 
 # List replies in one root thread
-linearis issues replies 6f4f28cd-4f53-4d76-ae95-80f1b6f6b87e
+linearis issues replies <root-thread-id>
 
-# Reply to a thread (use a root discussion thread ID)
-linearis issues reply 6f4f28cd-4f53-4d76-ae95-80f1b6f6b87e --body "I found the root cause"
+# Reply to a thread (use a root discussion thread ID, not a reply ID)
+linearis issues reply <root-thread-id> --body "I found the root cause"
 ```
 
-For the full reference of every command and flag, run:
+### Domains
 
-```bash
-linearis <domain> usage
-```
-
-### Migration: `comments` → issue discussion commands
-
-The `comments` domain remains available as a **deprecated compatibility facade**. For new automation and agent prompts, migrate to issue discussion commands in the `issues` domain:
-
-| Deprecated | Preferred |
+| Domain | What it covers |
 |---|---|
-| `linearis comments create <issue> --body <text>` | `linearis issues discuss <issue> --body <text>` |
-| `linearis comments list <issue>` | `linearis issues discussions <issue>` |
-| `linearis comments reply <thread> --body <text>` | `linearis issues reply <thread> --body <text>` |
-| `linearis comments edit <reply> --body <text>` | `linearis issues edit-reply <reply> --body <text>` |
-| `linearis comments delete <reply>` | `linearis issues delete-reply <reply>` |
+| `issues` | Work items with status, priority, assignee, labels, and discussions |
+| `projects` | Groups of issues working toward a goal |
+| `initiatives` | Strategic, multi-project goals |
+| `cycles` | Time-boxed iterations (sprints) per team |
+| `milestones` | Progress checkpoints within projects |
+| `documents` | Long-form markdown docs attached to projects or issues |
+| `labels` | Categorization tags for issues and projects |
+| `attachments` | Linked external resources on issues (PRs, commits, URLs) |
+| `files` | Upload and download file attachments |
+| `teams` | Organizational units owning issues and cycles |
+| `users` | Workspace members and assignees |
+| `auth` | Authenticate with the Linear API |
 
-Notes:
-- `issues discussions <issue>` lists **root** threads.
-- Use `issues replies <thread>` to fetch replies in one thread, including nested replies.
-- Replying requires a **root discussion thread ID** (not a reply ID).
-- Compatibility `comments edit/delete` accepts root thread IDs and reply IDs.
+## AI agent integration
 
-## AI Agent Integration
+Linearis is structured around a **discover-then-act** pattern that matches how agents work:
 
-### How agents use Linearis
+1. **Discover** — `linearis usage` returns a compact overview of all domains. The agent reads it once.
+2. **Drill down** — `linearis <domain> usage` gives the full reference for a single domain. The agent loads only what it needs.
+3. **Execute** — every command returns structured JSON. No table or prose parsing.
 
-The CLI is structured around a discover-then-act pattern that matches how agents work:
+The agent never loads the full API surface into context — it pays for what it uses, one domain at a time.
 
-1. **Discover** -- `linearis usage` returns a compact overview of all domains (~200 tokens). The agent reads this once to understand what's available.
-2. **Drill down** -- `linearis <domain> usage` gives the full command reference for one domain (~300-500 tokens). The agent only loads what it needs.
-3. **Execute** -- All commands return structured JSON. No parsing of human-readable tables or prose.
-
-This means the agent never loads the full API surface into context. It pays for what it uses, one domain at a time.
-
-### Linearis vs. MCP
+### Linearis vs. Linear MCP
 
 | | Linearis | Linear MCP |
 |---|---|---|
-| Context cost | ~500-700 tokens per interaction | ~13k tokens on connect |
+| Context cost | ~500–700 tokens per interaction | ~13k tokens on connect |
 | Coverage | Common operations (issues, discussions, cycles, docs, files) | Full Linear API |
-| Output | JSON via stdout | Tool call responses |
-| Setup | `npm install -g linearis` + bash tool | MCP server connection |
+| Output | JSON via stdout | Tool-call responses |
+| Setup | `npm install -g linearis` + Bash tool | MCP server connection |
 
 Use Linearis when token efficiency matters and you work primarily with issues and related data. Use the MCP when you need full API coverage or tight tool-call integration.
 
-### Example prompt
+### Example agent prompt
+
+Add this (or a version adapted to your workflow) to your `AGENTS.md` or `CLAUDE.md` so every session has it in context:
 
 ```markdown
 ## Linear (project management)
 
 Tool: `linearis` CLI via Bash. All output is JSON.
 
-Discovery: Run `linearis usage` once to see available domains. Run `linearis <domain> usage` for full command reference of a specific domain. Do NOT guess flags or subcommands -- check usage first.
+Discovery: Run `linearis usage` once to see available domains. Run
+`linearis <domain> usage` for the full command reference of a specific domain.
+Do NOT guess flags or subcommands — check usage first.
 
 Ticket format: "ABC-123". Always reference tickets by their identifier.
 
 Workflow rules:
-- When creating a ticket, ask the user which project to assign it to if unclear.
+- When creating a ticket, ask which project to assign it to if unclear.
 - For subtasks, inherit the parent ticket's project by default.
 - When a task in a ticket description changes status, update the description.
-- For progress beyond simple checkbox changes, start or reply in a discussion thread instead of editing the description.
+- For progress beyond checkbox changes, use a discussion thread instead of
+  editing the description.
 
-File handling: `issues read` returns an `embeds` array with signed download URLs and expiration timestamps. Use `files download` to retrieve them. Use `files upload` to attach new files, then reference the returned URL in discussions or descriptions.
+File handling: `issues read` returns an `embeds` array with signed download
+URLs and expiration timestamps. Use `files download` to retrieve them, and
+`files upload` to attach new files.
 ```
 
-Add this (or a version adapted to your workflow) to your `AGENTS.md` or `CLAUDE.md` so every agent session has it in context automatically.
+## Documentation
 
-## Release Automation Policy
-
-Linearis uses three CI/release workflows:
-
-- `ci.yml` for required pull request checks
-- `ci-post-merge.yml` for post-merge sentinel validation on `main`/`next` pushes
-- `release-check.yml` for push-driven and manual releases
-
-For the authoritative trigger matrix, required checks, and operational verification commands, see [`docs/ci-run-model.md`](docs/ci-run-model.md) (source of truth).
-
-`CHANGELOG.md` is automation-owned and must not be edited in pull requests. If a pull request branch contains `CHANGELOG.md` changes anywhere in `main...HEAD` history, CI fails and posts rebase instructions.
-
-## Contributing
-
-Want to contribute? See [CONTRIBUTING.md](CONTRIBUTING.md).
-
-## Creator
-
-Carlo Zottmann -- [c.zottmann.dev](https://c.zottmann.dev) | [github.com/czottmann](https://github.com/czottmann)
-
-Carlo created Linearis and drove its early development. As interest in the project grew, he handed maintenance over to [Fabian Jocks](https://github.com/iamfj) ([in/fabianjocks](https://linkedin.com/in/fabianjocks)).
-
-This project is neither affiliated with nor endorsed by Linear.
-
-### Sponsoring Carlo's work
-
-Carlo doesn't accept sponsoring in the "GitHub sponsorship" sense[^1] but [next to his own apps, he also sells "Tokens of Appreciation"](https://actions.work/store/?ref=github). Any support is appreciated!
-
-[^1]: Apparently, the German revenue service is still having some fits over "money for nothing??".
-
-> [!TIP]
-> Carlo makes Shortcuts-related macOS & iOS productivity apps like [Actions For Obsidian](https://actions.work/actions-for-obsidian), [Browser Actions](https://actions.work/browser-actions) (which adds Shortcuts support for several major browsers), and [BarCuts](https://actions.work/barcuts) (a surprisingly useful contextual Shortcuts launcher). Check them out!
+- [MIGRATION_2026.4.9.md](MIGRATION_2026.4.9.md) — migrating from the deprecated `comments` domain to discussions (v2026.4.9).
+- [`docs/`](docs/) — architecture, development, testing, and build-system references.
+- [`docs/ci-run-model.md`](docs/ci-run-model.md) — the authoritative CI/release trigger matrix.
+- [CONTRIBUTING.md](CONTRIBUTING.md) — contributor guidelines.
+- [SECURITY.md](SECURITY.md) — how to report security issues.
 
 ## Contributors
 
 <a href="https://github.com/linearis-oss/linearis/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=linearis-oss/linearis" />
+  <img src="https://contrib.rocks/image?repo=linearis-oss/linearis" alt="Contributors" />
 </a>
 
 Made with [contrib.rocks](https://contrib.rocks).
 
 ## License
 
-MIT. See [LICENSE.md](LICENSE.md).
+[MIT](LICENSE.md)
+
+This project is neither affiliated with nor endorsed by Linear.


### PR DESCRIPTION
## What does this PR do?

Adds `MIGRATION_2026.4.9.md`, a migration guide for moving from the deprecated `comments` domain to the new discussion commands (v2026.4.9), and restructures the README with badges, a features list, a domains table, a reworked AI-agent integration section, and a consolidated documentation links section.

Closes #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Tests
- [ ] Build / CI

## Checklist

- [ ] `npm run check:ci` passes (lint + format)
- [ ] `npx tsc --noEmit` passes (type check)
- [ ] `npm test` passes (unit tests)
- [ ] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Documentation-only change. Verified all README links resolve (migration guide, `docs/ci-run-model.md`, `CONTRIBUTING.md`, `SECURITY.md`, `LICENSE.md`) and that every referenced domain and discussion subcommand exists in `src/commands/`.

## Notes for reviewers

No code or behavior changes; the code checklist items above are not applicable to this docs-only PR.