### PR TITLE
ci: type-check test files in a dedicated tsc pass

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -60,6 +60,9 @@ jobs:
       - name: TypeScript type check
         run: npx tsc --noEmit
 
+      - name: TypeScript type check (tests)
+        run: npm run typecheck:test
+
   actionlint:
     name: Lint Workflows
     runs-on: ubuntu-latest

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "test:ui": "vitest --ui",
     "test:coverage": "vitest run --coverage",
     "test:commands": "tsx tests/command-coverage.ts",
+    "typecheck:test": "tsc --noEmit -p tsconfig.test.json",
     "generate": "graphql-codegen --config codegen.config.ts",
     "generate:usage": "tsx src/main.ts usage --all > USAGE.md",
     "format": "biome format --write .",

--- a/tests/unit/client/graphql-client.test.ts
+++ b/tests/unit/client/graphql-client.test.ts
@@ -1,6 +1,20 @@
+import type { TypedDocumentNode } from "@graphql-typed-document-node/core";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { GraphQLClient } from "../../../src/client/graphql-client.js";
 import { AuthenticationError } from "../../../src/common/errors.js";
+
+// A stand-in document for the error-path tests. Typing its variables as
+// `Record<string, never>` makes `request`'s variables argument optional, so
+// these calls can invoke it without variables.
+function fakeDocument<TResult = unknown>(): TypedDocumentNode<
+  TResult,
+  Record<string, never>
+> {
+  return { kind: "Document", definitions: [] } as unknown as TypedDocumentNode<
+    TResult,
+    Record<string, never>
+  >;
+}
 
 // We test the error handling logic by mocking the underlying rawRequest
 // The constructor creates a real LinearClient, so we mock at module level
@@ -49,9 +63,7 @@ describe("GraphQLClient", () => {
       });
 
       const client = new GraphQLClient("bad-token");
