### PR TITLE
refactor(services): move filter/input construction into service layer

### DIFF
--- a/src/commands/attachments.ts
+++ b/src/commands/attachments.ts
@@ -3,12 +3,10 @@ import { createContext, getRootOpts } from "../common/context.js";
 import { invalidParameterError } from "../common/errors.js";
 import { handleCommand, outputSuccess } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
-import type {
-  AttachmentCreateInput,
-  AttachmentFilter,
-} from "../gql/graphql.js";
 import { resolveIssueId } from "../resolvers/issue-resolver.js";
 import {
+  buildAttachmentFilter,
+  type CreateAttachmentInput,
   createAttachment,
   deleteAttachment,
   listAttachments,
@@ -67,29 +65,6 @@ function resolveIssueArgument(
   return issue;
 }
 
-function buildAttachmentFilter(
-  options: ListOptions,
-): AttachmentFilter | undefined {
-  const filters: AttachmentFilter[] = [];
-
-  if (options.sourceType) {
-    filters.push({ sourceType: { eq: options.sourceType } });
-  }
-  if (options.title) {
-    filters.push({ title: { eqIgnoreCase: options.title } });
-  }
-  if (options.createdAfter) {
-    filters.push({ createdAt: { gte: options.createdAfter } });
-  }
-  if (options.createdBefore) {
-    filters.push({ createdAt: { lt: options.createdBefore } });
-  }
-
-  if (filters.length === 0) return undefined;
-  if (filters.length === 1) return filters[0];
-  return { and: filters };
-}
-
 export function setupAttachmentsCommands(program: Command): void {
   const attachments = program
     .command("attachments")
@@ -143,7 +118,7 @@ export function setupAttachmentsCommands(program: Command): void {
         const issueIdentifier = resolveIssueArgument(issue, options.issue);
         const ctx = createContext(getRootOpts(command));
         const issueId = await resolveIssueId(ctx.sdk, issueIdentifier);
-        const input: AttachmentCreateInput = {
+        const input: CreateAttachmentInput = {
           issueId,
           title: options.title,
           url: options.url,

--- a/src/commands/documents.ts
+++ b/src/commands/documents.ts
@@ -3,16 +3,18 @@ import { createContext, getRootOpts } from "../common/context.js";
 import { invalidParameterError } from "../common/errors.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
-import type { DocumentFilter, DocumentUpdateInput } from "../gql/graphql.js";
 import { resolveIssueId } from "../resolvers/issue-resolver.js";
 import { resolveProjectId } from "../resolvers/project-resolver.js";
 import { resolveTeamId } from "../resolvers/team-resolver.js";
 import { listAttachments } from "../services/attachment-service.js";
 import {
+  buildIssueDocumentFilter,
+  buildProjectDocumentFilter,
   createDocument,
   deleteDocument,
   getDocument,
   listDocuments,
+  type UpdateDocumentInput,
   updateDocument,
 } from "../services/document-service.js";
 
@@ -69,25 +71,6 @@ function extractDocumentIdFromUrl(url: string): string | null {
   }
 }
 
-function buildIssueDocumentFilter(
-  issueId: string,
-  legacyDocumentSlugIds: string[],
-): DocumentFilter {
-  const issueFilter: DocumentFilter = { issue: { id: { eq: issueId } } };
-  if (legacyDocumentSlugIds.length === 0) {
-    return issueFilter;
-  }
-
-  return {
-    or: [
-      issueFilter,
-      ...legacyDocumentSlugIds.map((slugId) => ({
-        slugId: { eq: slugId },
-      })),
-    ],
-  };
-}
-
 export const DOCUMENTS_META: DomainMeta = {
   name: "documents",
   summary: "long-form markdown docs attached to projects or issues",
@@ -142,9 +125,9 @@ export function setupDocumentsCommands(program: Command): void {
           issueId = await resolveIssueId(ctx.sdk, options.issue);
         }
 
-        let filter: DocumentFilter | undefined;
+        let filter: ReturnType<typeof buildIssueDocumentFilter> | undefined;
         if (projectId) {
-          filter = { project: { id: { eq: projectId } } };
+          filter = buildProjectDocumentFilter(projectId);
         } else if (issueId) {
           const attachments = await listAttachments(ctx.gql, issueId);
           const legacyDocumentSlugIds = [
@@ -248,7 +231,7 @@ export function setupDocumentsCommands(program: Command): void {
         const rootOpts = getRootOpts(command);
         const ctx = createContext(rootOpts);
 
-        const input: DocumentUpdateInput = {};
+        const input: UpdateDocumentInput = {};
         if (options.title) input.title = options.title;
         if (options.content) input.content = options.content;
         if (options.project) {

--- a/src/commands/initiatives/entity.ts
+++ b/src/commands/initiatives/entity.ts
@@ -8,14 +8,6 @@ import {
   outputSuccess,
   parseLimit,
 } from "../../common/output.js";
-import type {
-  InitiativeCreateInput,
-  InitiativeSortInput,
-  InitiativeStatus,
-  InitiativeUpdateInput,
-  ListInitiativesQueryVariables,
-  PaginationOrderBy,
-} from "../../gql/graphql.js";
 import { resolveInitiativeId } from "../../resolvers/initiative-resolver.js";
 import { resolveTeamId } from "../../resolvers/team-resolver.js";
 import { resolveUserId } from "../../resolvers/user-resolver.js";
@@ -38,10 +30,18 @@ import {
 } from "../../services/discussion-service.js";
 import {
   archiveInitiative,
+  buildInitiativeFilter,
+  type CreateInitiativeInput,
   createInitiative,
   deleteInitiative,
   getInitiative,
+  type InitiativeFilterInput,
+  type InitiativeSortBy,
   listInitiatives,
+  mapSortByToInitiativeSort,
+  mapSortByToPaginationOrderBy,
+  parseInitiativeStatus,
+  type UpdateInitiativeInput,
   unarchiveInitiative,
   updateInitiative,
 } from "../../services/initiative-service.js";
@@ -187,16 +187,6 @@ interface InitiativeUpdateOptions {
   sortOrder?: string;
 }
 
-type InitiativeSortBy =
-  | "name"
-  | "createdAt"
-  | "updatedAt"
-  | "targetDate"
-  | "health"
-  | "healthUpdatedAt"
-  | "manual"
-  | "owner";
-
 function parseSortOrder(value?: string): "asc" | "desc" | undefined {
   if (!value) return undefined;
   const normalized = value.toLowerCase();
@@ -226,60 +216,6 @@ function parseSortBy(value?: string): InitiativeSortBy | undefined {
   );
 }
 
-function mapSortByToPaginationOrderBy(
-  sortBy?: InitiativeSortBy,
-): PaginationOrderBy | undefined {
-  return sortBy === "createdAt" || sortBy === "updatedAt" ? sortBy : undefined;
-}
-
-function mapSortByToInitiativeSort(
-  sortBy?: InitiativeSortBy,
-  sortOrder?: "asc" | "desc",
-): ListInitiativesQueryVariables["sort"] | undefined {
-  if (!sortBy) return undefined;
-
-  const withNulls = {
-    order: sortOrder === "desc" ? "Descending" : "Ascending",
-    nulls: "last",
-  } as const;
-
-  const sortEntry: InitiativeSortInput =
-    sortBy === "manual"
-      ? { manual: withNulls }
-      : sortBy === "name"
-        ? { name: withNulls }
-        : sortBy === "createdAt"
-          ? { createdAt: withNulls }
-          : sortBy === "updatedAt"
-            ? { updatedAt: withNulls }
-            : sortBy === "targetDate"
-              ? { targetDate: withNulls }
-              : sortBy === "health"
-                ? { health: withNulls }
-                : sortBy === "healthUpdatedAt"
-                  ? { healthUpdatedAt: withNulls }
-                  : { owner: withNulls };
-
-  return [sortEntry];
-}
-
-const INITIATIVE_STATUS_VALUES = ["Planned", "Active", "Completed"] as const;
-
-function parseInitiativeStatus(value?: string): InitiativeStatus | undefined {
-  if (!value) return undefined;
-
-  const normalized = value.toLowerCase();
-  const match = INITIATIVE_STATUS_VALUES.find(
-    (status) => status.toLowerCase() === normalized,
-  );
-  if (match) return match;
-
-  throw invalidParameterError(
-    "--status",
-    'must be one of: "Planned", "Active", "Completed"',
-  );
-}
-
 function parseSortOrderNumber(value?: string): number | undefined {
   if (value === undefined) return undefined;
   const parsed = Number.parseFloat(value);
@@ -290,19 +226,6 @@ function parseSortOrderNumber(value?: string): number | undefined {
     );
   }
   return parsed;
-}
-
-function applyNullableDateRange(
-  target: { gte?: string | null; lte?: string | null },
-  after?: string,
-  before?: string,
-): void {
-  if (after !== undefined) {
-    target.gte = after;
-  }
-  if (before !== undefined) {
-    target.lte = before;
-  }
 }
 
 function getExpandFlags(options: InitiativeExpandOptions): string[] {
@@ -319,102 +242,10 @@ function getExpandFlags(options: InitiativeExpandOptions): string[] {
   return map.filter(([enabled]) => enabled).map(([, flag]) => flag);
 }
 
-async function buildInitiativeFilter(
+async function resolveInitiativeFilterInput(
   sdk: LinearSdkClient,
   options: InitiativeListOptions,
-): Promise<ListInitiativesQueryVariables["filter"] | undefined> {
-  const filter: NonNullable<ListInitiativesQueryVariables["filter"]> = {};
-
-  if (options.id) {
-    filter.id = { eq: options.id };
-  }
-
-  if (options.slug) {
-    filter.slugId = { eqIgnoreCase: options.slug };
-  }
-
-  if (options.name) {
-    filter.name = { eqIgnoreCase: options.name };
-  }
-
-  const status = parseInitiativeStatus(options.status);
-  if (status) {
-    filter.status = { eq: status };
-  }
-
-  if (options.health) {
-    filter.health = { eq: options.health };
-  }
-
-  if (options.healthWithAge) {
-    filter.healthWithAge = { eq: options.healthWithAge };
-  }
-
-  if (options.owner) {
-    const ownerId = await resolveUserId(sdk, options.owner);
-    filter.owner = { id: { eq: ownerId } };
-  }
-
-  if (options.creator) {
-    const creatorId = await resolveUserId(sdk, options.creator);
-    filter.creator = { id: { eq: creatorId } };
-  }
-
-  if (options.team) {
-    const teamId = await resolveTeamId(sdk, options.team);
-    filter.teams = { some: { id: { eq: teamId } } };
-  }
-
-  if (options.targetAfter || options.targetBefore) {
-    filter.targetDate = {};
-    applyNullableDateRange(
-      filter.targetDate,
-      options.targetAfter,
-      options.targetBefore,
-    );
-  }
-
-  if (options.startedAfter || options.startedBefore) {
-    filter.startedAt = {};
-    applyNullableDateRange(
-      filter.startedAt,
-      options.startedAfter,
-      options.startedBefore,
-    );
-  }
-
-  if (options.completedAfter || options.completedBefore) {
-    filter.completedAt = {};
-    applyNullableDateRange(
-      filter.completedAt,
-      options.completedAfter,
-      options.completedBefore,
-    );
-  }
-
-  if (options.createdAfter || options.createdBefore) {
-    filter.createdAt = {};
-    applyNullableDateRange(
-      filter.createdAt,
-      options.createdAfter,
-      options.createdBefore,
-    );
-  }
-
-  if (options.updatedAfter || options.updatedBefore) {
-    filter.updatedAt = {};
-    applyNullableDateRange(
-      filter.updatedAt,
-      options.updatedAfter,
-      options.updatedBefore,
-    );
-  }
-
-  if (options.ancestor) {
-    const ancestorId = await resolveInitiativeId(sdk, options.ancestor);
-    filter.ancestors = { some: { id: { eq: ancestorId } } };
-  }
-
+): Promise<InitiativeFilterInput> {
   if (options.parent) {
     throw invalidParameterError(
       "--parent",
@@ -422,7 +253,42 @@ async function buildInitiativeFilter(
     );
   }
 
-  return Object.keys(filter).length > 0 ? filter : undefined;
+  const input: InitiativeFilterInput = {
+    id: options.id,
+    slug: options.slug,
+    name: options.name,
+    status: parseInitiativeStatus(options.status),
+    health: options.health,
+    healthWithAge: options.healthWithAge,
+    targetAfter: options.targetAfter,
+    targetBefore: options.targetBefore,
+    startedAfter: options.startedAfter,
+    startedBefore: options.startedBefore,
+    completedAfter: options.completedAfter,
+    completedBefore: options.completedBefore,
+    createdAfter: options.createdAfter,
+    createdBefore: options.createdBefore,
+    updatedAfter: options.updatedAfter,
+    updatedBefore: options.updatedBefore,
+  };
+
+  if (options.owner) {
+    input.ownerId = await resolveUserId(sdk, options.owner);
+  }
+
+  if (options.creator) {
+    input.creatorId = await resolveUserId(sdk, options.creator);
+  }
+
+  if (options.team) {
+    input.teamId = await resolveTeamId(sdk, options.team);
+  }
+
+  if (options.ancestor) {
+    input.ancestorId = await resolveInitiativeId(sdk, options.ancestor);
+  }
+
+  return input;
 }
 
 export function setupInitiativeEntityCommands(initiatives: Command): void {
@@ -497,7 +363,11 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           const orderBy = mapSortByToPaginationOrderBy(sortBy);
           const sort = mapSortByToInitiativeSort(sortBy, sortOrder);
 
-          const filter = await buildInitiativeFilter(ctx.sdk, options);
+          const filterInput = await resolveInitiativeFilterInput(
+            ctx.sdk,
+            options,
+          );
+          const filter = buildInitiativeFilter(filterInput);
 
           const result = await listInitiatives(ctx.gql, {
             limit: parseLimit(options.limit),
@@ -815,7 +685,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
         async (name, options, command) => {
           const ctx = createContext(getRootOpts(command));
 
-          const input: InitiativeCreateInput = { name };
+          const input: CreateInitiativeInput = { name };
 
           if (options.description !== undefined) {
             input.description = options.description;
@@ -865,7 +735,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           const ctx = createContext(getRootOpts(command));
           const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
 
-          const input: InitiativeUpdateInput = {};
+          const input: UpdateInitiativeInput = {};
 
           if (options.name !== undefined) {
             input.name = options.name;

--- a/src/commands/initiatives/updates.ts
+++ b/src/commands/initiatives/updates.ts
@@ -6,17 +6,15 @@ import {
   outputSuccess,
   parseLimit,
 } from "../../common/output.js";
-import type {
-  InitiativeUpdateCreateInput,
-  InitiativeUpdateHealthType,
-  InitiativeUpdateUpdateInput,
-} from "../../gql/graphql.js";
 import { resolveInitiativeId } from "../../resolvers/initiative-resolver.js";
 import {
   archiveInitiativeUpdate,
+  type CreateInitiativeUpdateInput,
   createInitiativeUpdate,
   getInitiativeUpdate,
   listInitiativeUpdates,
+  parseHealth,
+  type UpdateInitiativeUpdateInput,
   unarchiveInitiativeUpdate,
   updateInitiativeUpdate,
 } from "../../services/initiative-update-service.js";
@@ -37,20 +35,6 @@ interface InitiativeUpdatesCreateOptions {
 interface InitiativeUpdatesUpdateOptions {
   body?: string;
   health?: string;
-}
-
-function parseHealth(value?: string): InitiativeUpdateHealthType | undefined {
-  if (!value) return undefined;
-
-  const normalized = value.trim().toLowerCase();
-  if (normalized === "ontrack") return "onTrack";
-  if (normalized === "atrisk") return "atRisk";
-  if (normalized === "offtrack") return "offTrack";
-
-  throw invalidParameterError(
-    "--health",
-    'must be one of: "onTrack", "atRisk", "offTrack"',
-  );
 }
 
 export function setupInitiativeUpdateCommands(initiatives: Command): void {
@@ -122,7 +106,7 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
           options.initiative,
         );
 
-        const input: InitiativeUpdateCreateInput = { initiativeId };
+        const input: CreateInitiativeUpdateInput = { initiativeId };
 
         if (options.body !== undefined) {
           input.body = options.body;
@@ -152,7 +136,7 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
         ];
         const ctx = createContext(getRootOpts(command));
 
-        const input: InitiativeUpdateUpdateInput = {};
+        const input: UpdateInitiativeUpdateInput = {};
 
         if (options.body !== undefined) {
           input.body = options.body;

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -18,11 +18,7 @@ import {
 import { commandAction, outputSuccess, parseLimit } from "../common/output.js";
 import { resolveFilterOptions } from "../common/resolve-filters.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
-import type {
-  IssueCreateInput,
-  IssueRelationType,
-  IssueUpdateInput,
-} from "../gql/graphql.js";
+import type { IssueRelationType } from "../gql/graphql.js";
 import { resolveCycleId } from "../resolvers/cycle-resolver.js";
 import {
   resolveIssueEstimateContext,
@@ -63,6 +59,7 @@ import {
 } from "../services/issue-relation-service.js";
 import {
   archiveIssue,
+  type CreateIssueInput,
   createIssue,
   deleteIssue,
   getIssue,
@@ -77,6 +74,7 @@ import {
   getIssueWithReactions,
   listIssues,
   searchIssues,
+  type UpdateIssueInput,
   unarchiveIssue,
   updateIssue,
 } from "../services/issue-service.js";
@@ -1140,7 +1138,7 @@ export function setupIssuesCommands(program: Command): void {
             });
           }
 
-          const input: IssueCreateInput = {
+          const input: CreateIssueInput = {
             title,
             teamId,
           };
@@ -1342,7 +1340,7 @@ export function setupIssuesCommands(program: Command): void {
             ? await getIssue(ctx.gql, resolvedIssueId)
             : undefined;
 
-          const input: IssueUpdateInput = {};
+          const input: UpdateIssueInput = {};
 
           if (options.title) {
             input.title = options.title;

--- a/src/commands/labels.ts
+++ b/src/commands/labels.ts
@@ -7,16 +7,13 @@ import {
 import { invalidParameterError } from "../common/errors.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
-import type {
-  IssueLabelCreateInput,
-  IssueLabelUpdateInput,
-} from "../gql/graphql.js";
 import {
   type LabelResolverScope,
   resolveLabelId,
 } from "../resolvers/label-resolver.js";
 import { resolveTeamId } from "../resolvers/team-resolver.js";
 import {
+  type CreateLabelInput,
   createLabel,
   deleteLabel,
   getLabel,
@@ -24,6 +21,7 @@ import {
   type LabelType,
   listLabels,
   listProjectLabels,
+  type UpdateLabelInput,
   updateLabel,
 } from "../services/label-service.js";
 
@@ -113,8 +111,8 @@ async function resolveIssueLabelLookup(
   return { ctx, labelId };
 }
 
-function buildUpdateInput(options: UpdateLabelOptions): IssueLabelUpdateInput {
-  const input: IssueLabelUpdateInput = {};
+function buildUpdateInput(options: UpdateLabelOptions): UpdateLabelInput {
+  const input: UpdateLabelInput = {};
   const color = parseLabelColor(options.color);
 
   if (options.name) {
@@ -240,7 +238,7 @@ export function setupLabelsCommands(program: Command): void {
         ];
         const ctx = createContext(getRootOpts(command));
 
-        const input: IssueLabelCreateInput = { name };
+        const input: CreateLabelInput = { name };
         const color = parseLabelColor(options.color);
 
         if (options.team) {

--- a/src/commands/milestones.ts
+++ b/src/commands/milestones.ts
@@ -2,13 +2,13 @@ import type { Command } from "commander";
 import { createContext, getRootOpts } from "../common/context.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
-import type { ProjectMilestoneUpdateInput } from "../gql/graphql.js";
 import { resolveMilestoneId } from "../resolvers/milestone-resolver.js";
 import { resolveProjectId } from "../resolvers/project-resolver.js";
 import {
   createMilestone,
   getMilestone,
   listMilestones,
+  type UpdateMilestoneInput,
   updateMilestone,
 } from "../services/milestone-service.js";
 
@@ -177,7 +177,7 @@ export function setupMilestonesCommands(program: Command): void {
         );
 
         // Build update input (only include provided fields)
-        const updateInput: ProjectMilestoneUpdateInput = {};
+        const updateInput: UpdateMilestoneInput = {};
         if (options.name !== undefined) updateInput.name = options.name;
         if (options.description !== undefined) {
           updateInput.description = options.description;

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -5,7 +5,6 @@ import { resolveReactionEmojiInput } from "../common/emoji.js";
 import { invalidParameterError } from "../common/errors.js";
 import { commandAction, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
-import type { ProjectCreateInput, ProjectUpdateInput } from "../gql/graphql.js";
 import {
   resolveProjectId,
   resolveProjectLabelIds,
@@ -32,10 +31,12 @@ import {
 } from "../services/discussion-service.js";
 import {
   archiveProject,
+  type CreateProjectInput,
   createProject,
   deleteProject,
   getProject,
   listProjects,
+  type UpdateProjectInput,
   unarchiveProject,
   updateProject,
 } from "../services/project-service.js";
@@ -577,7 +578,7 @@ export function setupProjectsCommands(program: Command): void {
             teamNames.map((t) => resolveTeamId(ctx.sdk, t)),
           );
 
-          const input: ProjectCreateInput = {
+          const input: CreateProjectInput = {
             name,
             teamIds,
           };
@@ -723,7 +724,7 @@ export function setupProjectsCommands(program: Command): void {
             ? await getProject(ctx.gql, projectId)
             : undefined;
 
-          const input: ProjectUpdateInput = {};
+          const input: UpdateProjectInput = {};
 
           if (options.name) {
             input.name = options.name;

--- a/src/services/attachment-service.ts
+++ b/src/services/attachment-service.ts
@@ -15,11 +15,50 @@ export type AttachmentListItem =
 export type CreatedAttachment =
   AttachmentCreateMutation["attachmentCreate"]["attachment"];
 
+// Service-owned input type (UUIDs pre-resolved by the command).
+export type CreateAttachmentInput = Pick<
+  AttachmentCreateInput,
+  "issueId" | "title" | "url" | "subtitle" | "commentBody" | "iconUrl"
+>;
+
+export interface AttachmentFilterOptions {
+  sourceType?: string;
+  title?: string;
+  createdAfter?: string;
+  createdBefore?: string;
+}
+
+export function buildAttachmentFilter(
+  options: AttachmentFilterOptions,
+): AttachmentFilter | undefined {
+  const filters: AttachmentFilter[] = [];
+
+  if (options.sourceType) {
+    filters.push({ sourceType: { eq: options.sourceType } });
+  }
+  if (options.title) {
+    filters.push({ title: { eqIgnoreCase: options.title } });
+  }
+  if (options.createdAfter) {
+    filters.push({ createdAt: { gte: options.createdAfter } });
+  }
+  if (options.createdBefore) {
+    filters.push({ createdAt: { lt: options.createdBefore } });
+  }
+
+  if (filters.length === 0) return undefined;
+  if (filters.length === 1) return filters[0];
+  return { and: filters };
+}
+
 export async function createAttachment(
   client: GraphQLClient,
-  input: AttachmentCreateInput,
+  input: CreateAttachmentInput,
 ): Promise<CreatedAttachment> {
-  const result = await client.request(AttachmentCreateDocument, { input });
+  const gqlInput: AttachmentCreateInput = input;
+  const result = await client.request(AttachmentCreateDocument, {
+    input: gqlInput,
+  });
 
   if (!result.attachmentCreate.success || !result.attachmentCreate.attachment) {
     throw new Error("Failed to create attachment");

--- a/src/services/document-service.ts
+++ b/src/services/document-service.ts
@@ -23,6 +23,39 @@ export type CreatedDocument =
 export type UpdatedDocument =
   DocumentUpdateMutation["documentUpdate"]["document"];
 
+// Service-owned input types (UUIDs pre-resolved by the command).
+export type CreateDocumentInput = Pick<
+  DocumentCreateInput,
+  "title" | "content" | "projectId" | "teamId" | "issueId" | "icon" | "color"
+>;
+export type UpdateDocumentInput = Pick<
+  DocumentUpdateInput,
+  "title" | "content" | "projectId" | "icon" | "color"
+>;
+
+export function buildProjectDocumentFilter(projectId: string): DocumentFilter {
+  return { project: { id: { eq: projectId } } };
+}
+
+export function buildIssueDocumentFilter(
+  issueId: string,
+  legacyDocumentSlugIds: string[],
+): DocumentFilter {
+  const issueFilter: DocumentFilter = { issue: { id: { eq: issueId } } };
+  if (legacyDocumentSlugIds.length === 0) {
+    return issueFilter;
+  }
+
+  return {
+    or: [
+      issueFilter,
+      ...legacyDocumentSlugIds.map((slugId) => ({
+        slugId: { eq: slugId },
+      })),
+    ],
+  };
+}
+
 export async function getDocument(
   client: GraphQLClient,
   id: string,
@@ -40,9 +73,12 @@ export async function getDocument(
 
 export async function createDocument(
   client: GraphQLClient,
-  input: DocumentCreateInput,
+  input: CreateDocumentInput,
 ): Promise<CreatedDocument> {
-  const result = await client.request(DocumentCreateDocument, { input });
+  const gqlInput: DocumentCreateInput = input;
+  const result = await client.request(DocumentCreateDocument, {
+    input: gqlInput,
+  });
 
   if (!result.documentCreate.success || !result.documentCreate.document) {
     throw new Error("Failed to create document");
@@ -54,9 +90,13 @@ export async function createDocument(
 export async function updateDocument(
   client: GraphQLClient,
   id: string,
-  input: DocumentUpdateInput,
+  input: UpdateDocumentInput,
 ): Promise<UpdatedDocument> {
-  const result = await client.request(DocumentUpdateDocument, { id, input });
+  const gqlInput: DocumentUpdateInput = input;
+  const result = await client.request(DocumentUpdateDocument, {
+    id,
+    input: gqlInput,
+  });
 
   if (!result.documentUpdate.success || !result.documentUpdate.document) {
     throw new Error("Failed to update document");

--- a/src/services/initiative-service.ts
+++ b/src/services/initiative-service.ts
@@ -11,10 +11,13 @@ import {
   GetInitiativeDocument,
   type GetInitiativeQuery,
   type InitiativeCreateInput,
+  type InitiativeSortInput,
+  type InitiativeStatus,
   type InitiativeUpdateInput,
   ListInitiativesDocument,
   type ListInitiativesQuery,
   type ListInitiativesQueryVariables,
+  type PaginationOrderBy,
   UnarchiveInitiativeDocument,
   type UnarchiveInitiativeMutation,
   UpdateInitiativeDocument,
@@ -41,6 +44,225 @@ export type DeletedInitiative = {
   id: NonNullable<DeleteInitiativeMutation["initiativeDelete"]["entityId"]>;
   success: true;
 };
+
+// Service-owned input types (UUIDs pre-resolved by the command).
+export type CreateInitiativeInput = Pick<
+  InitiativeCreateInput,
+  | "name"
+  | "description"
+  | "content"
+  | "ownerId"
+  | "status"
+  | "targetDate"
+  | "sortOrder"
+>;
+export type UpdateInitiativeInput = Pick<
+  InitiativeUpdateInput,
+  | "name"
+  | "description"
+  | "content"
+  | "ownerId"
+  | "status"
+  | "targetDate"
+  | "sortOrder"
+>;
+
+export type InitiativeSortBy =
+  | "name"
+  | "createdAt"
+  | "updatedAt"
+  | "targetDate"
+  | "health"
+  | "healthUpdatedAt"
+  | "manual"
+  | "owner";
+
+const INITIATIVE_STATUS_VALUES = ["Planned", "Active", "Completed"] as const;
+
+export function parseInitiativeStatus(
+  value?: string,
+): InitiativeStatus | undefined {
+  if (!value) return undefined;
+
+  const normalized = value.toLowerCase();
+  const match = INITIATIVE_STATUS_VALUES.find(
+    (status) => status.toLowerCase() === normalized,
+  );
+  if (match) return match;
+
+  throw invalidParameterError(
+    "--status",
+    'must be one of: "Planned", "Active", "Completed"',
+  );
+}
+
+export function mapSortByToPaginationOrderBy(
+  sortBy?: InitiativeSortBy,
+): PaginationOrderBy | undefined {
+  return sortBy === "createdAt" || sortBy === "updatedAt" ? sortBy : undefined;
+}
+
+export function mapSortByToInitiativeSort(
+  sortBy?: InitiativeSortBy,
+  sortOrder?: "asc" | "desc",
+): ListInitiativesQueryVariables["sort"] | undefined {
+  if (!sortBy) return undefined;
+
+  const withNulls = {
+    order: sortOrder === "desc" ? "Descending" : "Ascending",
+    nulls: "last",
+  } as const;
+
+  const sortEntry: InitiativeSortInput =
+    sortBy === "manual"
+      ? { manual: withNulls }
+      : sortBy === "name"
+        ? { name: withNulls }
+        : sortBy === "createdAt"
+          ? { createdAt: withNulls }
+          : sortBy === "updatedAt"
+            ? { updatedAt: withNulls }
+            : sortBy === "targetDate"
+              ? { targetDate: withNulls }
+              : sortBy === "health"
+                ? { health: withNulls }
+                : sortBy === "healthUpdatedAt"
+                  ? { healthUpdatedAt: withNulls }
+                  : { owner: withNulls };
+
+  return [sortEntry];
+}
+
+// Filter input carrying pre-resolved UUIDs and a parsed status; the command
+// resolves human-friendly IDs before calling buildInitiativeFilter.
+export interface InitiativeFilterInput {
+  id?: string;
+  slug?: string;
+  name?: string;
+  status?: InitiativeStatus;
+  health?: string;
+  healthWithAge?: string;
+  ownerId?: string;
+  creatorId?: string;
+  teamId?: string;
+  targetAfter?: string;
+  targetBefore?: string;
+  startedAfter?: string;
+  startedBefore?: string;
+  completedAfter?: string;
+  completedBefore?: string;
+  createdAfter?: string;
+  createdBefore?: string;
+  updatedAfter?: string;
+  updatedBefore?: string;
+  ancestorId?: string;
+}
+
+function applyNullableDateRange(
+  target: { gte?: string | null; lte?: string | null },
+  after?: string,
+  before?: string,
+): void {
+  if (after !== undefined) {
+    target.gte = after;
+  }
+  if (before !== undefined) {
+    target.lte = before;
+  }
+}
+
+export function buildInitiativeFilter(
+  input: InitiativeFilterInput,
+): ListInitiativesQueryVariables["filter"] | undefined {
+  const filter: NonNullable<ListInitiativesQueryVariables["filter"]> = {};
+
+  if (input.id) {
+    filter.id = { eq: input.id };
+  }
+
+  if (input.slug) {
+    filter.slugId = { eqIgnoreCase: input.slug };
+  }
+
+  if (input.name) {
+    filter.name = { eqIgnoreCase: input.name };
+  }
+
+  if (input.status) {
+    filter.status = { eq: input.status };
+  }
+
+  if (input.health) {
+    filter.health = { eq: input.health };
+  }
+
+  if (input.healthWithAge) {
+    filter.healthWithAge = { eq: input.healthWithAge };
+  }
+
+  if (input.ownerId) {
+    filter.owner = { id: { eq: input.ownerId } };
+  }
+
+  if (input.creatorId) {
+    filter.creator = { id: { eq: input.creatorId } };
+  }
+
+  if (input.teamId) {
+    filter.teams = { some: { id: { eq: input.teamId } } };
+  }
+
+  if (input.targetAfter || input.targetBefore) {
+    filter.targetDate = {};
+    applyNullableDateRange(
+      filter.targetDate,
+      input.targetAfter,
+      input.targetBefore,
+    );
+  }
+
+  if (input.startedAfter || input.startedBefore) {
+    filter.startedAt = {};
+    applyNullableDateRange(
+      filter.startedAt,
+      input.startedAfter,
+      input.startedBefore,
+    );
+  }
+
+  if (input.completedAfter || input.completedBefore) {
+    filter.completedAt = {};
+    applyNullableDateRange(
+      filter.completedAt,
+      input.completedAfter,
+      input.completedBefore,
+    );
+  }
+
+  if (input.createdAfter || input.createdBefore) {
+    filter.createdAt = {};
+    applyNullableDateRange(
+      filter.createdAt,
+      input.createdAfter,
+      input.createdBefore,
+    );
+  }
+
+  if (input.updatedAfter || input.updatedBefore) {
+    filter.updatedAt = {};
+    applyNullableDateRange(
+      filter.updatedAt,
+      input.updatedAfter,
+      input.updatedBefore,
+    );
+  }
+
+  if (input.ancestorId) {
+    filter.ancestors = { some: { id: { eq: input.ancestorId } } };
+  }
+
+  return Object.keys(filter).length > 0 ? filter : undefined;
+}
 
 export interface InitiativeListOptions {
   limit?: number;
@@ -96,10 +318,11 @@ export async function getInitiative(
 
 export async function createInitiative(
   client: GraphQLClient,
-  input: InitiativeCreateInput,
+  input: CreateInitiativeInput,
 ): Promise<CreatedInitiative> {
+  const gqlInput: InitiativeCreateInput = input;
   const result = await client.request(CreateInitiativeDocument, {
-    input,
+    input: gqlInput,
   });
 
   if (!result.initiativeCreate.success || !result.initiativeCreate.initiative) {
@@ -112,7 +335,7 @@ export async function createInitiative(
 export async function updateInitiative(
   client: GraphQLClient,
   id: string,
-  input: InitiativeUpdateInput,
+  input: UpdateInitiativeInput,
 ): Promise<UpdatedInitiative> {
   const hasAtLeastOneField = Object.values(input).some(
     (value) => value !== undefined,
@@ -125,9 +348,10 @@ export async function updateInitiative(
     );
   }
 
+  const gqlInput: InitiativeUpdateInput = input;
   const result = await client.request(UpdateInitiativeDocument, {
     id,
-    input,
+    input: gqlInput,
   });
 
   if (!result.initiativeUpdate.success || !result.initiativeUpdate.initiative) {

--- a/src/services/initiative-update-service.ts
+++ b/src/services/initiative-update-service.ts
@@ -9,6 +9,7 @@ import {
   GetInitiativeUpdateDocument,
   type GetInitiativeUpdateQuery,
   type InitiativeUpdateCreateInput,
+  type InitiativeUpdateHealthType,
   type InitiativeUpdateUpdateInput,
   ListInitiativeUpdatesDocument,
   type ListInitiativeUpdatesQuery,
@@ -42,6 +43,32 @@ export interface InitiativeUpdateListOptions {
   limit?: number;
   after?: string;
   includeArchived?: boolean;
+}
+
+// Service-owned input types (UUIDs pre-resolved by the command).
+export type CreateInitiativeUpdateInput = Pick<
+  InitiativeUpdateCreateInput,
+  "initiativeId" | "body" | "health"
+>;
+export type UpdateInitiativeUpdateInput = Pick<
+  InitiativeUpdateUpdateInput,
+  "body" | "health"
+>;
+
+export function parseHealth(
+  value?: string,
+): InitiativeUpdateHealthType | undefined {
+  if (!value) return undefined;
+
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "ontrack") return "onTrack";
+  if (normalized === "atrisk") return "atRisk";
+  if (normalized === "offtrack") return "offTrack";
+
+  throw invalidParameterError(
+    "--health",
+    'must be one of: "onTrack", "atRisk", "offTrack"',
+  );
 }
 
 export async function listInitiativeUpdates(
@@ -78,10 +105,11 @@ export async function getInitiativeUpdate(
 
 export async function createInitiativeUpdate(
   client: GraphQLClient,
-  input: InitiativeUpdateCreateInput,
+  input: CreateInitiativeUpdateInput,
 ): Promise<CreatedInitiativeUpdate> {
+  const gqlInput: InitiativeUpdateCreateInput = input;
   const result = await client.request(CreateInitiativeUpdateDocument, {
-    input,
+    input: gqlInput,
   });
 
   if (
@@ -97,7 +125,7 @@ export async function createInitiativeUpdate(
 export async function updateInitiativeUpdate(
   client: GraphQLClient,
   id: string,
-  input: InitiativeUpdateUpdateInput,
+  input: UpdateInitiativeUpdateInput,
 ): Promise<UpdatedInitiativeUpdate> {
   const hasAtLeastOneField = Object.values(input).some(
     (value) => value !== undefined,
@@ -110,9 +138,10 @@ export async function updateInitiativeUpdate(
     );
   }
 
+  const gqlInput: InitiativeUpdateUpdateInput = input;
   const result = await client.request(UpdateInitiativeUpdateDocument, {
     id,
-    input,
+    input: gqlInput,
   });
 
   if (

--- a/src/services/issue-service.ts
+++ b/src/services/issue-service.ts
@@ -76,6 +76,39 @@ export type UpdatedIssue = NonNullable<
   UpdateIssueMutation["issueUpdate"]["issue"]
 >;
 
+// Service-owned input types (UUIDs pre-resolved by the command).
+export type CreateIssueInput = Pick<
+  IssueCreateInput,
+  | "title"
+  | "teamId"
+  | "description"
+  | "assigneeId"
+  | "priority"
+  | "estimate"
+  | "projectId"
+  | "labelIds"
+  | "projectMilestoneId"
+  | "cycleId"
+  | "stateId"
+  | "parentId"
+  | "dueDate"
+>;
+export type UpdateIssueInput = Pick<
+  IssueUpdateInput,
+  | "title"
+  | "description"
+  | "stateId"
+  | "priority"
+  | "estimate"
+  | "assigneeId"
+  | "projectId"
+  | "labelIds"
+  | "parentId"
+  | "projectMilestoneId"
+  | "cycleId"
+  | "dueDate"
+>;
+
 const NON_COMPLETED_ISSUES_FILTER: IssueFilter = {
   state: { type: { neq: "completed" } },
 };
@@ -403,9 +436,10 @@ export async function searchIssues(
 
 export async function createIssue(
   client: GraphQLClient,
-  input: IssueCreateInput,
+  input: CreateIssueInput,
 ): Promise<CreatedIssue> {
-  const result = await client.request(CreateIssueDocument, { input });
+  const gqlInput: IssueCreateInput = input;
+  const result = await client.request(CreateIssueDocument, { input: gqlInput });
   if (!result.issueCreate.success || !result.issueCreate.issue) {
     throw new Error("Failed to create issue");
   }
@@ -415,9 +449,13 @@ export async function createIssue(
 export async function updateIssue(
   client: GraphQLClient,
   id: string,
-  input: IssueUpdateInput,
+  input: UpdateIssueInput,
 ): Promise<UpdatedIssue> {
-  const result = await client.request(UpdateIssueDocument, { id, input });
+  const gqlInput: IssueUpdateInput = input;
+  const result = await client.request(UpdateIssueDocument, {
+    id,
+    input: gqlInput,
+  });
   if (!result.issueUpdate.success || !result.issueUpdate.issue) {
     throw new Error("Failed to update issue");
   }

--- a/src/services/label-service.ts
+++ b/src/services/label-service.ts
@@ -32,6 +32,16 @@ export interface ListLabelOptions extends PaginationOptions {
   scope?: LabelScope;
 }
 
+// Service-owned input types (UUIDs pre-resolved by the command).
+export type CreateLabelInput = Pick<
+  IssueLabelCreateInput,
+  "name" | "teamId" | "color" | "description"
+>;
+export type UpdateLabelInput = Pick<
+  IssueLabelUpdateInput,
+  "name" | "color" | "description"
+>;
+
 function mapIssueLabel(label: {
   id: string;
   name: string;
@@ -64,9 +74,12 @@ export async function getLabel(
 
 export async function createLabel(
   client: GraphQLClient,
-  input: IssueLabelCreateInput,
+  input: CreateLabelInput,
 ): Promise<Label> {
-  const result = await client.request(CreateIssueLabelDocument, { input });
+  const gqlInput: IssueLabelCreateInput = input;
+  const result = await client.request(CreateIssueLabelDocument, {
+    input: gqlInput,
+  });
 
   if (!result.issueLabelCreate.success) {
     throw new Error(`Failed to create label "${input.name}"`);
@@ -78,9 +91,13 @@ export async function createLabel(
 export async function updateLabel(
   client: GraphQLClient,
   id: string,
-  input: IssueLabelUpdateInput,
+  input: UpdateLabelInput,
 ): Promise<Label> {
-  const result = await client.request(UpdateIssueLabelDocument, { id, input });
+  const gqlInput: IssueLabelUpdateInput = input;
+  const result = await client.request(UpdateIssueLabelDocument, {
+    id,
+    input: gqlInput,
+  });
 
   if (!result.issueLabelUpdate.success) {
     throw new Error(`Failed to update label "${id}"`);

--- a/src/services/milestone-service.ts
+++ b/src/services/milestone-service.ts
@@ -26,6 +26,16 @@ export type UpdatedMilestone = NonNullable<
   UpdateProjectMilestoneMutation["projectMilestoneUpdate"]["projectMilestone"]
 >;
 
+// Service-owned input types (UUIDs pre-resolved by the command).
+export type CreateMilestoneInput = Pick<
+  ProjectMilestoneCreateInput,
+  "projectId" | "name" | "description" | "targetDate"
+>;
+export type UpdateMilestoneInput = Pick<
+  ProjectMilestoneUpdateInput,
+  "name" | "description" | "targetDate" | "sortOrder"
+>;
+
 export async function listMilestones(
   client: GraphQLClient,
   projectId: string,
@@ -66,10 +76,11 @@ export async function getMilestone(
 
 export async function createMilestone(
   client: GraphQLClient,
-  input: ProjectMilestoneCreateInput,
+  input: CreateMilestoneInput,
 ): Promise<CreatedMilestone> {
+  const gqlInput: ProjectMilestoneCreateInput = input;
   const result = await client.request(CreateProjectMilestoneDocument, {
-    input,
+    input: gqlInput,
   });
 
   if (
@@ -85,11 +96,12 @@ export async function createMilestone(
 export async function updateMilestone(
   client: GraphQLClient,
   id: string,
-  input: ProjectMilestoneUpdateInput,
+  input: UpdateMilestoneInput,
 ): Promise<UpdatedMilestone> {
+  const gqlInput: ProjectMilestoneUpdateInput = input;
   const result = await client.request(UpdateProjectMilestoneDocument, {
     id,
-    input,
+    input: gqlInput,
   });
 
   if (

--- a/src/services/project-service.ts
+++ b/src/services/project-service.ts
@@ -38,6 +38,40 @@ export type DeletedProject = {
   success: true;
 };
 
+// Service-owned input types (UUIDs pre-resolved by the command).
+export type CreateProjectInput = Pick<
+  ProjectCreateInput,
+  | "name"
+  | "teamIds"
+  | "description"
+  | "content"
+  | "icon"
+  | "color"
+  | "leadId"
+  | "memberIds"
+  | "priority"
+  | "statusId"
+  | "startDate"
+  | "targetDate"
+  | "labelIds"
+>;
+export type UpdateProjectInput = Pick<
+  ProjectUpdateInput,
+  | "name"
+  | "description"
+  | "content"
+  | "icon"
+  | "color"
+  | "leadId"
+  | "memberIds"
+  | "priority"
+  | "statusId"
+  | "startDate"
+  | "targetDate"
+  | "teamIds"
+  | "labelIds"
+>;
+
 export interface ProjectListOptions extends PaginationOptions {
   includeArchived?: boolean;
 }
@@ -97,9 +131,12 @@ export async function getProject(
 
 export async function createProject(
   client: GraphQLClient,
-  input: ProjectCreateInput,
+  input: CreateProjectInput,
 ): Promise<CreatedProject> {
-  const result = await client.request(CreateProjectDocument, { input });
+  const gqlInput: ProjectCreateInput = input;
+  const result = await client.request(CreateProjectDocument, {
+    input: gqlInput,
+  });
 
   if (!result.projectCreate.success || !result.projectCreate.project) {
     throw new Error(`Failed to create project "${input.name}"`);
@@ -111,9 +148,13 @@ export async function createProject(
 export async function updateProject(
   client: GraphQLClient,
   id: string,
-  input: ProjectUpdateInput,
+  input: UpdateProjectInput,
 ): Promise<UpdatedProject> {
-  const result = await client.request(UpdateProjectDocument, { id, input });
+  const gqlInput: ProjectUpdateInput = input;
+  const result = await client.request(UpdateProjectDocument, {
+    id,
+    input: gqlInput,
+  });
 
   if (!result.projectUpdate.success || !result.projectUpdate.project) {
     throw new Error(`Failed to update project "${id}"`);

--- a/tests/unit/commands/attachments.test.ts
+++ b/tests/unit/commands/attachments.test.ts
@@ -22,22 +22,32 @@ vi.mock("../../../src/resolvers/issue-resolver.js", () => ({
   resolveIssueId: vi.fn().mockResolvedValue("resolved-issue-uuid"),
 }));
 
-vi.mock("../../../src/services/attachment-service.js", () => ({
-  createAttachment: vi.fn().mockResolvedValue({
-    id: "att-1",
-    title: "Test",
-    url: "https://example.com",
-  }),
-  deleteAttachment: vi.fn().mockResolvedValue({
-    id: "att-1",
-    success: true,
-  }),
-  listAttachments: vi
-    .fn()
-    .mockResolvedValue([
-      { id: "att-1", title: "PR #42", sourceType: "github" },
-    ]),
-}));
+vi.mock(
+  "../../../src/services/attachment-service.js",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../../src/services/attachment-service.js")
+      >();
+    return {
+      ...actual,
+      createAttachment: vi.fn().mockResolvedValue({
+        id: "att-1",
+        title: "Test",
+        url: "https://example.com",
+      }),
+      deleteAttachment: vi.fn().mockResolvedValue({
+        id: "att-1",
+        success: true,
+      }),
+      listAttachments: vi
+        .fn()
+        .mockResolvedValue([
+          { id: "att-1", title: "PR #42", sourceType: "github" },
+        ]),
+    };
+  },
+);
 
 import { setupAttachmentsCommands } from "../../../src/commands/attachments.js";
 import { resolveIssueId } from "../../../src/resolvers/issue-resolver.js";

--- a/tests/unit/commands/documents.test.ts
+++ b/tests/unit/commands/documents.test.ts
@@ -34,20 +34,29 @@ vi.mock("../../../src/services/attachment-service.js", () => ({
   listAttachments: vi.fn().mockResolvedValue([]),
 }));
 
-vi.mock("../../../src/services/document-service.js", () => ({
-  createDocument: vi.fn().mockResolvedValue({
-    id: "doc-1",
-    title: "Runbook",
-    url: "https://linear.app/example/document/runbook-abc123",
-  }),
-  deleteDocument: vi.fn().mockResolvedValue({ id: "doc-1", success: true }),
-  getDocument: vi.fn().mockResolvedValue({ id: "doc-1", title: "Runbook" }),
-  listDocuments: vi.fn().mockResolvedValue({
-    nodes: [{ id: "doc-1", title: "Runbook" }],
-    pageInfo: { hasNextPage: false, endCursor: null },
-  }),
-  updateDocument: vi.fn().mockResolvedValue({ id: "doc-1", title: "Runbook" }),
-}));
+vi.mock("../../../src/services/document-service.js", async (importOriginal) => {
+  const actual =
+    await importOriginal<
+      typeof import("../../../src/services/document-service.js")
+    >();
+  return {
+    ...actual,
+    createDocument: vi.fn().mockResolvedValue({
+      id: "doc-1",
+      title: "Runbook",
+      url: "https://linear.app/example/document/runbook-abc123",
+    }),
+    deleteDocument: vi.fn().mockResolvedValue({ id: "doc-1", success: true }),
+    getDocument: vi.fn().mockResolvedValue({ id: "doc-1", title: "Runbook" }),
+    listDocuments: vi.fn().mockResolvedValue({
+      nodes: [{ id: "doc-1", title: "Runbook" }],
+      pageInfo: { hasNextPage: false, endCursor: null },
+    }),
+    updateDocument: vi
+      .fn()
+      .mockResolvedValue({ id: "doc-1", title: "Runbook" }),
+  };
+});
 
 import { setupDocumentsCommands } from "../../../src/commands/documents.js";
 import { resolveIssueId } from "../../../src/resolvers/issue-resolver.js";

--- a/tests/unit/commands/initiatives.test.ts
+++ b/tests/unit/commands/initiatives.test.ts
@@ -40,28 +40,40 @@ vi.mock("../../../src/resolvers/user-resolver.js", () => ({
   resolveUserId: vi.fn().mockResolvedValue("resolved-user-uuid"),
 }));
 
-vi.mock("../../../src/services/initiative-service.js", () => ({
-  listInitiatives: vi.fn().mockResolvedValue({
-    nodes: [],
-    pageInfo: { hasNextPage: false, endCursor: null },
-  }),
-  getInitiative: vi.fn().mockResolvedValue({ id: "resolved-initiative-uuid" }),
-  createInitiative: vi
-    .fn()
-    .mockResolvedValue({ id: "resolved-initiative-uuid" }),
-  updateInitiative: vi
-    .fn()
-    .mockResolvedValue({ id: "resolved-initiative-uuid" }),
-  archiveInitiative: vi
-    .fn()
-    .mockResolvedValue({ id: "resolved-initiative-uuid" }),
-  unarchiveInitiative: vi
-    .fn()
-    .mockResolvedValue({ id: "resolved-initiative-uuid" }),
-  deleteInitiative: vi
-    .fn()
-    .mockResolvedValue({ id: "resolved-initiative-uuid", success: true }),
-}));
+vi.mock(
+  "../../../src/services/initiative-service.js",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../../src/services/initiative-service.js")
+      >();
+    return {
+      ...actual,
+      listInitiatives: vi.fn().mockResolvedValue({
+        nodes: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      }),
+      getInitiative: vi
+        .fn()
+        .mockResolvedValue({ id: "resolved-initiative-uuid" }),
+      createInitiative: vi
+        .fn()
+        .mockResolvedValue({ id: "resolved-initiative-uuid" }),
+      updateInitiative: vi
+        .fn()
+        .mockResolvedValue({ id: "resolved-initiative-uuid" }),
+      archiveInitiative: vi
+        .fn()
+        .mockResolvedValue({ id: "resolved-initiative-uuid" }),
+      unarchiveInitiative: vi
+        .fn()
+        .mockResolvedValue({ id: "resolved-initiative-uuid" }),
+      deleteInitiative: vi
+        .fn()
+        .mockResolvedValue({ id: "resolved-initiative-uuid", success: true }),
+    };
+  },
+);
 
 vi.mock("../../../src/services/initiative-relation-service.js", () => ({
   createInitiativeRelation: vi
@@ -81,27 +93,37 @@ vi.mock("../../../src/services/initiative-project-service.js", () => ({
     .mockResolvedValue({ id: "resolved-link-uuid", success: true }),
 }));
 
-vi.mock("../../../src/services/initiative-update-service.js", () => ({
-  listInitiativeUpdates: vi.fn().mockResolvedValue({
-    nodes: [],
-    pageInfo: { hasNextPage: false, endCursor: null },
-  }),
-  getInitiativeUpdate: vi
-    .fn()
-    .mockResolvedValue({ id: "resolved-update-uuid" }),
-  createInitiativeUpdate: vi
-    .fn()
-    .mockResolvedValue({ id: "resolved-update-uuid" }),
-  updateInitiativeUpdate: vi
-    .fn()
-    .mockResolvedValue({ id: "resolved-update-uuid" }),
-  archiveInitiativeUpdate: vi
-    .fn()
-    .mockResolvedValue({ id: "resolved-update-uuid" }),
-  unarchiveInitiativeUpdate: vi
-    .fn()
-    .mockResolvedValue({ id: "resolved-update-uuid" }),
-}));
+vi.mock(
+  "../../../src/services/initiative-update-service.js",
+  async (importOriginal) => {
+    const actual =
+      await importOriginal<
+        typeof import("../../../src/services/initiative-update-service.js")
+      >();
+    return {
+      ...actual,
+      listInitiativeUpdates: vi.fn().mockResolvedValue({
+        nodes: [],
+        pageInfo: { hasNextPage: false, endCursor: null },
+      }),
+      getInitiativeUpdate: vi
+        .fn()
+        .mockResolvedValue({ id: "resolved-update-uuid" }),
+      createInitiativeUpdate: vi
+        .fn()
+        .mockResolvedValue({ id: "resolved-update-uuid" }),
+      updateInitiativeUpdate: vi
+        .fn()
+        .mockResolvedValue({ id: "resolved-update-uuid" }),
+      archiveInitiativeUpdate: vi
+        .fn()
+        .mockResolvedValue({ id: "resolved-update-uuid" }),
+      unarchiveInitiativeUpdate: vi
+        .fn()
+        .mockResolvedValue({ id: "resolved-update-uuid" }),
+    };
+  },
+);
 
 vi.mock("../../../src/services/discussion-service.js", () => ({
   startInitiativeDiscussion: vi


### PR DESCRIPTION
## What does this PR do?

Moves filter building, sort/status/health parsing, and CRUD input typing out of the command layer and into the services, so each service owns its `Pick`-based `CreateX`/`UpdateX` input types and exposes pure helpers (`buildInitiativeFilter`, `buildAttachmentFilter`, the document filters, `parseInitiativeStatus`, `parseHealth`, and the sort mappers) that operate on pre-resolved UUIDs. Commands keep ID resolution and delegate all shaping to the services, tightening the layer separation with no behavior change. Tests were updated to use `importOriginal` so the real moved helpers run while network calls stay mocked.

Closes #195

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `npx tsc --noEmit` — clean
- `npm test` — 829 tests passing
- `npm run check:ci` — passes (lint + format)
- `npm run knip` — clean

## Notes for reviewers

Pure refactor: no field is added or dropped from any mutation input (the new `Pick` types are exact subsets, verified by the type checker), and every filter branch was moved verbatim. Existing command-level tests exercise the relocated helpers via `importOriginal`.