### PR TITLE
refactor(commands): centralize Commander action typing via commandAction

### DIFF
--- a/src/commands/initiatives/entity.ts
+++ b/src/commands/initiatives/entity.ts
@@ -4,7 +4,7 @@ import { createContext, getRootOpts } from "../../common/context.js";
 import { resolveReactionEmojiInput } from "../../common/emoji.js";
 import { invalidParameterError } from "../../common/errors.js";
 import {
-  handleCommand,
+  commandAction,
   outputSuccess,
   parseLimit,
 } from "../../common/output.js";
@@ -114,22 +114,18 @@ function addCommentReactionCommands(
     .description(`add a reaction to a discussion ${noun}`)
     .option("--shortcode <name>", "emoji shortcode (e.g. thumbs_up)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [commentId, emoji, options, command] = args as [
-          string,
-          string | undefined,
-          ReactionOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
-        const result = await createDiscussionCommentReaction(ctx.gql, {
-          commentId,
-          target: noun,
-          expectedEntityKind: "initiative",
-          emoji: resolveReactionEmojiInput(emoji, options.shortcode),
-        });
-        outputSuccess(result);
-      }),
+      commandAction<[string, string | undefined, ReactionOptions, Command]>(
+        async (commentId, emoji, options, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const result = await createDiscussionCommentReaction(ctx.gql, {
+            commentId,
+            target: noun,
+            expectedEntityKind: "initiative",
+            emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+          });
+          outputSuccess(result);
+        },
+      ),
     );
 
   parent
@@ -137,22 +133,18 @@ function addCommentReactionCommands(
     .description(`remove your reaction from a discussion ${noun} by emoji`)
     .option("--shortcode <name>", "emoji shortcode (e.g. thumbs_up)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [commentId, emoji, options, command] = args as [
-          string,
-          string | undefined,
-          ReactionOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
-        const result = await deleteDiscussionCommentReactionByEmoji(ctx.gql, {
-          commentId,
-          target: noun,
-          expectedEntityKind: "initiative",
-          emoji: resolveReactionEmojiInput(emoji, options.shortcode),
-        });
-        outputSuccess(result);
-      }),
+      commandAction<[string, string | undefined, ReactionOptions, Command]>(
+        async (commentId, emoji, options, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const result = await deleteDiscussionCommentReactionByEmoji(ctx.gql, {
+            commentId,
+            target: noun,
+            expectedEntityKind: "initiative",
+            emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+          });
+          outputSuccess(result);
+        },
+      ),
     );
 
   parent
@@ -161,22 +153,18 @@ function addCommentReactionCommands(
       `remove your reaction from a discussion ${noun} by reaction ID`,
     )
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [commentId, reactionId, , command] = args as [
-          string,
-          string,
-          unknown,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
-        const result = await deleteDiscussionCommentReactionById(ctx.gql, {
-          commentId,
-          target: noun,
-          expectedEntityKind: "initiative",
-          reactionId,
-        });
-        outputSuccess(result);
-      }),
+      commandAction<[string, string, unknown, Command]>(
+        async (commentId, reactionId, _unused2, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const result = await deleteDiscussionCommentReactionById(ctx.gql, {
+            commentId,
+            target: noun,
+            expectedEntityKind: "initiative",
+            reactionId,
+          });
+          outputSuccess(result);
+        },
+      ),
     );
 }
 
@@ -484,44 +472,45 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .option("--with-history", "include history in list output")
     .option("--with-documents", "include documents in list output")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [options, command] = args as [InitiativeListOptions, Command];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[InitiativeListOptions, Command]>(
+        async (options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const sortOrder = parseSortOrder(options.sortOrder);
-        const sortBy = parseSortBy(options.sortBy);
+          const sortOrder = parseSortOrder(options.sortOrder);
+          const sortBy = parseSortBy(options.sortBy);
 
-        const expandFlags = getExpandFlags(options);
-        if (expandFlags.length > 0) {
-          throw invalidParameterError(
-            "expand flags",
-            `${expandFlags.join(", ")} are not supported for initiatives list yet`,
-          );
-        }
+          const expandFlags = getExpandFlags(options);
+          if (expandFlags.length > 0) {
+            throw invalidParameterError(
+              "expand flags",
+              `${expandFlags.join(", ")} are not supported for initiatives list yet`,
+            );
+          }
 
-        if (sortOrder && !sortBy) {
-          throw invalidParameterError(
-            "--sort-order",
-            "requires --sort-by to be specified",
-          );
-        }
+          if (sortOrder && !sortBy) {
+            throw invalidParameterError(
+              "--sort-order",
+              "requires --sort-by to be specified",
+            );
+          }
 
-        const orderBy = mapSortByToPaginationOrderBy(sortBy);
-        const sort = mapSortByToInitiativeSort(sortBy, sortOrder);
+          const orderBy = mapSortByToPaginationOrderBy(sortBy);
+          const sort = mapSortByToInitiativeSort(sortBy, sortOrder);
 
-        const filter = await buildInitiativeFilter(ctx.sdk, options);
+          const filter = await buildInitiativeFilter(ctx.sdk, options);
 
-        const result = await listInitiatives(ctx.gql, {
-          limit: parseLimit(options.limit),
-          after: options.after,
-          includeArchived: options.includeArchived ?? false,
-          filter,
-          orderBy,
-          sort,
-        });
+          const result = await listInitiatives(ctx.gql, {
+            limit: parseLimit(options.limit),
+            after: options.after,
+            includeArchived: options.includeArchived ?? false,
+            filter,
+            orderBy,
+            sort,
+          });
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   initiatives
@@ -541,22 +530,19 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .option("--with-history", "include history in read output")
     .option("--with-documents", "include documents in read output")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [initiative, options, command] = args as [
-          string,
-          InitiativeReadOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
-        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+      commandAction<[string, InitiativeReadOptions, Command]>(
+        async (initiative, options, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
 
-        // Read query already returns expanded fields. Keep flags accepted for
-        // CLI contract compatibility until conditional field selection is added.
-        void getExpandFlags(options);
+          // Read query already returns expanded fields. Keep flags accepted for
+          // CLI contract compatibility until conditional field selection is added.
+          void getExpandFlags(options);
 
-        const result = await getInitiative(ctx.gql, initiativeId);
-        outputSuccess(result);
-      }),
+          const result = await getInitiative(ctx.gql, initiativeId);
+          outputSuccess(result);
+        },
+      ),
     );
 
   initiatives