-      const fakeDoc = { kind: "Document", definitions: [] } as Parameters<
-        typeof client.request
-      >[0];
+      const fakeDoc = fakeDocument();
 
       await expect(client.request(fakeDoc)).rejects.toThrow(
         AuthenticationError,
@@ -66,9 +78,7 @@ describe("GraphQLClient", () => {
       });
 
       const client = new GraphQLClient("bad-token");
-      const fakeDoc = { kind: "Document", definitions: [] } as Parameters<
-        typeof client.request
-      >[0];
+      const fakeDoc = fakeDocument();
 
       await expect(client.request(fakeDoc)).rejects.toThrow(
         AuthenticationError,
@@ -83,9 +93,7 @@ describe("GraphQLClient", () => {
       });
 
       const client = new GraphQLClient("good-token");
-      const fakeDoc = { kind: "Document", definitions: [] } as Parameters<
-        typeof client.request
-      >[0];
+      const fakeDoc = fakeDocument();
 
       try {
         await client.request(fakeDoc);
@@ -101,9 +109,7 @@ describe("GraphQLClient", () => {
       mockRawRequest.mockResolvedValueOnce({ data: undefined });
 
       const client = new GraphQLClient("good-token");
-      const fakeDoc = { kind: "Document", definitions: [] } as Parameters<
-        typeof client.request
-      >[0];
+      const fakeDoc = fakeDocument();
 
       await expect(client.request(fakeDoc)).rejects.toThrow(
         "GraphQL response contained no data",
@@ -116,11 +122,9 @@ describe("GraphQLClient", () => {
         mockRawRequest.mockResolvedValueOnce({ data: { ok: true } });
 
         const client = new GraphQLClient("good-token");
-        const fakeDoc = { kind: "Document", definitions: [] } as Parameters<
-          typeof client.request
-        >[0];
+        const fakeDoc = fakeDocument<{ ok: boolean }>();
 
-        const result = await client.request<{ ok: boolean }>(fakeDoc);
+        const result = await client.request(fakeDoc);
 
         expect(result).toEqual({ ok: true });
         expect(vi.getTimerCount()).toBe(0);
@@ -139,9 +143,7 @@ describe("GraphQLClient", () => {
         });
 
         const client = new GraphQLClient("good-token");
-        const fakeDoc = { kind: "Document", definitions: [] } as Parameters<
-          typeof client.request
-        >[0];
+        const fakeDoc = fakeDocument();
 
         await expect(client.request(fakeDoc)).rejects.toThrow(
           "Entity not found",
@@ -165,9 +167,7 @@ describe("GraphQLClient", () => {
         });
 
         const client = new GraphQLClient("good-token");
-        const fakeDoc = { kind: "Document", definitions: [] } as Parameters<
-          typeof client.request
-        >[0];
+        const fakeDoc = fakeDocument();
 
         const promise = client.request(fakeDoc);
         const rejection = expect(promise).rejects.toThrow("Request timed out");
@@ -188,9 +188,7 @@ describe("GraphQLClient", () => {
         .mockResolvedValueOnce({ data: { foo: "bar" } });
 
       const client = new GraphQLClient("good-token");
-      const fakeDoc = { kind: "Document", definitions: [] } as Parameters<
-        typeof client.request
-      >[0];
+      const fakeDoc = fakeDocument();
 
       vi.useFakeTimers();
       try {
@@ -215,9 +213,7 @@ describe("GraphQLClient", () => {
           .mockResolvedValueOnce({ data: { foo: "bar" } });
 
         const client = new GraphQLClient("good-token");
-        const fakeDoc = { kind: "Document", definitions: [] } as Parameters<
-          typeof client.request
-        >[0];
+        const fakeDoc = fakeDocument();
 
         const promise = client.request(fakeDoc);
 

--- a/tests/unit/services/initiative-service.test.ts
+++ b/tests/unit/services/initiative-service.test.ts
@@ -72,7 +72,7 @@ describe("listInitiatives", () => {
       after: "cursor-1",
       includeArchived: true,
       filter: { name: { eqIgnoreCase: "Growth" } },
-      orderBy: { createdAt: "Asc" },
+      orderBy: "createdAt",
     });
 
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
@@ -80,7 +80,7 @@ describe("listInitiatives", () => {
       after: "cursor-1",
       includeArchived: true,
       filter: { name: { eqIgnoreCase: "Growth" } },
-      orderBy: { createdAt: "Asc" },
+      orderBy: "createdAt",
       sort: undefined,
     });
   });

--- a/tests/unit/services/issue-service.test.ts
+++ b/tests/unit/services/issue-service.test.ts
@@ -367,7 +367,7 @@ describe("getIssueByIdentifierWithComments", () => {
     });
     const result = await getIssueByIdentifierWithComments(client, "ENG", 42);
 
-    expect(result.comments.nodes[0].user.displayName).toBe("Ada");
+    expect(result.comments.nodes[0].user?.displayName).toBe("Ada");
     expect(client.request).toHaveBeenCalledWith(
       GetIssueByIdentifierWithCommentsDocument,
       {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -25,9 +25,9 @@
   "exclude": [
     "node_modules",
     "dist",
-    // Tests excluded from TypeScript compilation to prevent them from
-    // being compiled into dist/. Tests are type-checked and validated
-    // by Vitest at runtime, which provides sufficient type safety.
+    // Tests are excluded from the *build* so they are never emitted into
+    // dist/. They are NOT unchecked: tsconfig.test.json runs a dedicated
+    // `tsc --noEmit` over src + tests (see the "typecheck:test" script and CI).
     "tests",
     "**/*.test.ts",
     "**/*.spec.ts",

--- a/tsconfig.test.json
+++ b/tsconfig.test.json
@@ -1,0 +1,21 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": ".",
+    "noEmit": true,
+    // Allow importing the plain-CommonJS release scripts (scripts/release/*.cjs)
+    // from their tests without a declaration file.
+    "allowJs": true,
+    "types": ["node"]
+  },
+  "include": [
+    "src/**/*",
+    "tests/**/*",
+    "vitest.config.ts",
+    "vitest.base.config.ts",
+    "vitest.integration.config.ts"
+  ],
+  // Override the base config's exclude (which drops tests/ and *.test.ts) so
+  // the test files listed in "include" are actually type-checked here.
+  "exclude": ["node_modules", "dist"]
+}


### PR DESCRIPTION
## What does this PR do?

Test files were excluded from `tsconfig.json` (to keep them out of `dist/`) and were therefore never type-checked by `tsc`. This adds a dedicated `tsconfig.test.json` plus a `typecheck:test` npm script, wired into CI, so type errors in tests now fail the build. Enabling the check surfaced pre-existing type errors in tests that had drifted from the code they exercise (the `request()` variables-argument signature, `orderBy` being a `PaginationOrderBy` string, and a nullable `comment.user`), which are fixed here.

Closes #198

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Tests
- [x] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `npm run typecheck:test` — exit 0 (now covers 68 test files that were previously unchecked; fails on injected test type errors as expected)
- `npx tsc --noEmit` — exit 0
- `npm run check:ci` — exit 0
- `npm test` — 829 tests passed across 60 files

## Notes for reviewers

`allowJs` is enabled in `tsconfig.test.json` so the tests can import the plain-CommonJS release scripts (`scripts/release/*.cjs`) without a declaration file; `noEmit` keeps the pass check-only.