@@ -564,26 +550,23 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .description("start a discussion thread on an initiative")
     .option("--body <text>", "discussion body (required, markdown supported)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [initiative, options, command] = args as [
-          string,
-          DiscussionBodyOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionBodyOptions, Command]>(
+        async (initiative, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        if (!options.body) {
-          throw invalidParameterError("--body", "is required");
-        }
+          if (!options.body) {
+            throw invalidParameterError("--body", "is required");
+          }
 
-        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
-        const result = await startInitiativeDiscussion(ctx.gql, {
-          initiativeId,
-          body: options.body,
-        });
+          const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+          const result = await startInitiativeDiscussion(ctx.gql, {
+            initiativeId,
+            body: options.body,
+          });
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   initiatives
@@ -593,33 +576,30 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .option("--after <cursor>", "cursor for next page")
     .option("--with-reactions", "include normalized discussion reactions")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [initiative, options, command] = args as [
-          string,
-          DiscussionsOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionsOptions, Command]>(
+        async (initiative, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
-        const paginationOptions = {
-          limit: parseLimit(options.limit || "25"),
-          after: options.after,
-        };
-        const result = options.withReactions
-          ? await listDiscussionsForInitiativeWithReactions(
-              ctx.gql,
-              initiativeId,
-              paginationOptions,
-            )
-          : await listDiscussionsForInitiative(
-              ctx.gql,
-              initiativeId,
-              paginationOptions,
-            );
+          const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+          const paginationOptions = {
+            limit: parseLimit(options.limit || "25"),
+            after: options.after,
+          };
+          const result = options.withReactions
+            ? await listDiscussionsForInitiativeWithReactions(
+                ctx.gql,
+                initiativeId,
+                paginationOptions,
+              )
+            : await listDiscussionsForInitiative(
+                ctx.gql,
+                initiativeId,
+                paginationOptions,
+              );
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   const initiativeThreads = initiatives
@@ -634,34 +614,31 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .option("--after <cursor>", "cursor for next page")
     .option("--with-reactions", "include normalized discussion reactions")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [thread, options, command] = args as [
-          string,
-          DiscussionsOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionsOptions, Command]>(
+        async (thread, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const paginationOptions = {
-          limit: parseLimit(options.limit || "50"),
-          after: options.after,
-        };
-        const result = options.withReactions
-          ? await listDiscussionRepliesWithReactions(
-              ctx.gql,
-              thread,
-              paginationOptions,
-              "initiative",
-            )
-          : await listDiscussionReplies(
-              ctx.gql,
-              thread,
-              paginationOptions,
-              "initiative",
-            );
+          const paginationOptions = {
+            limit: parseLimit(options.limit || "50"),
+            after: options.after,
+          };
+          const result = options.withReactions
+            ? await listDiscussionRepliesWithReactions(
+                ctx.gql,
+                thread,
+                paginationOptions,
+                "initiative",
+              )
+            : await listDiscussionReplies(
+                ctx.gql,
+                thread,
+                paginationOptions,
+                "initiative",
+              );
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
   addCommentReactionCommands(initiativeReplies, "reply");
 
@@ -674,26 +651,23 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     )
     .option("--body <text>", "reply body (required, markdown supported)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [thread, options, command] = args as [
-          string,
-          DiscussionBodyOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionBodyOptions, Command]>(
+        async (thread, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        if (!options.body) {
-          throw invalidParameterError("--body", "is required");
-        }
+          if (!options.body) {
+            throw invalidParameterError("--body", "is required");
+          }
 
-        const result = await replyToDiscussion(ctx.gql, {
-          threadId: thread,
-          body: options.body,
-          entityKind: "initiative",
-        });
+          const result = await replyToDiscussion(ctx.gql, {
+            threadId: thread,
+            body: options.body,
+            entityKind: "initiative",
+          });
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   initiatives
@@ -701,29 +675,26 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .description("edit a root discussion or reply comment")
     .option("--body <text>", "new comment body (required, markdown supported)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [comment, options, command] = args as [
-          string,
-          DiscussionBodyOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionBodyOptions, Command]>(
+        async (comment, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        if (!options.body) {
-          throw invalidParameterError("--body", "is required");
-        }
+          if (!options.body) {
+            throw invalidParameterError("--body", "is required");
+          }
 
-        const result = await editDiscussionComment(
-          ctx.gql,
-          comment,
-          {
-            body: options.body,
-          },
-          "initiative",
-        );
+          const result = await editDiscussionComment(
+            ctx.gql,
+            comment,
+            {
+              body: options.body,
+            },
+            "initiative",
+          );
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   initiatives
@@ -731,65 +702,64 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .description("edit a discussion reply")
     .option("--body <text>", "new reply body (required, markdown supported)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [reply, options, command] = args as [
-          string,
-          DiscussionBodyOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionBodyOptions, Command]>(
+        async (reply, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        if (!options.body) {
-          throw invalidParameterError("--body", "is required");
-        }
+          if (!options.body) {
+            throw invalidParameterError("--body", "is required");
+          }
 
-        const result = await editDiscussionReply(
-          ctx.gql,
-          reply,
-          {
-            body: options.body,
-          },
-          "initiative",
-        );
+          const result = await editDiscussionReply(
+            ctx.gql,
+            reply,
+            {
+              body: options.body,
+            },
+            "initiative",
+          );
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   initiatives
     .command("delete-comment <comment>")
     .description("delete a root discussion or reply comment")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [comment, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, unknown, Command]>(
+        async (comment, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const result = await deleteDiscussionComment(
-          ctx.gql,
-          comment,
-          "initiative",
-        );
+          const result = await deleteDiscussionComment(
+            ctx.gql,
+            comment,
+            "initiative",
+          );
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   initiatives
     .command("delete-reply <reply>")
     .description("delete a discussion reply")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [reply, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, unknown, Command]>(
+        async (reply, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const result = await deleteDiscussionReply(
-          ctx.gql,
-          reply,
-          "initiative",
-        );
+          const result = await deleteDiscussionReply(
+            ctx.gql,
+            reply,
+            "initiative",
+          );
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   initiatives
@@ -797,36 +767,38 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .description("resolve a discussion thread")
     .option("--with-comment <comment>", "comment to mark as resolving comment")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [thread, options, command] = args as [
-          string,
-          ResolveDiscussionOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, ResolveDiscussionOptions, Command]>(
+        async (thread, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const result = await resolveDiscussion(ctx.gql, {
-          threadId: thread,
-          resolvingCommentId: options.withComment,
-          entityKind: "initiative",
-        });
+          const result = await resolveDiscussion(ctx.gql, {
+            threadId: thread,
+            resolvingCommentId: options.withComment,
+            entityKind: "initiative",
+          });
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   initiatives
     .command("unresolve <thread>")
     .description("unresolve a discussion thread")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [thread, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, unknown, Command]>(
+        async (thread, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const result = await unresolveDiscussion(ctx.gql, thread, "initiative");
+          const result = await unresolveDiscussion(
+            ctx.gql,
+            thread,
+            "initiative",
+          );
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   initiatives
@@ -839,45 +811,42 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .option("--target-date <date>", "target date (YYYY-MM-DD)")
     .option("--sort-order <n>", "display sort order")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [name, options, command] = args as [
-          string,
-          InitiativeCreateOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, InitiativeCreateOptions, Command]>(
+        async (name, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const input: InitiativeCreateInput = { name };
+          const input: InitiativeCreateInput = { name };
 
-        if (options.description !== undefined) {
-          input.description = options.description;
-        }
+          if (options.description !== undefined) {
+            input.description = options.description;
+          }
 
-        if (options.content !== undefined) {
-          input.content = options.content;
-        }
+          if (options.content !== undefined) {
+            input.content = options.content;
+          }
 
-        if (options.owner) {
-          input.ownerId = await resolveUserId(ctx.sdk, options.owner);
-        }
+          if (options.owner) {
+            input.ownerId = await resolveUserId(ctx.sdk, options.owner);
+          }
 
-        const status = parseInitiativeStatus(options.status);
-        if (status) {
-          input.status = status;
-        }
+          const status = parseInitiativeStatus(options.status);
+          if (status) {
+            input.status = status;
+          }
 
-        if (options.targetDate !== undefined) {
-          input.targetDate = options.targetDate;
-        }
+          if (options.targetDate !== undefined) {
+            input.targetDate = options.targetDate;
+          }
 
-        const sortOrder = parseSortOrderNumber(options.sortOrder);
-        if (sortOrder !== undefined) {
-          input.sortOrder = sortOrder;
-        }
+          const sortOrder = parseSortOrderNumber(options.sortOrder);
+          if (sortOrder !== undefined) {
+            input.sortOrder = sortOrder;
+          }
 
-        const result = await createInitiative(ctx.gql, input);
-        outputSuccess(result);
-      }),
+          const result = await createInitiative(ctx.gql, input);
+          outputSuccess(result);
+        },
+      ),
     );
 
   initiatives
@@ -891,95 +860,95 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .option("--target-date <date>", "new target date (YYYY-MM-DD)")
     .option("--sort-order <n>", "new display sort order")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [initiative, options, command] = args as [
-          string,
-          InitiativeUpdateOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
-        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+      commandAction<[string, InitiativeUpdateOptions, Command]>(
+        async (initiative, options, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
 
-        const input: InitiativeUpdateInput = {};
+          const input: InitiativeUpdateInput = {};
 
-        if (options.name !== undefined) {
-          input.name = options.name;
-        }
+          if (options.name !== undefined) {
+            input.name = options.name;
+          }
 
-        if (options.description !== undefined) {
-          input.description = options.description;
-        }
+          if (options.description !== undefined) {
+            input.description = options.description;
+          }
 
-        if (options.content !== undefined) {
-          input.content = options.content;
-        }
+          if (options.content !== undefined) {
+            input.content = options.content;
+          }
 
-        if (options.owner) {
-          input.ownerId = await resolveUserId(ctx.sdk, options.owner);
-        }
+          if (options.owner) {
+            input.ownerId = await resolveUserId(ctx.sdk, options.owner);
+          }
 
-        const status = parseInitiativeStatus(options.status);
-        if (status) {
-          input.status = status;
-        }
+          const status = parseInitiativeStatus(options.status);
+          if (status) {
+            input.status = status;
+          }
 
-        if (options.targetDate !== undefined) {
-          input.targetDate = options.targetDate;
-        }
+          if (options.targetDate !== undefined) {
+            input.targetDate = options.targetDate;
+          }
 
-        const sortOrder = parseSortOrderNumber(options.sortOrder);
-        if (sortOrder !== undefined) {
-          input.sortOrder = sortOrder;
-        }
+          const sortOrder = parseSortOrderNumber(options.sortOrder);
+          if (sortOrder !== undefined) {
+            input.sortOrder = sortOrder;
+          }
 
-        if (Object.keys(input).length === 0) {
-          throw invalidParameterError(
-            "update options",
-            "at least one option must be provided",
-          );
-        }
+          if (Object.keys(input).length === 0) {
+            throw invalidParameterError(
+              "update options",
+              "at least one option must be provided",
+            );
+          }
 
-        const result = await updateInitiative(ctx.gql, initiativeId, input);
-        outputSuccess(result);
-      }),
+          const result = await updateInitiative(ctx.gql, initiativeId, input);
+          outputSuccess(result);
+        },
+      ),
     );
 
   initiatives
     .command("archive <initiative>")
     .description("archive an initiative")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [initiative, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
-        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
-        const result = await archiveInitiative(ctx.gql, initiativeId);
-        outputSuccess(result);
-      }),
+      commandAction<[string, unknown, Command]>(
+        async (initiative, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+          const result = await archiveInitiative(ctx.gql, initiativeId);
+          outputSuccess(result);
+        },
+      ),
     );
 
   initiatives
     .command("unarchive <initiative>")
     .description("unarchive an initiative")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [initiative, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
-        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
-        const result = await unarchiveInitiative(ctx.gql, initiativeId);
-        outputSuccess(result);
-      }),
+      commandAction<[string, unknown, Command]>(
+        async (initiative, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+          const result = await unarchiveInitiative(ctx.gql, initiativeId);
+          outputSuccess(result);
+        },
+      ),
     );
 
   initiatives
     .command("delete <initiative>")
     .description("delete an initiative")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [initiative, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
-        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
-        const result = await deleteInitiative(ctx.gql, initiativeId);
-        outputSuccess(result);
-      }),
+      commandAction<[string, unknown, Command]>(
+        async (initiative, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+          const result = await deleteInitiative(ctx.gql, initiativeId);
+          outputSuccess(result);
+        },
+      ),
     );
 }

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -15,7 +15,7 @@ import {
   parseEstimateOption,
   parsePriorityOption,
 } from "../common/number-options.js";
-import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
+import { commandAction, outputSuccess, parseLimit } from "../common/output.js";
 import { resolveFilterOptions } from "../common/resolve-filters.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import type {
@@ -188,23 +188,19 @@ function addCommentReactionCommands(
     .description(`add a reaction to a discussion ${noun}`)
     .option("--shortcode <name>", "emoji shortcode (e.g. thumbs_up)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [commentId, emoji, options, command] = args as [
-          string,
-          string | undefined,
-          ReactionOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
-        const result = await createDiscussionCommentReaction(ctx.gql, {
-          commentId,
-          target: noun,
-          expectedEntityKind: "issue",
-          emoji: resolveReactionEmojiInput(emoji, options.shortcode),
-        });
+      commandAction<[string, string | undefined, ReactionOptions, Command]>(
+        async (commentId, emoji, options, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const result = await createDiscussionCommentReaction(ctx.gql, {
+            commentId,
+            target: noun,
+            expectedEntityKind: "issue",
+            emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+          });
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   parent
@@ -212,23 +208,19 @@ function addCommentReactionCommands(
     .description(`remove your reaction from a discussion ${noun} by emoji`)
     .option("--shortcode <name>", "emoji shortcode (e.g. thumbs_up)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [commentId, emoji, options, command] = args as [
-          string,
-          string | undefined,
-          ReactionOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
-        const result = await deleteDiscussionCommentReactionByEmoji(ctx.gql, {
-          commentId,
-          target: noun,
-          expectedEntityKind: "issue",
-          emoji: resolveReactionEmojiInput(emoji, options.shortcode),
-        });
+      commandAction<[string, string | undefined, ReactionOptions, Command]>(
+        async (commentId, emoji, options, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const result = await deleteDiscussionCommentReactionByEmoji(ctx.gql, {
+            commentId,
+            target: noun,
+            expectedEntityKind: "issue",
+            emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+          });
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   parent
@@ -237,23 +229,19 @@ function addCommentReactionCommands(
       `remove your reaction from a discussion ${noun} by reaction ID`,
     )
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [commentId, reactionId, , command] = args as [
-          string,
-          string,
-          unknown,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
-        const result = await deleteDiscussionCommentReactionById(ctx.gql, {
-          commentId,
-          target: noun,
-          expectedEntityKind: "issue",
-          reactionId,
-        });
+      commandAction<[string, string, unknown, Command]>(
+        async (commentId, reactionId, _unused2, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const result = await deleteDiscussionCommentReactionById(ctx.gql, {
+            commentId,
+            target: noun,
+            expectedEntityKind: "issue",
+            reactionId,
+          });
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 }
 
@@ -542,14 +530,15 @@ export function setupIssuesCommands(program: Command): void {
     .command("list <issue>")
     .description("list relations for an issue")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [issue, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
-        const issueId = await resolveIssueId(ctx.sdk, issue);
-        const result = await listIssueRelations(ctx.gql, issueId);
+      commandAction<[string, unknown, Command]>(
+        async (issue, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const result = await listIssueRelations(ctx.gql, issueId);
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   relations
@@ -563,44 +552,42 @@ export function setupIssuesCommands(program: Command): void {
     )
     .option("--similar <issues>", "similar issues (comma-separated)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [issue, options, command] = args as [
-          string,
-          RelationAddOptions,
-          Command,
-        ];
-        const relation = parseRelationAddOptions(options);
-        const ctx = createContext(getRootOpts(command));
-        const sourceIssueId = await resolveIssueId(ctx.sdk, issue);
-        const targetIds = await Promise.all(
-          relation.targets.map((target) => resolveIssueId(ctx.sdk, target)),
-        );
+      commandAction<[string, RelationAddOptions, Command]>(
+        async (issue, options, command) => {
+          const relation = parseRelationAddOptions(options);
+          const ctx = createContext(getRootOpts(command));
+          const sourceIssueId = await resolveIssueId(ctx.sdk, issue);
+          const targetIds = await Promise.all(
+            relation.targets.map((target) => resolveIssueId(ctx.sdk, target)),
+          );
 
-        const created = await Promise.all(
-          targetIds.map((targetId) =>
-            createIssueRelation(ctx.gql, {
-              issueId: sourceIssueId,
-              relatedIssueId: targetId,
-              type: relation.type,
-            }),
-          ),
-        );
+          const created = await Promise.all(
+            targetIds.map((targetId) =>
+              createIssueRelation(ctx.gql, {
+                issueId: sourceIssueId,
+                relatedIssueId: targetId,
+                type: relation.type,
+              }),
+            ),
+          );
 
-        outputSuccess(created);
-      }),
+          outputSuccess(created);
+        },
+      ),
     );
 
   relations
     .command("remove <relation>")
     .description("remove a relation by UUID")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [relation, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
-        const result = await deleteIssueRelation(ctx.gql, relation);
+      commandAction<[string, unknown, Command]>(
+        async (relation, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const result = await deleteIssueRelation(ctx.gql, relation);
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   addFilterOptions(
@@ -611,8 +598,7 @@ export function setupIssuesCommands(program: Command): void {
       .option("-l, --limit <n>", "max results", "50")
       .option("--after <cursor>", "cursor for next page"),
   ).action(
-    handleCommand(async (...args: unknown[]) => {
-      const [options, command] = args as [FilterOptions, Command];
+    commandAction<[FilterOptions, Command]>(async (options, command) => {
       const ctx = createContext(getRootOpts(command));
 
       const paginationOptions = {
@@ -646,29 +632,26 @@ export function setupIssuesCommands(program: Command): void {
       .option("-l, --limit <n>", "max results", "50")
       .option("--after <cursor>", "cursor for next page"),
   ).action(
-    handleCommand(async (...args: unknown[]) => {
-      const [query, options, command] = args as [
-        string,
-        FilterOptions,
-        Command,
-      ];
-      const ctx = createContext(getRootOpts(command));
+    commandAction<[string, FilterOptions, Command]>(
+      async (query, options, command) => {
+        const ctx = createContext(getRootOpts(command));
 
-      const paginationOptions = {
-        limit: parseLimit(options.limit),
-        after: options.after,
-      };
+        const paginationOptions = {
+          limit: parseLimit(options.limit),
+          after: options.after,
+        };
 
-      const filterOptions = await resolveFilterOptions(ctx, options);
-      const filter = buildIssueFilter(filterOptions);
-      const result = await searchIssues(
-        ctx.gql,
-        query,
-        paginationOptions,
-        filter,
-      );
-      outputSuccess(result);
-    }),
+        const filterOptions = await resolveFilterOptions(ctx, options);
+        const filter = buildIssueFilter(filterOptions);
+        const result = await searchIssues(
+          ctx.gql,
+          query,
+          paginationOptions,
+          filter,
+        );
+        outputSuccess(result);
+      },
+    ),
   );
 
   issues
@@ -686,92 +669,89 @@ export function setupIssuesCommands(program: Command): void {
       `\nWhen passing issue IDs, both UUID and identifiers like ABC-123 are supported.`,
     )
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [issue, options, command] = args as [
-          string,
-          ReadOptions,
-          Command,
-        ];
-        validateReadOptions(options);
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, ReadOptions, Command]>(
+        async (issue, options, command) => {
+          validateReadOptions(options);
+          const ctx = createContext(getRootOpts(command));
 
-        if (options.withAttachments) {
+          if (options.withAttachments) {
+            if (isUuid(issue)) {
+              const result = await getIssueWithAttachments(ctx.gql, issue);
+              outputSuccess(result);
+            } else {
+              const { teamKey, issueNumber } = parseIssueIdentifier(issue);
+              const result = await getIssueByIdentifierWithAttachments(
+                ctx.gql,
+                teamKey,
+                issueNumber,
+              );
+              outputSuccess(result);
+            }
+            return;
+          }
+
+          if (options.withCommentThreads) {
+            if (isUuid(issue)) {
+              const result = await getIssueWithCommentThreads(ctx.gql, issue);
+              outputSuccess(result);
+            } else {
+              const { teamKey, issueNumber } = parseIssueIdentifier(issue);
+              const result = await getIssueByIdentifierWithCommentThreads(
+                ctx.gql,
+                teamKey,
+                issueNumber,
+              );
+              outputSuccess(result);
+            }
+            return;
+          }
+
+          if (options.withComments) {
+            if (isUuid(issue)) {
+              const result = await getIssueWithComments(ctx.gql, issue);
+              outputSuccess(result);
+            } else {
+              const { teamKey, issueNumber } = parseIssueIdentifier(issue);
+              const result = await getIssueByIdentifierWithComments(
+                ctx.gql,
+                teamKey,
+                issueNumber,
+              );
+              outputSuccess(result);
+            }
+            return;
+          }
+
+          if (options.withReactions) {
+            if (isUuid(issue)) {
+              const result = await getIssueWithReactions(ctx.gql, issue);
+              outputSuccess(result);
+            } else {
+              const { teamKey, issueNumber } = parseIssueIdentifier(issue);
+              const result = await getIssueByIdentifierWithReactions(
+                ctx.gql,
+                teamKey,
+                issueNumber,
+              );
+              outputSuccess(result);
+            }
+            return;
+          }
+
           if (isUuid(issue)) {
-            const result = await getIssueWithAttachments(ctx.gql, issue);
+            const result = await getIssue(ctx.gql, issue);
             outputSuccess(result);
           } else {
             const { teamKey, issueNumber } = parseIssueIdentifier(issue);
-            const result = await getIssueByIdentifierWithAttachments(
+            const result = await getIssueByIdentifier(
               ctx.gql,
               teamKey,
               issueNumber,
             );
             outputSuccess(result);
           }
-          return;
-        }
-
-        if (options.withCommentThreads) {
-          if (isUuid(issue)) {
-            const result = await getIssueWithCommentThreads(ctx.gql, issue);
-            outputSuccess(result);
-          } else {
-            const { teamKey, issueNumber } = parseIssueIdentifier(issue);
-            const result = await getIssueByIdentifierWithCommentThreads(
-              ctx.gql,
-              teamKey,
-              issueNumber,
-            );
-            outputSuccess(result);
-          }
-          return;
-        }
-
-        if (options.withComments) {
-          if (isUuid(issue)) {
-            const result = await getIssueWithComments(ctx.gql, issue);
-            outputSuccess(result);
-          } else {
-            const { teamKey, issueNumber } = parseIssueIdentifier(issue);
-            const result = await getIssueByIdentifierWithComments(
-              ctx.gql,
-              teamKey,
-              issueNumber,
-            );
-            outputSuccess(result);
-          }
-          return;
-        }
-
-        if (options.withReactions) {
-          if (isUuid(issue)) {
-            const result = await getIssueWithReactions(ctx.gql, issue);
-            outputSuccess(result);
-          } else {
-            const { teamKey, issueNumber } = parseIssueIdentifier(issue);
-            const result = await getIssueByIdentifierWithReactions(
-              ctx.gql,
-              teamKey,
-              issueNumber,
-            );
-            outputSuccess(result);
-          }
-          return;
-        }
-
-        if (isUuid(issue)) {
-          const result = await getIssue(ctx.gql, issue);
-          outputSuccess(result);
-        } else {
-          const { teamKey, issueNumber } = parseIssueIdentifier(issue);
-          const result = await getIssueByIdentifier(
-            ctx.gql,
-            teamKey,
-            issueNumber,
-          );
-          outputSuccess(result);
-        }
-      }),
+        },
+      ),
     );
 
   issues
@@ -783,22 +763,18 @@ export function setupIssuesCommands(program: Command): void {
       `\nWhen passing issue IDs, both UUID and identifiers like ABC-123 are supported.`,
     )
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [issue, emoji, options, command] = args as [
-          string,
-          string | undefined,
-          ReactionOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
-        const issueId = await resolveIssueId(ctx.sdk, issue);
-        const result = await createReactionForIssue(ctx.gql, {
-          issueId,
-          emoji: resolveReactionEmojiInput(emoji, options.shortcode),
-        });
+      commandAction<[string, string | undefined, ReactionOptions, Command]>(
+        async (issue, emoji, options, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const result = await createReactionForIssue(ctx.gql, {
+            issueId,
+            emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+          });
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   issues
@@ -810,23 +786,19 @@ export function setupIssuesCommands(program: Command): void {
       `\nWhen passing issue IDs, both UUID and identifiers like ABC-123 are supported.`,
     )
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [issue, emoji, options, command] = args as [
-          string,
-          string | undefined,
-          ReactionOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
-        const issueId = await resolveIssueId(ctx.sdk, issue);
-        const result = await deleteOwnReactionByEmoji(ctx.gql, {
-          kind: "issue",
-          id: issueId,
-          emoji: resolveReactionEmojiInput(emoji, options.shortcode),
-        });
+      commandAction<[string, string | undefined, ReactionOptions, Command]>(
+        async (issue, emoji, options, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const result = await deleteOwnReactionByEmoji(ctx.gql, {
+            kind: "issue",
+            id: issueId,
+            emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+          });
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   issues
@@ -837,23 +809,19 @@ export function setupIssuesCommands(program: Command): void {
       `\nWhen passing issue IDs, both UUID and identifiers like ABC-123 are supported.`,
     )
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [issue, reactionId, , command] = args as [
-          string,
-          string,
-          unknown,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
-        const issueId = await resolveIssueId(ctx.sdk, issue);
-        const result = await deleteOwnReactionById(ctx.gql, {
-          kind: "issue",
-          id: issueId,
-          reactionId,
-        });
+      commandAction<[string, string, unknown, Command]>(
+        async (issue, reactionId, _unused2, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const result = await deleteOwnReactionById(ctx.gql, {
+            kind: "issue",
+            id: issueId,
+            reactionId,
+          });
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   issues
@@ -865,26 +833,23 @@ export function setupIssuesCommands(program: Command): void {
     )
     .option("--body <text>", "discussion body (required, markdown supported)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [issue, options, command] = args as [
-          string,
-          DiscussionBodyOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionBodyOptions, Command]>(
+        async (issue, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        if (!options.body) {
-          throw invalidParameterError("--body", "is required");
-        }
+          if (!options.body) {
+            throw invalidParameterError("--body", "is required");
+          }
 
-        const issueId = await resolveIssueId(ctx.sdk, issue);
-        const result = await startIssueDiscussion(ctx.gql, {
-          issueId,
-          body: options.body,
-        });
+          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const result = await startIssueDiscussion(ctx.gql, {
+            issueId,
+            body: options.body,
+          });
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   issues
@@ -898,29 +863,30 @@ export function setupIssuesCommands(program: Command): void {
     .option("--after <cursor>", "cursor for next page")
     .option("--with-reactions", "include normalized discussion reactions")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [issue, options, command] = args as [
-          string,
-          DiscussionsOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionsOptions, Command]>(
+        async (issue, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const issueId = await resolveIssueId(ctx.sdk, issue);
-        const paginationOptions = {
-          limit: parseLimit(options.limit || "25"),
-          after: options.after,
-        };
-        const result = options.withReactions
-          ? await listDiscussionsForIssueWithReactions(
-              ctx.gql,
-              issueId,
-              paginationOptions,
-            )
-          : await listDiscussionsForIssue(ctx.gql, issueId, paginationOptions);
+          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const paginationOptions = {
+            limit: parseLimit(options.limit || "25"),
+            after: options.after,
+          };
+          const result = options.withReactions
+            ? await listDiscussionsForIssueWithReactions(
+                ctx.gql,
+                issueId,
+                paginationOptions,
+              )
+            : await listDiscussionsForIssue(
+                ctx.gql,
+                issueId,
+                paginationOptions,
+              );
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   const issueThreads = issues
@@ -935,34 +901,31 @@ export function setupIssuesCommands(program: Command): void {
     .option("--after <cursor>", "cursor for next page")
     .option("--with-reactions", "include normalized discussion reactions")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [thread, options, command] = args as [
-          string,
-          DiscussionsOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionsOptions, Command]>(
+        async (thread, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const paginationOptions = {
-          limit: parseLimit(options.limit || "50"),
-          after: options.after,
-        };
-        const result = options.withReactions
-          ? await listDiscussionRepliesWithReactions(
-              ctx.gql,
-              thread,
-              paginationOptions,
-              "issue",
-            )
-          : await listDiscussionReplies(
-              ctx.gql,
-              thread,
-              paginationOptions,
-              "issue",
-            );
+          const paginationOptions = {
+            limit: parseLimit(options.limit || "50"),
+            after: options.after,
+          };
+          const result = options.withReactions
+            ? await listDiscussionRepliesWithReactions(
+                ctx.gql,
+                thread,
+                paginationOptions,
+                "issue",
+              )
+            : await listDiscussionReplies(
+                ctx.gql,
+                thread,
+                paginationOptions,
+                "issue",
+              );
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
   addCommentReactionCommands(issueReplies, "reply");
 
@@ -975,26 +938,23 @@ export function setupIssuesCommands(program: Command): void {
     )
     .option("--body <text>", "reply body (required, markdown supported)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [thread, options, command] = args as [
-          string,
-          DiscussionBodyOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionBodyOptions, Command]>(
+        async (thread, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        if (!options.body) {
-          throw invalidParameterError("--body", "is required");
-        }
+          if (!options.body) {
+            throw invalidParameterError("--body", "is required");
+          }
 
-        const result = await replyToDiscussion(ctx.gql, {
-          threadId: thread,
-          body: options.body,
-          entityKind: "issue",
-        });
+          const result = await replyToDiscussion(ctx.gql, {
+            threadId: thread,
+            body: options.body,
+            entityKind: "issue",
+          });
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   issues
@@ -1002,29 +962,26 @@ export function setupIssuesCommands(program: Command): void {
     .description("edit a root discussion or reply comment")
     .option("--body <text>", "new comment body (required, markdown supported)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [comment, options, command] = args as [
-          string,
-          DiscussionBodyOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionBodyOptions, Command]>(
+        async (comment, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        if (!options.body) {
-          throw invalidParameterError("--body", "is required");
-        }
+          if (!options.body) {
+            throw invalidParameterError("--body", "is required");
+          }
 
-        const result = await editDiscussionComment(
-          ctx.gql,
-          comment,
-          {
-            body: options.body,
-          },
-          "issue",
-        );
+          const result = await editDiscussionComment(
+            ctx.gql,
+            comment,
+            {
+              body: options.body,
+            },
+            "issue",
+          );
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   issues
@@ -1032,57 +989,60 @@ export function setupIssuesCommands(program: Command): void {
     .description("edit a discussion reply")
     .option("--body <text>", "new reply body (required, markdown supported)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [reply, options, command] = args as [
-          string,
-          DiscussionBodyOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionBodyOptions, Command]>(
+        async (reply, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        if (!options.body) {
-          throw invalidParameterError("--body", "is required");
-        }
+          if (!options.body) {
+            throw invalidParameterError("--body", "is required");
+          }
 
-        const result = await editDiscussionReply(
-          ctx.gql,
-          reply,
-          {
-            body: options.body,
-          },
-          "issue",
-        );
+          const result = await editDiscussionReply(
+            ctx.gql,
+            reply,
+            {
+              body: options.body,
+            },
+            "issue",
+          );
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   issues
     .command("delete-comment <comment>")
     .description("delete a root discussion or reply comment")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [comment, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, unknown, Command]>(
+        async (comment, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const result = await deleteDiscussionComment(ctx.gql, comment, "issue");
+          const result = await deleteDiscussionComment(
+            ctx.gql,
+            comment,
+            "issue",
+          );
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   issues
     .command("delete-reply <reply>")
     .description("delete a discussion reply")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [reply, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, unknown, Command]>(
+        async (reply, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const result = await deleteDiscussionReply(ctx.gql, reply, "issue");
+          const result = await deleteDiscussionReply(ctx.gql, reply, "issue");
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   issues
@@ -1090,36 +1050,34 @@ export function setupIssuesCommands(program: Command): void {
     .description("resolve a discussion thread")
     .option("--with-comment <comment>", "comment to mark as resolving comment")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [thread, options, command] = args as [
-          string,
-          ResolveDiscussionOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, ResolveDiscussionOptions, Command]>(
+        async (thread, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const result = await resolveDiscussion(ctx.gql, {
-          threadId: thread,
-          resolvingCommentId: options.withComment,
-          entityKind: "issue",
-        });
+          const result = await resolveDiscussion(ctx.gql, {
+            threadId: thread,
+            resolvingCommentId: options.withComment,
+            entityKind: "issue",
+          });
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   issues
     .command("unresolve <thread>")
     .description("unresolve a discussion thread")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [thread, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, unknown, Command]>(
+        async (thread, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const result = await unresolveDiscussion(ctx.gql, thread, "issue");
+          const result = await unresolveDiscussion(ctx.gql, thread, "issue");
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   issues
@@ -1143,125 +1101,125 @@ export function setupIssuesCommands(program: Command): void {
     .option("--duplicate-of <issue>", "this issue duplicates <issue>")
     .option("--similar-to <issue>", "this issue is similar to <issue>")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [title, options, command] = args as [
-          string,
-          CreateOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, CreateOptions, Command]>(
+        async (title, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const relationActions = parseRelationFlags(options);
+          const relationActions = parseRelationFlags(options);
 
-        const parsedPriority =
-          options.priority !== undefined
-            ? parsePriorityOption(options.priority)
-            : undefined;
-        const parsedEstimate =
-          options.estimate !== undefined
-            ? parseEstimateOption(options.estimate)
-            : undefined;
+          const parsedPriority =
+            options.priority !== undefined
+              ? parsePriorityOption(options.priority)
+              : undefined;
+          const parsedEstimate =
+            options.estimate !== undefined
+              ? parseEstimateOption(options.estimate)
+              : undefined;
 
-        if (!options.team) {
-          throw new Error("--team is required");
-        }
+          if (!options.team) {
+            throw new Error("--team is required");
+          }
 
-        const teamEstimateContext =
-          parsedEstimate !== undefined
-            ? await resolveTeamEstimateContext(ctx.sdk, options.team)
-            : undefined;
+          const teamEstimateContext =
+            parsedEstimate !== undefined
+              ? await resolveTeamEstimateContext(ctx.sdk, options.team)
+              : undefined;
 
-        const teamId = teamEstimateContext
-          ? teamEstimateContext.teamId
-          : await resolveTeamId(ctx.sdk, options.team);
+          const teamId = teamEstimateContext
+            ? teamEstimateContext.teamId
+            : await resolveTeamId(ctx.sdk, options.team);
 
-        if (parsedEstimate !== undefined && teamEstimateContext) {
-          validateEstimateAgainstTeamConfig(parsedEstimate, {
-            teamKey: teamEstimateContext.teamKey,
-            issueEstimationType: teamEstimateContext.issueEstimationType,
-            issueEstimationExtended:
-              teamEstimateContext.issueEstimationExtended,
-            issueEstimationAllowZero:
-              teamEstimateContext.issueEstimationAllowZero,
-          });
-        }
+          if (parsedEstimate !== undefined && teamEstimateContext) {
+            validateEstimateAgainstTeamConfig(parsedEstimate, {
+              teamKey: teamEstimateContext.teamKey,
+              issueEstimationType: teamEstimateContext.issueEstimationType,
+              issueEstimationExtended:
+                teamEstimateContext.issueEstimationExtended,
+              issueEstimationAllowZero:
+                teamEstimateContext.issueEstimationAllowZero,
+            });
+          }
 
-        const input: IssueCreateInput = {
-          title,
-          teamId,
-        };
+          const input: IssueCreateInput = {
+            title,
+            teamId,
+          };
 
-        if (options.description) {
-          input.description = options.description;
-        }
+          if (options.description) {
+            input.description = options.description;
+          }
 
-        if (options.assignee) {
-          input.assigneeId = await resolveUserId(ctx.sdk, options.assignee);
-        }
+          if (options.assignee) {
+            input.assigneeId = await resolveUserId(ctx.sdk, options.assignee);
+          }
 
-        if (parsedPriority !== undefined) {
-          input.priority = parsedPriority;
-        }
+          if (parsedPriority !== undefined) {
+            input.priority = parsedPriority;
+          }
 
-        if (parsedEstimate !== undefined) {
-          input.estimate = parsedEstimate;
-        }
+          if (parsedEstimate !== undefined) {
+            input.estimate = parsedEstimate;
+          }
 
-        if (options.project) {
-          input.projectId = await resolveProjectId(ctx.sdk, options.project);
-        }
+          if (options.project) {
+            input.projectId = await resolveProjectId(ctx.sdk, options.project);
+          }
 
-        if (options.labels) {
-          const labelNames = options.labels.split(",").map((l) => l.trim());
-          input.labelIds = await resolveLabelIds(ctx.sdk, labelNames);
-        }
+          if (options.labels) {
+            const labelNames = options.labels.split(",").map((l) => l.trim());
+            input.labelIds = await resolveLabelIds(ctx.sdk, labelNames);
+          }
 
-        if (options.projectMilestone) {
-          if (!options.project) {
-            throw new Error(
-              "--project-milestone requires --project to be specified",
+          if (options.projectMilestone) {
+            if (!options.project) {
+              throw new Error(
+                "--project-milestone requires --project to be specified",
+              );
+            }
+            input.projectMilestoneId = await resolveMilestoneId(
+              ctx.gql,
+              ctx.sdk,
+              options.projectMilestone,
+              options.project,
             );
           }
-          input.projectMilestoneId = await resolveMilestoneId(
-            ctx.gql,
-            ctx.sdk,
-            options.projectMilestone,
-            options.project,
-          );
-        }
 
-        if (options.cycle) {
-          input.cycleId = await resolveCycleId(
-            ctx.sdk,
-            options.cycle,
-            options.team,
-          );
-        }
+          if (options.cycle) {
+            input.cycleId = await resolveCycleId(
+              ctx.sdk,
+              options.cycle,
+              options.team,
+            );
+          }
 
-        if (options.status) {
-          input.stateId = await resolveStatusId(
-            ctx.sdk,
-            options.status,
-            teamId,
-          );
-        }
+          if (options.status) {
+            input.stateId = await resolveStatusId(
+              ctx.sdk,
+              options.status,
+              teamId,
+            );
+          }
 
-        if (options.parentTicket) {
-          input.parentId = await resolveIssueId(ctx.sdk, options.parentTicket);
-        }
+          if (options.parentTicket) {
+            input.parentId = await resolveIssueId(
+              ctx.sdk,
+              options.parentTicket,
+            );
+          }
 
-        if (options.dueDate) {
-          input.dueDate = parseDueDate(options.dueDate);
-        }
+          if (options.dueDate) {
+            input.dueDate = parseDueDate(options.dueDate);
+          }
 
-        const result = await createIssue(ctx.gql, input);
+          const result = await createIssue(ctx.gql, input);
 
-        if (relationActions.length > 0) {
-          await resolveAndApplyRelations(ctx, result.id, relationActions);
-        }
+          if (relationActions.length > 0) {
+            await resolveAndApplyRelations(ctx, result.id, relationActions);
+          }
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   issues
@@ -1297,251 +1255,263 @@ export function setupIssuesCommands(program: Command): void {
     .option("--similar-to <issue>", "add similar relation")
     .option("--remove-relation <issue>", "remove relation with <issue>")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [issue, options, command] = args as [
-          string,
-          UpdateOptions,
-          Command,
-        ];
-        if (options.parentTicket && options.clearParentTicket) {
-          throw new Error(
-            "Cannot use --parent-ticket and --clear-parent-ticket together",
-          );
-        }
-
-        if (options.projectMilestone && options.clearProjectMilestone) {
-          throw new Error(
-            "Cannot use --project-milestone and --clear-project-milestone together",
-          );
-        }
-
-        if (options.estimate !== undefined && options.clearEstimate) {
-          throw new Error(
-            "Cannot use --estimate and --clear-estimate together",
-          );
-        }
-
-        if (options.cycle && options.clearCycle) {
-          throw new Error("Cannot use --cycle and --clear-cycle together");
-        }
-
-        if (options.dueDate && options.clearDueDate) {
-          throw new Error(
-            "Cannot use --due-date and --clear-due-date together",
-          );
-        }
-
-        if (options.labelMode && !options.labels) {
-          throw new Error("--label-mode requires --labels to be specified");
-        }
-
-        if (options.clearLabels && options.labels) {
-          throw new Error("--clear-labels cannot be used with --labels");
-        }
-
-        if (options.clearLabels && options.labelMode) {
-          throw new Error("--clear-labels cannot be used with --label-mode");
-        }
-
-        const labelMode = parseLabelMode(options.labelMode);
-
-        const parsedPriority =
-          options.priority !== undefined
-            ? parsePriorityOption(options.priority)
-            : undefined;
-        const parsedEstimate =
-          options.estimate !== undefined
-            ? parseEstimateOption(options.estimate)
-            : undefined;
-
-        const relationActions = parseRelationFlags(options);
-
-        const ctx = createContext(getRootOpts(command));
-
-        const issueEstimateContext =
-          parsedEstimate !== undefined
-            ? await resolveIssueEstimateContext(ctx.sdk, issue)
-            : undefined;
-
-        const resolvedIssueId = issueEstimateContext
-          ? issueEstimateContext.issueId
-          : await resolveIssueId(ctx.sdk, issue);
-
-        if (parsedEstimate !== undefined && issueEstimateContext) {
-          validateEstimateAgainstTeamConfig(parsedEstimate, {
-            teamKey: issueEstimateContext.team.teamKey,
-            issueEstimationType: issueEstimateContext.team.issueEstimationType,
-            issueEstimationExtended:
-              issueEstimateContext.team.issueEstimationExtended,
-            issueEstimationAllowZero:
-              issueEstimateContext.team.issueEstimationAllowZero,
-          });
-        }
-
-        const needsContext =
-          options.status ||
-          options.projectMilestone ||
-          options.cycle ||
-          (options.labels && (labelMode === "add" || labelMode === "remove"));
-        const issueContext = needsContext
-          ? await getIssue(ctx.gql, resolvedIssueId)
-          : undefined;
-
-        const input: IssueUpdateInput = {};
-
-        if (options.title) {
-          input.title = options.title;
-        }
-
-        if (options.description) {
-          input.description = options.description;
-        }
-
-        if (options.status) {
-          const teamId =
-            issueContext && "team" in issueContext && issueContext.team
-              ? issueContext.team.id
-              : undefined;
-          input.stateId = await resolveStatusId(
-            ctx.sdk,
-            options.status,
-            teamId,
-          );
-        }
-
-        if (parsedPriority !== undefined) {
-          input.priority = parsedPriority;
-        }
-
-        if (options.clearEstimate) {
-          input.estimate = null;
-        } else if (parsedEstimate !== undefined) {
-          input.estimate = parsedEstimate;
-        }
-
-        if (options.assignee) {
-          input.assigneeId = await resolveUserId(ctx.sdk, options.assignee);
-        }
-
-        if (options.project) {
-          input.projectId = await resolveProjectId(ctx.sdk, options.project);
-        }
-
-        if (options.clearLabels) {
-          input.labelIds = [];
-        } else if (options.labels) {
-          const labelNames = options.labels.split(",").map((l) => l.trim());
-          const labelIds = await resolveLabelIds(ctx.sdk, labelNames);
-
-          if (labelMode === "add") {
-            const currentLabels =
-              issueContext &&
-              "labels" in issueContext &&
-              issueContext.labels?.nodes
-                ? issueContext.labels.nodes.map((l) => l.id)
-                : [];
-            input.labelIds = [...new Set([...currentLabels, ...labelIds])];
-          } else if (labelMode === "remove") {
-            const currentLabels =
-              issueContext &&
-              "labels" in issueContext &&
-              issueContext.labels?.nodes
-                ? issueContext.labels.nodes.map((l) => l.id)
-                : [];
-            input.labelIds = currentLabels.filter(
-              (id) => !labelIds.includes(id),
+      commandAction<[string, UpdateOptions, Command]>(
+        async (issue, options, command) => {
+          if (options.parentTicket && options.clearParentTicket) {
+            throw new Error(
+              "Cannot use --parent-ticket and --clear-parent-ticket together",
             );
-          } else {
-            input.labelIds = labelIds;
           }
-        }
 
-        if (options.clearParentTicket) {
-          input.parentId = null;
-        } else if (options.parentTicket) {
-          input.parentId = await resolveIssueId(ctx.sdk, options.parentTicket);
-        }
+          if (options.projectMilestone && options.clearProjectMilestone) {
+            throw new Error(
+              "Cannot use --project-milestone and --clear-project-milestone together",
+            );
+          }
 
-        if (options.clearProjectMilestone) {
-          input.projectMilestoneId = null;
-        } else if (options.projectMilestone) {
-          const projectName =
-            issueContext &&
-            "project" in issueContext &&
-            issueContext.project?.name
-              ? issueContext.project.name
+          if (options.estimate !== undefined && options.clearEstimate) {
+            throw new Error(
+              "Cannot use --estimate and --clear-estimate together",
+            );
+          }
+
+          if (options.cycle && options.clearCycle) {
+            throw new Error("Cannot use --cycle and --clear-cycle together");
+          }
+
+          if (options.dueDate && options.clearDueDate) {
+            throw new Error(
+              "Cannot use --due-date and --clear-due-date together",
+            );
+          }
+
+          if (options.labelMode && !options.labels) {
+            throw new Error("--label-mode requires --labels to be specified");
+          }
+
+          if (options.clearLabels && options.labels) {
+            throw new Error("--clear-labels cannot be used with --labels");
+          }
+
+          if (options.clearLabels && options.labelMode) {
+            throw new Error("--clear-labels cannot be used with --label-mode");
+          }
+
+          const labelMode = parseLabelMode(options.labelMode);
+
+          const parsedPriority =
+            options.priority !== undefined
+              ? parsePriorityOption(options.priority)
               : undefined;
-          input.projectMilestoneId = await resolveMilestoneId(
-            ctx.gql,
-            ctx.sdk,
-            options.projectMilestone,
-            projectName,
-          );
-        }
-
-        if (options.clearCycle) {
-          input.cycleId = null;
-        } else if (options.cycle) {
-          const teamKey =
-            issueContext && "team" in issueContext && issueContext.team?.key
-              ? issueContext.team.key
+          const parsedEstimate =
+            options.estimate !== undefined
+              ? parseEstimateOption(options.estimate)
               : undefined;
-          input.cycleId = await resolveCycleId(ctx.sdk, options.cycle, teamKey);
-        }
 
-        if (options.clearDueDate) {
-          input.dueDate = null;
-        } else if (options.dueDate) {
-          input.dueDate = parseDueDate(options.dueDate);
-        }
+          const relationActions = parseRelationFlags(options);
 
-        const result = await updateIssue(ctx.gql, resolvedIssueId, input);
+          const ctx = createContext(getRootOpts(command));
 
-        if (relationActions.length > 0) {
-          await resolveAndApplyRelations(ctx, resolvedIssueId, relationActions);
-        }
+          const issueEstimateContext =
+            parsedEstimate !== undefined
+              ? await resolveIssueEstimateContext(ctx.sdk, issue)
+              : undefined;
 
-        outputSuccess(result);
-      }),
+          const resolvedIssueId = issueEstimateContext
+            ? issueEstimateContext.issueId
+            : await resolveIssueId(ctx.sdk, issue);
+
+          if (parsedEstimate !== undefined && issueEstimateContext) {
+            validateEstimateAgainstTeamConfig(parsedEstimate, {
+              teamKey: issueEstimateContext.team.teamKey,
+              issueEstimationType:
+                issueEstimateContext.team.issueEstimationType,
+              issueEstimationExtended:
+                issueEstimateContext.team.issueEstimationExtended,
+              issueEstimationAllowZero:
+                issueEstimateContext.team.issueEstimationAllowZero,
+            });
+          }
+
+          const needsContext =
+            options.status ||
+            options.projectMilestone ||
+            options.cycle ||
+            (options.labels && (labelMode === "add" || labelMode === "remove"));
+          const issueContext = needsContext
+            ? await getIssue(ctx.gql, resolvedIssueId)
+            : undefined;
+
+          const input: IssueUpdateInput = {};
+
+          if (options.title) {
+            input.title = options.title;
+          }
+
+          if (options.description) {
+            input.description = options.description;
+          }
+
+          if (options.status) {
+            const teamId =
+              issueContext && "team" in issueContext && issueContext.team
+                ? issueContext.team.id
+                : undefined;
+            input.stateId = await resolveStatusId(
+              ctx.sdk,
+              options.status,
+              teamId,
+            );
+          }
+
+          if (parsedPriority !== undefined) {
+            input.priority = parsedPriority;
+          }
+
+          if (options.clearEstimate) {
+            input.estimate = null;
+          } else if (parsedEstimate !== undefined) {
+            input.estimate = parsedEstimate;
+          }
+
+          if (options.assignee) {
+            input.assigneeId = await resolveUserId(ctx.sdk, options.assignee);
+          }
+
+          if (options.project) {
+            input.projectId = await resolveProjectId(ctx.sdk, options.project);
+          }
+
+          if (options.clearLabels) {
+            input.labelIds = [];
+          } else if (options.labels) {
+            const labelNames = options.labels.split(",").map((l) => l.trim());
+            const labelIds = await resolveLabelIds(ctx.sdk, labelNames);
+
+            if (labelMode === "add") {
+              const currentLabels =
+                issueContext &&
+                "labels" in issueContext &&
+                issueContext.labels?.nodes
+                  ? issueContext.labels.nodes.map((l) => l.id)
+                  : [];
+              input.labelIds = [...new Set([...currentLabels, ...labelIds])];
+            } else if (labelMode === "remove") {
+              const currentLabels =
+                issueContext &&
+                "labels" in issueContext &&
+                issueContext.labels?.nodes
+                  ? issueContext.labels.nodes.map((l) => l.id)
+                  : [];
+              input.labelIds = currentLabels.filter(
+                (id) => !labelIds.includes(id),
+              );
+            } else {
+              input.labelIds = labelIds;
+            }
+          }
+
+          if (options.clearParentTicket) {
+            input.parentId = null;
+          } else if (options.parentTicket) {
+            input.parentId = await resolveIssueId(
+              ctx.sdk,
+              options.parentTicket,
+            );
+          }
+
+          if (options.clearProjectMilestone) {
+            input.projectMilestoneId = null;
+          } else if (options.projectMilestone) {
+            const projectName =
+              issueContext &&
+              "project" in issueContext &&
+              issueContext.project?.name
+                ? issueContext.project.name
+                : undefined;
+            input.projectMilestoneId = await resolveMilestoneId(
+              ctx.gql,
+              ctx.sdk,
+              options.projectMilestone,
+              projectName,
+            );
+          }
+
+          if (options.clearCycle) {
+            input.cycleId = null;
+          } else if (options.cycle) {
+            const teamKey =
+              issueContext && "team" in issueContext && issueContext.team?.key
+                ? issueContext.team.key
+                : undefined;
+            input.cycleId = await resolveCycleId(
+              ctx.sdk,
+              options.cycle,
+              teamKey,
+            );
+          }
+
+          if (options.clearDueDate) {
+            input.dueDate = null;
+          } else if (options.dueDate) {
+            input.dueDate = parseDueDate(options.dueDate);
+          }
+
+          const result = await updateIssue(ctx.gql, resolvedIssueId, input);
+
+          if (relationActions.length > 0) {
+            await resolveAndApplyRelations(
+              ctx,
+              resolvedIssueId,
+              relationActions,
+            );
+          }
+
+          outputSuccess(result);
+        },
+      ),
     );
 
   issues
     .command("archive <issue>")
     .description("archive an issue")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [issue, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
-        const issueId = await resolveIssueId(ctx.sdk, issue);
-        const result = await archiveIssue(ctx.gql, issueId);
-        outputSuccess(result);
-      }),
+      commandAction<[string, unknown, Command]>(
+        async (issue, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const result = await archiveIssue(ctx.gql, issueId);
+          outputSuccess(result);
+        },
+      ),
     );
 
   issues
     .command("unarchive <issue>")
     .description("unarchive an issue")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [issue, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
-        const issueId = await resolveIssueId(ctx.sdk, issue);
-        const result = await unarchiveIssue(ctx.gql, issueId);
-        outputSuccess(result);
-      }),
+      commandAction<[string, unknown, Command]>(
+        async (issue, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const result = await unarchiveIssue(ctx.gql, issueId);
+          outputSuccess(result);
+        },
+      ),
     );
 
   issues
     .command("delete <issue>")
     .description("delete an issue")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [issue, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
-        const issueId = await resolveIssueId(ctx.sdk, issue);
-        const result = await deleteIssue(ctx.gql, issueId);
-        outputSuccess(result);
-      }),
+      commandAction<[string, unknown, Command]>(
+        async (issue, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const result = await deleteIssue(ctx.gql, issueId);
+          outputSuccess(result);
+        },
+      ),
     );
 
   issues

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -3,7 +3,7 @@ import { createContext, getRootOpts } from "../common/context.js";
 import { type Priority, parseLabelMode } from "../common/domain-values.js";
 import { resolveReactionEmojiInput } from "../common/emoji.js";
 import { invalidParameterError } from "../common/errors.js";
-import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
+import { commandAction, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import type { ProjectCreateInput, ProjectUpdateInput } from "../gql/graphql.js";
 import {
@@ -78,22 +78,18 @@ function addCommentReactionCommands(
     .description(`add a reaction to a discussion ${noun}`)
     .option("--shortcode <name>", "emoji shortcode (e.g. thumbs_up)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [commentId, emoji, options, command] = args as [
-          string,
-          string | undefined,
-          ReactionOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
-        const result = await createDiscussionCommentReaction(ctx.gql, {
-          commentId,
-          target: noun,
-          expectedEntityKind: "project",
-          emoji: resolveReactionEmojiInput(emoji, options.shortcode),
-        });
-        outputSuccess(result);
-      }),
+      commandAction<[string, string | undefined, ReactionOptions, Command]>(
+        async (commentId, emoji, options, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const result = await createDiscussionCommentReaction(ctx.gql, {
+            commentId,
+            target: noun,
+            expectedEntityKind: "project",
+            emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+          });
+          outputSuccess(result);
+        },
+      ),
     );
 
   parent
@@ -101,22 +97,18 @@ function addCommentReactionCommands(
     .description(`remove your reaction from a discussion ${noun} by emoji`)
     .option("--shortcode <name>", "emoji shortcode (e.g. thumbs_up)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [commentId, emoji, options, command] = args as [
-          string,
-          string | undefined,
-          ReactionOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
-        const result = await deleteDiscussionCommentReactionByEmoji(ctx.gql, {
-          commentId,
-          target: noun,
-          expectedEntityKind: "project",
-          emoji: resolveReactionEmojiInput(emoji, options.shortcode),
-        });
-        outputSuccess(result);
-      }),
+      commandAction<[string, string | undefined, ReactionOptions, Command]>(
+        async (commentId, emoji, options, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const result = await deleteDiscussionCommentReactionByEmoji(ctx.gql, {
+            commentId,
+            target: noun,
+            expectedEntityKind: "project",
+            emoji: resolveReactionEmojiInput(emoji, options.shortcode),
+          });
+          outputSuccess(result);
+        },
+      ),
     );
 
   parent
@@ -125,22 +117,18 @@ function addCommentReactionCommands(
       `remove your reaction from a discussion ${noun} by reaction ID`,
     )
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [commentId, reactionId, , command] = args as [
-          string,
-          string,
-          unknown,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
-        const result = await deleteDiscussionCommentReactionById(ctx.gql, {
-          commentId,
-          target: noun,
-          expectedEntityKind: "project",
-          reactionId,
-        });
-        outputSuccess(result);
-      }),
+      commandAction<[string, string, unknown, Command]>(
+        async (commentId, reactionId, _unused2, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const result = await deleteDiscussionCommentReactionById(ctx.gql, {
+            commentId,
+            target: noun,
+            expectedEntityKind: "project",
+            reactionId,
+          });
+          outputSuccess(result);
+        },
+      ),
     );
 }
 
@@ -271,8 +259,7 @@ export function setupProjectsCommands(program: Command): void {
     .option("--after <cursor>", "cursor for next page")
     .option("--include-archived", "include archived projects")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [options, command] = args as [ListOptions, Command];
+      commandAction<[ListOptions, Command]>(async (options, command) => {
         const ctx = createContext(getRootOpts(command));
         const result = await listProjects(ctx.gql, {
           limit: parseLimit(options.limit),
@@ -297,26 +284,23 @@ export function setupProjectsCommands(program: Command): void {
       "50",
     )
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [project, options, command] = args as [
-          string,
-          ReadOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
-        const projectId = await resolveProjectId(ctx.sdk, project);
-        const result = await getProject(ctx.gql, projectId, {
-          milestonesFirst: parseNonNegativeIntegerOption(
-            "--milestones-first",
-            options.milestonesFirst,
-          ),
-          issuesFirst: parseNonNegativeIntegerOption(
-            "--issues-first",
-            options.issuesFirst,
-          ),
-        });
-        outputSuccess(result);
-      }),
+      commandAction<[string, ReadOptions, Command]>(
+        async (project, options, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const projectId = await resolveProjectId(ctx.sdk, project);
+          const result = await getProject(ctx.gql, projectId, {
+            milestonesFirst: parseNonNegativeIntegerOption(
+              "--milestones-first",
+              options.milestonesFirst,
+            ),
+            issuesFirst: parseNonNegativeIntegerOption(
+              "--issues-first",
+              options.issuesFirst,
+            ),
+          });
+          outputSuccess(result);
+        },
+      ),
     );
 
   projects
@@ -324,26 +308,23 @@ export function setupProjectsCommands(program: Command): void {
     .description("start a discussion thread on a project")
     .option("--body <text>", "discussion body (required, markdown supported)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [project, options, command] = args as [
-          string,
-          DiscussionBodyOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionBodyOptions, Command]>(
+        async (project, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        if (!options.body) {
-          throw invalidParameterError("--body", "is required");
-        }
+          if (!options.body) {
+            throw invalidParameterError("--body", "is required");
+          }
 
-        const projectId = await resolveProjectId(ctx.sdk, project);
-        const result = await startProjectDiscussion(ctx.gql, {
-          projectId,
-          body: options.body,
-        });
+          const projectId = await resolveProjectId(ctx.sdk, project);
+          const result = await startProjectDiscussion(ctx.gql, {
+            projectId,
+            body: options.body,
+          });
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   projects
@@ -353,33 +334,30 @@ export function setupProjectsCommands(program: Command): void {
     .option("--after <cursor>", "cursor for next page")
     .option("--with-reactions", "include normalized discussion reactions")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [project, options, command] = args as [
-          string,
-          DiscussionsOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionsOptions, Command]>(
+        async (project, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const projectId = await resolveProjectId(ctx.sdk, project);
-        const paginationOptions = {
-          limit: parseLimit(options.limit || "25"),
-          after: options.after,
-        };
-        const result = options.withReactions
-          ? await listDiscussionsForProjectWithReactions(
-              ctx.gql,
-              projectId,
-              paginationOptions,
-            )
-          : await listDiscussionsForProject(
-              ctx.gql,
-              projectId,
-              paginationOptions,
-            );
+          const projectId = await resolveProjectId(ctx.sdk, project);
+          const paginationOptions = {
+            limit: parseLimit(options.limit || "25"),
+            after: options.after,
+          };
+          const result = options.withReactions
+            ? await listDiscussionsForProjectWithReactions(
+                ctx.gql,
+                projectId,
+                paginationOptions,
+              )
+            : await listDiscussionsForProject(
+                ctx.gql,
+                projectId,
+                paginationOptions,
+              );
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   const projectThreads = projects
@@ -394,34 +372,31 @@ export function setupProjectsCommands(program: Command): void {
     .option("--after <cursor>", "cursor for next page")
     .option("--with-reactions", "include normalized discussion reactions")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [thread, options, command] = args as [
-          string,
-          DiscussionsOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionsOptions, Command]>(
+        async (thread, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const paginationOptions = {
-          limit: parseLimit(options.limit || "50"),
-          after: options.after,
-        };
-        const result = options.withReactions
-          ? await listDiscussionRepliesWithReactions(
-              ctx.gql,
-              thread,
-              paginationOptions,
-              "project",
-            )
-          : await listDiscussionReplies(
-              ctx.gql,
-              thread,
-              paginationOptions,
-              "project",
-            );
+          const paginationOptions = {
+            limit: parseLimit(options.limit || "50"),
+            after: options.after,
+          };
+          const result = options.withReactions
+            ? await listDiscussionRepliesWithReactions(
+                ctx.gql,
+                thread,
+                paginationOptions,
+                "project",
+              )
+            : await listDiscussionReplies(
+                ctx.gql,
+                thread,
+                paginationOptions,
+                "project",
+              );
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
   addCommentReactionCommands(projectReplies, "reply");
 
@@ -434,26 +409,23 @@ export function setupProjectsCommands(program: Command): void {
     )
     .option("--body <text>", "reply body (required, markdown supported)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [thread, options, command] = args as [
-          string,
-          DiscussionBodyOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionBodyOptions, Command]>(
+        async (thread, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        if (!options.body) {
-          throw invalidParameterError("--body", "is required");
-        }
+          if (!options.body) {
+            throw invalidParameterError("--body", "is required");
+          }
 
-        const result = await replyToDiscussion(ctx.gql, {
-          threadId: thread,
-          body: options.body,
-          entityKind: "project",
-        });
+          const result = await replyToDiscussion(ctx.gql, {
+            threadId: thread,
+            body: options.body,
+            entityKind: "project",
+          });
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   projects
@@ -461,29 +433,26 @@ export function setupProjectsCommands(program: Command): void {
     .description("edit a root discussion or reply comment")
     .option("--body <text>", "new comment body (required, markdown supported)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [comment, options, command] = args as [
-          string,
-          DiscussionBodyOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionBodyOptions, Command]>(
+        async (comment, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        if (!options.body) {
-          throw invalidParameterError("--body", "is required");
-        }
+          if (!options.body) {
+            throw invalidParameterError("--body", "is required");
+          }
 
-        const result = await editDiscussionComment(
-          ctx.gql,
-          comment,
-          {
-            body: options.body,
-          },
-          "project",
-        );
+          const result = await editDiscussionComment(
+            ctx.gql,
+            comment,
+            {
+              body: options.body,
+            },
+            "project",
+          );
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   projects
@@ -491,61 +460,60 @@ export function setupProjectsCommands(program: Command): void {
     .description("edit a discussion reply")
     .option("--body <text>", "new reply body (required, markdown supported)")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [reply, options, command] = args as [
-          string,
-          DiscussionBodyOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, DiscussionBodyOptions, Command]>(
+        async (reply, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        if (!options.body) {
-          throw invalidParameterError("--body", "is required");
-        }
+          if (!options.body) {
+            throw invalidParameterError("--body", "is required");
+          }
 
-        const result = await editDiscussionReply(
-          ctx.gql,
-          reply,
-          {
-            body: options.body,
-          },
-          "project",
-        );
+          const result = await editDiscussionReply(
+            ctx.gql,
+            reply,
+            {
+              body: options.body,
+            },
+            "project",
+          );
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   projects
     .command("delete-comment <comment>")
     .description("delete a root discussion or reply comment")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [comment, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, unknown, Command]>(
+        async (comment, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const result = await deleteDiscussionComment(
-          ctx.gql,
-          comment,
-          "project",
-        );
+          const result = await deleteDiscussionComment(
+            ctx.gql,
+            comment,
+            "project",
+          );
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   projects
     .command("delete-reply <reply>")
     .description("delete a discussion reply")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [reply, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, unknown, Command]>(
+        async (reply, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const result = await deleteDiscussionReply(ctx.gql, reply, "project");
+          const result = await deleteDiscussionReply(ctx.gql, reply, "project");
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   projects
@@ -553,36 +521,34 @@ export function setupProjectsCommands(program: Command): void {
     .description("resolve a discussion thread")
     .option("--with-comment <comment>", "comment to mark as resolving comment")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [thread, options, command] = args as [
-          string,
-          ResolveDiscussionOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, ResolveDiscussionOptions, Command]>(
+        async (thread, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const result = await resolveDiscussion(ctx.gql, {
-          threadId: thread,
-          resolvingCommentId: options.withComment,
-          entityKind: "project",
-        });
+          const result = await resolveDiscussion(ctx.gql, {
+            threadId: thread,
+            resolvingCommentId: options.withComment,
+            entityKind: "project",
+          });
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   projects
     .command("unresolve <thread>")
     .description("unresolve a discussion thread")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [thread, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, unknown, Command]>(
+        async (thread, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const result = await unresolveDiscussion(ctx.gql, thread, "project");
+          const result = await unresolveDiscussion(ctx.gql, thread, "project");
 
-        outputSuccess(result);
-      }),
+          outputSuccess(result);
+        },
+      ),
     );
 
   projects
@@ -602,84 +568,81 @@ export function setupProjectsCommands(program: Command): void {
     .option("--target-date <date>", "target date (YYYY-MM-DD)")
     .option("--labels <labels>", "comma-separated label names or UUIDs")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [name, options, command] = args as [
-          string,
-          CreateOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, CreateOptions, Command]>(
+        async (name, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        const teamNames = getCreateTeamNames(options);
-        const teamIds = await Promise.all(
-          teamNames.map((t) => resolveTeamId(ctx.sdk, t)),
-        );
-
-        const input: ProjectCreateInput = {
-          name,
-          teamIds,
-        };
-
-        if (options.description) {
-          input.description = options.description;
-        }
-
-        if (options.content) {
-          input.content = options.content;
-        }
-
-        if (options.icon !== undefined) {
-          input.icon = options.icon;
-        }
-
-        if (options.color !== undefined) {
-          input.color = options.color;
-        }
-
-        if (options.lead) {
-          input.leadId = await resolveUserId(ctx.sdk, options.lead);
-        }
-
-        if (options.members) {
-          const memberNames = options.members
-            .split(",")
-            .map((m) => m.trim())
-            .filter(Boolean);
-          input.memberIds = await Promise.all(
-            memberNames.map((m) => resolveUserId(ctx.sdk, m)),
+          const teamNames = getCreateTeamNames(options);
+          const teamIds = await Promise.all(
+            teamNames.map((t) => resolveTeamId(ctx.sdk, t)),
           );
-        }
 
-        if (options.priority) {
-          input.priority = parsePriority(options.priority);
-        }
+          const input: ProjectCreateInput = {
+            name,
+            teamIds,
+          };
 
-        if (options.status) {
-          input.statusId = await resolveProjectStatusId(
-            ctx.gql,
-            options.status,
-          );
-        }
+          if (options.description) {
+            input.description = options.description;
+          }
 
-        if (options.startDate) {
-          input.startDate = options.startDate;
-        }
+          if (options.content) {
+            input.content = options.content;
+          }
 
-        if (options.targetDate) {
-          input.targetDate = options.targetDate;
-        }
+          if (options.icon !== undefined) {
+            input.icon = options.icon;
+          }
 
-        if (options.labels) {
-          const labelNames = options.labels
-            .split(",")
-            .map((l) => l.trim())
-            .filter(Boolean);
-          input.labelIds = await resolveProjectLabelIds(ctx.sdk, labelNames);
-        }
+          if (options.color !== undefined) {
+            input.color = options.color;
+          }
 
-        const result = await createProject(ctx.gql, input);
-        outputSuccess(result);
-      }),
+          if (options.lead) {
+            input.leadId = await resolveUserId(ctx.sdk, options.lead);
+          }
+
+          if (options.members) {
+            const memberNames = options.members
+              .split(",")
+              .map((m) => m.trim())
+              .filter(Boolean);
+            input.memberIds = await Promise.all(
+              memberNames.map((m) => resolveUserId(ctx.sdk, m)),
+            );
+          }
+
+          if (options.priority) {
+            input.priority = parsePriority(options.priority);
+          }
+
+          if (options.status) {
+            input.statusId = await resolveProjectStatusId(
+              ctx.gql,
+              options.status,
+            );
+          }
+
+          if (options.startDate) {
+            input.startDate = options.startDate;
+          }
+
+          if (options.targetDate) {
+            input.targetDate = options.targetDate;
+          }
+
+          if (options.labels) {
+            const labelNames = options.labels
+              .split(",")
+              .map((l) => l.trim())
+              .filter(Boolean);
+            input.labelIds = await resolveProjectLabelIds(ctx.sdk, labelNames);
+          }
+
+          const result = await createProject(ctx.gql, input);
+          outputSuccess(result);
+        },
+      ),
     );
 
   projects
@@ -705,212 +668,212 @@ export function setupProjectsCommands(program: Command): void {
     .option("--label-mode <mode>", "add | remove | overwrite")
     .option("--clear-labels", "remove all labels")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [project, options, command] = args as [
-          string,
-          UpdateOptions,
-          Command,
-        ];
-        const ctx = createContext(getRootOpts(command));
+      commandAction<[string, UpdateOptions, Command]>(
+        async (project, options, command) => {
+          const ctx = createContext(getRootOpts(command));
 
-        if (options.lead && options.clearLead) {
-          throw invalidParameterError(
-            "--lead",
-            "cannot be combined with --clear-lead",
-          );
-        }
-
-        if (options.startDate && options.clearStartDate) {
-          throw invalidParameterError(
-            "--start-date",
-            "cannot be combined with --clear-start-date",
-          );
-        }
-
-        if (options.targetDate && options.clearTargetDate) {
-          throw invalidParameterError(
-            "--target-date",
-            "cannot be combined with --clear-target-date",
-          );
-        }
-
-        if (options.labelMode && !options.labels) {
-          throw invalidParameterError(
-            "--label-mode",
-            "requires --labels to be specified",
-          );
-        }
-
-        if (options.clearLabels && options.labels) {
-          throw invalidParameterError(
-            "--clear-labels",
-            "cannot be used with --labels",
-          );
-        }
-
-        if (options.clearLabels && options.labelMode) {
-          throw invalidParameterError(
-            "--clear-labels",
-            "cannot be used with --label-mode",
-          );
-        }
-
-        const labelMode = parseLabelMode(options.labelMode);
-
-        const projectId = await resolveProjectId(ctx.sdk, project);
-        const needsLabelContext =
-          options.labels && (labelMode === "add" || labelMode === "remove");
-        const projectContext = needsLabelContext
-          ? await getProject(ctx.gql, projectId)
-          : undefined;
-
-        const input: ProjectUpdateInput = {};
-
-        if (options.name) {
-          input.name = options.name;
-        }
-
-        if (options.description) {
-          input.description = options.description;
-        }
-
-        if (options.content) {
-          input.content = options.content;
-        }
-
-        if (options.icon !== undefined) {
-          input.icon = options.icon;
-        }
-
-        if (options.color !== undefined) {
-          input.color = options.color;
-        }
-
-        if (options.clearLead) {
-          input.leadId = null;
-        } else if (options.lead) {
-          input.leadId = await resolveUserId(ctx.sdk, options.lead);
-        }
-
-        if (options.members) {
-          const memberNames = options.members
-            .split(",")
-            .map((m) => m.trim())
-            .filter(Boolean);
-          input.memberIds = await Promise.all(
-            memberNames.map((m) => resolveUserId(ctx.sdk, m)),
-          );
-        }
-
-        if (options.priority) {
-          input.priority = parsePriority(options.priority);
-        }
-
-        if (options.status) {
-          input.statusId = await resolveProjectStatusId(
-            ctx.gql,
-            options.status,
-          );
-        }
-
-        if (options.clearStartDate) {
-          input.startDate = null;
-        } else if (options.startDate) {
-          input.startDate = options.startDate;
-        }
-
-        if (options.clearTargetDate) {
-          input.targetDate = null;
-        } else if (options.targetDate) {
-          input.targetDate = options.targetDate;
-        }
-
-        const teamNames = getUpdateTeamNames(options);
-        if (teamNames) {
-          input.teamIds = await Promise.all(
-            teamNames.map((t) => resolveTeamId(ctx.sdk, t)),
-          );
-        }
-
-        if (options.clearLabels) {
-          input.labelIds = [];
-        } else if (options.labels) {
-          const labelNames = options.labels
-            .split(",")
-            .map((l) => l.trim())
-            .filter(Boolean);
-          const labelIds = await resolveProjectLabelIds(ctx.sdk, labelNames);
-
-          if (labelMode === "add") {
-            const currentLabels = projectContext?.labels?.nodes
-              ? projectContext.labels.nodes.map((l) => l.id)
-              : [];
-            input.labelIds = [...new Set([...currentLabels, ...labelIds])];
-          } else if (labelMode === "remove") {
-            const currentLabels = projectContext?.labels?.nodes
-              ? projectContext.labels.nodes.map((l) => l.id)
-              : [];
-            input.labelIds = currentLabels.filter(
-              (id) => !labelIds.includes(id),
+          if (options.lead && options.clearLead) {
+            throw invalidParameterError(
+              "--lead",
+              "cannot be combined with --clear-lead",
             );
-          } else {
-            input.labelIds = labelIds;
           }
-        }
 
-        if (Object.keys(input).length === 0) {
-          throw invalidParameterError(
-            "update options",
-            "at least one option must be provided",
-          );
-        }
+          if (options.startDate && options.clearStartDate) {
+            throw invalidParameterError(
+              "--start-date",
+              "cannot be combined with --clear-start-date",
+            );
+          }
 
-        const result = await updateProject(ctx.gql, projectId, input);
-        outputSuccess(result);
-      }),
+          if (options.targetDate && options.clearTargetDate) {
+            throw invalidParameterError(
+              "--target-date",
+              "cannot be combined with --clear-target-date",
+            );
+          }
+
+          if (options.labelMode && !options.labels) {
+            throw invalidParameterError(
+              "--label-mode",
+              "requires --labels to be specified",
+            );
+          }
+
+          if (options.clearLabels && options.labels) {
+            throw invalidParameterError(
+              "--clear-labels",
+              "cannot be used with --labels",
+            );
+          }
+
+          if (options.clearLabels && options.labelMode) {
+            throw invalidParameterError(
+              "--clear-labels",
+              "cannot be used with --label-mode",
+            );
+          }
+
+          const labelMode = parseLabelMode(options.labelMode);
+
+          const projectId = await resolveProjectId(ctx.sdk, project);
+          const needsLabelContext =
+            options.labels && (labelMode === "add" || labelMode === "remove");
+          const projectContext = needsLabelContext
+            ? await getProject(ctx.gql, projectId)
+            : undefined;
+
+          const input: ProjectUpdateInput = {};
+
+          if (options.name) {
+            input.name = options.name;
+          }
+
+          if (options.description) {
+            input.description = options.description;
+          }
+
+          if (options.content) {
+            input.content = options.content;
+          }
+
+          if (options.icon !== undefined) {
+            input.icon = options.icon;
+          }
+
+          if (options.color !== undefined) {
+            input.color = options.color;
+          }
+
+          if (options.clearLead) {
+            input.leadId = null;
+          } else if (options.lead) {
+            input.leadId = await resolveUserId(ctx.sdk, options.lead);
+          }
+
+          if (options.members) {
+            const memberNames = options.members
+              .split(",")
+              .map((m) => m.trim())
+              .filter(Boolean);
+            input.memberIds = await Promise.all(
+              memberNames.map((m) => resolveUserId(ctx.sdk, m)),
+            );
+          }
+
+          if (options.priority) {
+            input.priority = parsePriority(options.priority);
+          }
+
+          if (options.status) {
+            input.statusId = await resolveProjectStatusId(
+              ctx.gql,
+              options.status,
+            );
+          }
+
+          if (options.clearStartDate) {
+            input.startDate = null;
+          } else if (options.startDate) {
+            input.startDate = options.startDate;
+          }
+
+          if (options.clearTargetDate) {
+            input.targetDate = null;
+          } else if (options.targetDate) {
+            input.targetDate = options.targetDate;
+          }
+
+          const teamNames = getUpdateTeamNames(options);
+          if (teamNames) {
+            input.teamIds = await Promise.all(
+              teamNames.map((t) => resolveTeamId(ctx.sdk, t)),
+            );
+          }
+
+          if (options.clearLabels) {
+            input.labelIds = [];
+          } else if (options.labels) {
+            const labelNames = options.labels
+              .split(",")
+              .map((l) => l.trim())
+              .filter(Boolean);
+            const labelIds = await resolveProjectLabelIds(ctx.sdk, labelNames);
+
+            if (labelMode === "add") {
+              const currentLabels = projectContext?.labels?.nodes
+                ? projectContext.labels.nodes.map((l) => l.id)
+                : [];
+              input.labelIds = [...new Set([...currentLabels, ...labelIds])];
+            } else if (labelMode === "remove") {
+              const currentLabels = projectContext?.labels?.nodes
+                ? projectContext.labels.nodes.map((l) => l.id)
+                : [];
+              input.labelIds = currentLabels.filter(
+                (id) => !labelIds.includes(id),
+              );
+            } else {
+              input.labelIds = labelIds;
+            }
+          }
+
+          if (Object.keys(input).length === 0) {
+            throw invalidParameterError(
+              "update options",
+              "at least one option must be provided",
+            );
+          }
+
+          const result = await updateProject(ctx.gql, projectId, input);
+          outputSuccess(result);
+        },
+      ),
     );
 
   projects
     .command("archive <project>")
     .description("archive a project")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [project, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
-        const projectId = await resolveProjectId(ctx.sdk, project);
-        const result = await archiveProject(ctx.gql, projectId);
-        outputSuccess(result);
-      }),
+      commandAction<[string, unknown, Command]>(
+        async (project, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const projectId = await resolveProjectId(ctx.sdk, project);
+          const result = await archiveProject(ctx.gql, projectId);
+          outputSuccess(result);
+        },
+      ),
     );
 
   projects
     .command("unarchive <project>")
     .description("unarchive a project")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [project, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
-        const projectId = await resolveProjectId(ctx.sdk, project, {
-          includeArchived: true,
-        });
-        const result = await unarchiveProject(ctx.gql, projectId);
-        outputSuccess(result);
-      }),
+      commandAction<[string, unknown, Command]>(
+        async (project, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const projectId = await resolveProjectId(ctx.sdk, project, {
+            includeArchived: true,
+          });
+          const result = await unarchiveProject(ctx.gql, projectId);
+          outputSuccess(result);
+        },
+      ),
     );
 
   projects
     .command("delete <project>")
     .description("delete a project")
     .action(
-      handleCommand(async (...args: unknown[]) => {
-        const [project, , command] = args as [string, unknown, Command];
-        const ctx = createContext(getRootOpts(command));
-        const projectId = await resolveProjectId(ctx.sdk, project, {
-          includeArchived: true,
-        });
-        const result = await deleteProject(ctx.gql, projectId);
-        outputSuccess(result);
-      }),
+      commandAction<[string, unknown, Command]>(
+        async (project, _unused1, command) => {
+          const ctx = createContext(getRootOpts(command));
+          const projectId = await resolveProjectId(ctx.sdk, project, {
+            includeArchived: true,
+          });
+          const result = await deleteProject(ctx.gql, projectId);
+          outputSuccess(result);
+        },
+      ),
     );
 
   projects

--- a/src/common/output.ts
+++ b/src/common/output.ts
@@ -124,3 +124,35 @@ export function handleCommand(
     }
   };
 }
+
+/**
+ * Typed wrapper around {@link handleCommand} for Commander action handlers.
+ *
+ * Commander invokes an action with the positional arguments first, followed by
+ * the parsed options object and the `Command` instance. That boundary is
+ * inherently `unknown[]`, so command bodies used to open with a hand-written
+ * tuple cast (`const [issue, options, command] = args as [...]`). Those casts
+ * are invisible to the compiler: if a command signature changes, TypeScript
+ * cannot flag the now-wrong destructuring.
+ *
+ * `commandAction` centralizes the cast in one place. Declare the expected
+ * argument tuple once via the generic parameter and the handler receives fully
+ * typed arguments, while `handleCommand` remains the single error wrapper.
+ *
+ * @example
+ * .action(
+ *   commandAction<[string, ReadOptions, Command]>(
+ *     async (issue, options, command) => {
+ *       const ctx = createContext(getRootOpts(command));
+ *       // ...
+ *     },
+ *   ),
+ * )
+ */
+export function commandAction<TArgs extends readonly unknown[]>(
+  fn: (...args: TArgs) => Promise<void>,
+): (...args: unknown[]) => Promise<void> {
+  return handleCommand(async (...args: unknown[]) => {
+    await fn(...(args as unknown as TArgs));
+  });
+}


### PR DESCRIPTION
## What does this PR do?

Introduces a typed `commandAction<TArgs>` wrapper in `src/common/output.ts` and uses it to replace the repeated Commander action boilerplate (`handleCommand(async (...args: unknown[]) => { const [...] = args as [...] })`) across all issue, project, and initiative commands. The argument tuple is now declared once as a generic parameter and each handler receives typed positional arguments, while `handleCommand` remains the single error wrapper. This is a pure refactor with no behavior change.

Closes #200

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [ ] `npm test` passes (unit tests)
- [ ] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

`npx tsc --noEmit` and `npm run check:ci` both pass. The change is a mechanical conversion; every converted handler preserves the original argument tuple order and positional-argument count.

## Notes for reviewers

`commandAction` is an ergonomic wrapper: the tuple assertion (`as unknown as TArgs`) is centralized in one place rather than repeated in each command body, so handlers get typed parameters without a per-command cast.