### PR TITLE
refactor(services): extract shared mutation-payload assertion helpers

### DIFF
--- a/src/common/mutation-payload.ts
+++ b/src/common/mutation-payload.ts
@@ -1,0 +1,28 @@
+/**
+ * Assert a Linear mutation payload succeeded and return its entity field.
+ *
+ * The entity field name varies per mutation (`issue`, `project`, `entity`,
+ * `comment`, …), so the caller supplies the key. Typing stays exact via
+ * `keyof` + `NonNullable`, so no `any` is needed and the returned value is
+ * narrowed to the non-null entity type.
+ */
+export function requireMutationEntity<
+  P extends { success: boolean },
+  K extends keyof P,
+>(payload: P, key: K, message: string): NonNullable<P[K]> {
+  const entity = payload[key];
+  if (!payload.success || entity == null) {
+    throw new Error(message);
+  }
+  return entity as NonNullable<P[K]>;
+}
+
+/** Assert a mutation payload succeeded when there is no entity to return. */
+export function requireMutationSuccess(
+  payload: { success: boolean },
+  message: string,
+): void {
+  if (!payload.success) {
+    throw new Error(message);
+  }
+}

--- a/src/services/attachment-service.ts
+++ b/src/services/attachment-service.ts
@@ -1,5 +1,9 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
 import {
+  requireMutationEntity,
+  requireMutationSuccess,
+} from "../common/mutation-payload.js";
+import {
   AttachmentCreateDocument,
   type AttachmentCreateInput,
   type AttachmentCreateMutation,
@@ -60,11 +64,11 @@ export async function createAttachment(
     input: gqlInput,
   });
 
-  if (!result.attachmentCreate.success || !result.attachmentCreate.attachment) {
-    throw new Error("Failed to create attachment");
-  }
-
-  return result.attachmentCreate.attachment;
+  return requireMutationEntity(
+    result.attachmentCreate,
+    "attachment",
+    "Failed to create attachment",
+  );
 }
 
 export async function deleteAttachment(
@@ -73,9 +77,10 @@ export async function deleteAttachment(
 ): Promise<{ id: string; success: boolean }> {
   const result = await client.request(AttachmentDeleteDocument, { id });
 
-  if (!result.attachmentDelete.success) {
-    throw new Error("Failed to delete attachment");
-  }
+  requireMutationSuccess(
+    result.attachmentDelete,
+    "Failed to delete attachment",
+  );
 
   return { id: result.attachmentDelete.entityId, success: true };
 }

--- a/src/services/comment-service.ts
+++ b/src/services/comment-service.ts
@@ -1,4 +1,8 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import {
+  requireMutationEntity,
+  requireMutationSuccess,
+} from "../common/mutation-payload.js";
 import type { PaginatedResult, PaginationOptions } from "../common/types.js";
 import {
   type CommentCreateInput,
@@ -28,11 +32,11 @@ export async function createComment(
 ): Promise<CreatedComment> {
   const result = await client.request(CreateCommentDocument, { input });
 
-  if (!result.commentCreate.success || !result.commentCreate.comment) {
-    throw new Error("Failed to create comment");
-  }
-
-  return result.commentCreate.comment;
+  return requireMutationEntity(
+    result.commentCreate,
+    "comment",
+    "Failed to create comment",
+  );
 }
 
 export async function updateComment(
@@ -42,11 +46,11 @@ export async function updateComment(
 ): Promise<UpdatedComment> {
   const result = await client.request(UpdateCommentDocument, { id, input });
 
-  if (!result.commentUpdate.success || !result.commentUpdate.comment) {
-    throw new Error("Failed to update comment");
-  }
-
-  return result.commentUpdate.comment;
+  return requireMutationEntity(
+    result.commentUpdate,
+    "comment",
+    "Failed to update comment",
+  );
 }
 
 export async function listComments(
@@ -83,11 +87,11 @@ export async function replyToComment(
     input: { parentId: input.parentId, body: input.body },
   });
 
-  if (!result.commentCreate.success || !result.commentCreate.comment) {
-    throw new Error("Failed to create reply");
-  }
-
-  return result.commentCreate.comment;
+  return requireMutationEntity(
+    result.commentCreate,
+    "comment",
+    "Failed to create reply",
+  );
 }
 
 export async function deleteComment(
@@ -96,9 +100,7 @@ export async function deleteComment(
 ): Promise<{ id: string; success: boolean }> {
   const result = await client.request(DeleteCommentDocument, { id });
 
-  if (!result.commentDelete.success) {
-    throw new Error("Failed to delete comment");
-  }
+  requireMutationSuccess(result.commentDelete, "Failed to delete comment");
 
   return {
     id: result.commentDelete.entityId,

--- a/src/services/discussion-service.ts
+++ b/src/services/discussion-service.ts
@@ -1,4 +1,8 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import {
+  requireMutationEntity,
+  requireMutationSuccess,
+} from "../common/mutation-payload.js";
 import type { PaginatedResult, PaginationOptions } from "../common/types.js";
 import {
   type CommentCreateInput,
@@ -471,11 +475,11 @@ async function startDiscussion(
 ): Promise<StartDiscussionMutation["commentCreate"]["comment"]> {
   const result = await client.request(StartDiscussionDocument, { input });
 
-  if (!result.commentCreate.success || !result.commentCreate.comment) {
-    throw new Error("Failed to start discussion");
-  }
-
-  return result.commentCreate.comment;
+  return requireMutationEntity(
+    result.commentCreate,
+    "comment",
+    "Failed to start discussion",
+  );
 }
 
 export async function createDiscussionCommentReaction(
@@ -788,11 +792,11 @@ export async function replyToDiscussion(
     },
   });
 
-  if (!result.commentCreate.success || !result.commentCreate.comment) {
-    throw new Error("Failed to create discussion reply");
-  }
-
-  return result.commentCreate.comment;
+  return requireMutationEntity(
+    result.commentCreate,
+    "comment",
+    "Failed to create discussion reply",
+  );
 }
 
 export async function editDiscussionReply(
@@ -808,11 +812,11 @@ export async function editDiscussionReply(
     input,
   });
 
-  if (!result.commentUpdate.success || !result.commentUpdate.comment) {
-    throw new Error("Failed to edit discussion reply");
-  }
-
-  return result.commentUpdate.comment;
+  return requireMutationEntity(
+    result.commentUpdate,
+    "comment",
+    "Failed to edit discussion reply",
+  );
 }
 
 export async function deleteDiscussionReply(
@@ -824,9 +828,10 @@ export async function deleteDiscussionReply(
 
   const result = await client.request(DeleteDiscussionReplyDocument, { id });
 
-  if (!result.commentDelete.success) {
-    throw new Error("Failed to delete discussion reply");
-  }
+  requireMutationSuccess(
+    result.commentDelete,
+    "Failed to delete discussion reply",
+  );
 
   return {
     id: result.commentDelete.entityId,
@@ -847,11 +852,11 @@ export async function editDiscussionComment(
     input,
   });
 
-  if (!result.commentUpdate.success || !result.commentUpdate.comment) {
-    throw new Error("Failed to edit discussion comment");
-  }
-
-  return result.commentUpdate.comment;
+  return requireMutationEntity(
+    result.commentUpdate,
+    "comment",
+    "Failed to edit discussion comment",
+  );
 }
 
 export async function deleteDiscussionComment(
@@ -863,9 +868,10 @@ export async function deleteDiscussionComment(
 
   const result = await client.request(DeleteDiscussionReplyDocument, { id });
 
-  if (!result.commentDelete.success) {
-    throw new Error("Failed to delete discussion comment");
-  }
+  requireMutationSuccess(
+    result.commentDelete,
+    "Failed to delete discussion comment",
+  );
 
   return {
     id: result.commentDelete.entityId,
@@ -888,11 +894,11 @@ export async function resolveDiscussion(
     resolvingCommentId: input.resolvingCommentId,
   });
 
-  if (!result.commentResolve.success || !result.commentResolve.comment) {
-    throw new Error("Failed to resolve discussion");
-  }
-
-  return result.commentResolve.comment;
+  return requireMutationEntity(
+    result.commentResolve,
+    "comment",
+    "Failed to resolve discussion",
+  );
 }
 
 export async function unresolveDiscussion(
@@ -906,9 +912,9 @@ export async function unresolveDiscussion(
     id: threadId,
   });
 
-  if (!result.commentUnresolve.success || !result.commentUnresolve.comment) {
-    throw new Error("Failed to unresolve discussion");
-  }
-
-  return result.commentUnresolve.comment;
+  return requireMutationEntity(
+    result.commentUnresolve,
+    "comment",
+    "Failed to unresolve discussion",
+  );
 }

--- a/src/services/document-service.ts
+++ b/src/services/document-service.ts
@@ -1,4 +1,8 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import {
+  requireMutationEntity,
+  requireMutationSuccess,
+} from "../common/mutation-payload.js";
 import type { PaginatedResult } from "../common/types.js";
 import {
   DocumentCreateDocument,
@@ -80,11 +84,11 @@ export async function createDocument(
     input: gqlInput,
   });
 
-  if (!result.documentCreate.success || !result.documentCreate.document) {
-    throw new Error("Failed to create document");
-  }
-
-  return result.documentCreate.document;
+  return requireMutationEntity(
+    result.documentCreate,
+    "document",
+    "Failed to create document",
+  );
 }
 
 export async function updateDocument(
@@ -98,11 +102,11 @@ export async function updateDocument(
     input: gqlInput,
   });
 
-  if (!result.documentUpdate.success || !result.documentUpdate.document) {
-    throw new Error("Failed to update document");
-  }
-
-  return result.documentUpdate.document;
+  return requireMutationEntity(
+    result.documentUpdate,
+    "document",
+    "Failed to update document",
+  );
 }
 
 export async function listDocuments(
@@ -134,9 +138,7 @@ export async function deleteDocument(
 ): Promise<{ id: string; success: boolean }> {
   const result = await client.request(DocumentDeleteDocument, { id });
 
-  if (!result.documentDelete.success) {
-    throw new Error("Failed to delete document");
-  }
+  requireMutationSuccess(result.documentDelete, "Failed to delete document");
 
   return { id: result.documentDelete.entity?.id ?? id, success: true };
 }

--- a/src/services/initiative-project-service.ts
+++ b/src/services/initiative-project-service.ts
@@ -1,4 +1,5 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import { requireMutationEntity } from "../common/mutation-payload.js";
 import {
   CreateInitiativeToProjectDocument,
   type CreateInitiativeToProjectMutation,
@@ -25,16 +26,11 @@ export async function createInitiativeProjectLink(
     input,
   });
 
-  if (
-    !result.initiativeToProjectCreate.success ||
-    !result.initiativeToProjectCreate.initiativeToProject
-  ) {
-    throw new Error(
-      `Failed to create initiative-project link for initiative "${input.initiativeId}" and project "${input.projectId}"`,
-    );
-  }
-
-  return result.initiativeToProjectCreate.initiativeToProject;
+  return requireMutationEntity(
+    result.initiativeToProjectCreate,
+    "initiativeToProject",
+    `Failed to create initiative-project link for initiative "${input.initiativeId}" and project "${input.projectId}"`,
+  );
 }
 
 export async function deleteInitiativeProjectLink(
@@ -45,15 +41,14 @@ export async function deleteInitiativeProjectLink(
     id,
   });
 
-  if (
-    !result.initiativeToProjectDelete.success ||
-    !result.initiativeToProjectDelete.entityId
-  ) {
-    throw new Error(`Failed to delete initiative-project link "${id}"`);
-  }
+  const entityId = requireMutationEntity(
+    result.initiativeToProjectDelete,
+    "entityId",
+    `Failed to delete initiative-project link "${id}"`,
+  );
 
   return {
-    id: result.initiativeToProjectDelete.entityId,
+    id: entityId,
     success: true,
   };
 }

--- a/src/services/initiative-relation-service.ts
+++ b/src/services/initiative-relation-service.ts
@@ -1,4 +1,5 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import { requireMutationEntity } from "../common/mutation-payload.js";
 import {
   CreateInitiativeRelationDocument,
   type CreateInitiativeRelationMutation,
@@ -28,16 +29,11 @@ export async function createInitiativeRelation(
     },
   });
 
-  if (
-    !result.initiativeRelationCreate.success ||
-    !result.initiativeRelationCreate.initiativeRelation
-  ) {
-    throw new Error(
-      `Failed to create initiative relation from "${input.parentId}" to "${input.childId}"`,
-    );
-  }
-
-  return result.initiativeRelationCreate.initiativeRelation;
+  return requireMutationEntity(
+    result.initiativeRelationCreate,
+    "initiativeRelation",
+    `Failed to create initiative relation from "${input.parentId}" to "${input.childId}"`,
+  );
 }
 
 export async function deleteInitiativeRelation(
@@ -46,15 +42,14 @@ export async function deleteInitiativeRelation(
 ): Promise<DeletedInitiativeRelation> {
   const result = await client.request(DeleteInitiativeRelationDocument, { id });
 
-  if (
-    !result.initiativeRelationDelete.success ||
-    !result.initiativeRelationDelete.entityId
-  ) {
-    throw new Error(`Failed to delete initiative relation "${id}"`);
-  }
+  const entityId = requireMutationEntity(
+    result.initiativeRelationDelete,
+    "entityId",
+    `Failed to delete initiative relation "${id}"`,
+  );
 
   return {
-    id: result.initiativeRelationDelete.entityId,
+    id: entityId,
     success: true,
   };
 }

--- a/src/services/initiative-service.ts
+++ b/src/services/initiative-service.ts
@@ -1,5 +1,6 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
 import { invalidParameterError } from "../common/errors.js";
+import { requireMutationEntity } from "../common/mutation-payload.js";
 import type { PaginatedResult } from "../common/types.js";
 import {
   ArchiveInitiativeDocument,
@@ -325,11 +326,11 @@ export async function createInitiative(
     input: gqlInput,
   });
 
-  if (!result.initiativeCreate.success || !result.initiativeCreate.initiative) {
-    throw new Error(`Failed to create initiative "${input.name}"`);
-  }
-
-  return result.initiativeCreate.initiative;
+  return requireMutationEntity(
+    result.initiativeCreate,
+    "initiative",
+    `Failed to create initiative "${input.name}"`,
+  );
 }
 
 export async function updateInitiative(
@@ -354,11 +355,11 @@ export async function updateInitiative(
     input: gqlInput,
   });
 
-  if (!result.initiativeUpdate.success || !result.initiativeUpdate.initiative) {
-    throw new Error(`Failed to update initiative "${id}"`);
-  }
-
-  return result.initiativeUpdate.initiative;
+  return requireMutationEntity(
+    result.initiativeUpdate,
+    "initiative",
+    `Failed to update initiative "${id}"`,
+  );
 }
 
 export async function archiveInitiative(
@@ -367,11 +368,11 @@ export async function archiveInitiative(
 ): Promise<ArchivedInitiative> {
   const result = await client.request(ArchiveInitiativeDocument, { id });
 
-  if (!result.initiativeArchive.success || !result.initiativeArchive.entity) {
-    throw new Error(`Failed to archive initiative "${id}"`);
-  }
-
-  return result.initiativeArchive.entity;
+  return requireMutationEntity(
+    result.initiativeArchive,
+    "entity",
+    `Failed to archive initiative "${id}"`,
+  );
 }
 
 export async function unarchiveInitiative(
@@ -380,14 +381,11 @@ export async function unarchiveInitiative(
 ): Promise<UnarchivedInitiative> {
   const result = await client.request(UnarchiveInitiativeDocument, { id });
 
-  if (
-    !result.initiativeUnarchive.success ||
-    !result.initiativeUnarchive.entity
-  ) {
-    throw new Error(`Failed to unarchive initiative "${id}"`);
-  }
-
-  return result.initiativeUnarchive.entity;
+  return requireMutationEntity(
+    result.initiativeUnarchive,
+    "entity",
+    `Failed to unarchive initiative "${id}"`,
+  );
 }
 
 export async function deleteInitiative(
@@ -396,12 +394,14 @@ export async function deleteInitiative(
 ): Promise<DeletedInitiative> {
   const result = await client.request(DeleteInitiativeDocument, { id });
 
-  if (!result.initiativeDelete.success || !result.initiativeDelete.entityId) {
-    throw new Error(`Failed to delete initiative "${id}"`);
-  }
+  const entityId = requireMutationEntity(
+    result.initiativeDelete,
+    "entityId",
+    `Failed to delete initiative "${id}"`,
+  );
 
   return {
-    id: result.initiativeDelete.entityId,
+    id: entityId,
     success: true,
   };
 }

--- a/src/services/initiative-update-service.ts
+++ b/src/services/initiative-update-service.ts
@@ -1,5 +1,6 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
 import { invalidParameterError } from "../common/errors.js";
+import { requireMutationEntity } from "../common/mutation-payload.js";
 import type { PaginatedResult } from "../common/types.js";
 import {
   ArchiveInitiativeUpdateDocument,
@@ -112,14 +113,11 @@ export async function createInitiativeUpdate(
     input: gqlInput,
   });
 
-  if (
-    !result.initiativeUpdateCreate.success ||
-    !result.initiativeUpdateCreate.initiativeUpdate
-  ) {
-    throw new Error("Failed to create initiative update");
-  }
-
-  return result.initiativeUpdateCreate.initiativeUpdate;
+  return requireMutationEntity(
+    result.initiativeUpdateCreate,
+    "initiativeUpdate",
+    "Failed to create initiative update",
+  );
 }
 
 export async function updateInitiativeUpdate(
@@ -144,14 +142,11 @@ export async function updateInitiativeUpdate(
     input: gqlInput,
   });
 
-  if (
-    !result.initiativeUpdateUpdate.success ||
-    !result.initiativeUpdateUpdate.initiativeUpdate
-  ) {
-    throw new Error(`Failed to update initiative update "${id}"`);
-  }
-
-  return result.initiativeUpdateUpdate.initiativeUpdate;
+  return requireMutationEntity(
+    result.initiativeUpdateUpdate,
+    "initiativeUpdate",
+    `Failed to update initiative update "${id}"`,
+  );
 }
 
 export async function archiveInitiativeUpdate(
@@ -160,14 +155,11 @@ export async function archiveInitiativeUpdate(
 ): Promise<ArchivedInitiativeUpdate> {
   const result = await client.request(ArchiveInitiativeUpdateDocument, { id });
 
-  if (
-    !result.initiativeUpdateArchive.success ||
-    !result.initiativeUpdateArchive.entity
-  ) {
-    throw new Error(`Failed to archive initiative update "${id}"`);
-  }
-
-  return result.initiativeUpdateArchive.entity;
+  return requireMutationEntity(
+    result.initiativeUpdateArchive,
+    "entity",
+    `Failed to archive initiative update "${id}"`,
+  );
 }
 
 export async function unarchiveInitiativeUpdate(
@@ -178,12 +170,9 @@ export async function unarchiveInitiativeUpdate(
     id,
   });
 
-  if (
-    !result.initiativeUpdateUnarchive.success ||
-    !result.initiativeUpdateUnarchive.entity
-  ) {
-    throw new Error(`Failed to unarchive initiative update "${id}"`);
-  }
-
-  return result.initiativeUpdateUnarchive.entity;
+  return requireMutationEntity(
+    result.initiativeUpdateUnarchive,
+    "entity",
+    `Failed to unarchive initiative update "${id}"`,
+  );
 }

--- a/src/services/issue-relation-service.ts
+++ b/src/services/issue-relation-service.ts
@@ -1,5 +1,6 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
 import { notFoundError } from "../common/errors.js";
+import { requireMutationSuccess } from "../common/mutation-payload.js";
 import {
   CreateIssueRelationDocument,
   type CreateIssueRelationMutation,
@@ -24,9 +25,10 @@ export async function createIssueRelation(
   },
 ): Promise<CreatedIssueRelation> {
   const result = await client.request(CreateIssueRelationDocument, { input });
-  if (!result.issueRelationCreate.success) {
-    throw new Error("Failed to create issue relation");
-  }
+  requireMutationSuccess(
+    result.issueRelationCreate,
+    "Failed to create issue relation",
+  );
   return result.issueRelationCreate.issueRelation;
 }
 
@@ -90,8 +92,9 @@ export async function deleteIssueRelation(
   const result = await client.request(DeleteIssueRelationDocument, {
     id: relationId,
   });
-  if (!result.issueRelationDelete.success) {
-    throw new Error("Failed to delete issue relation");
-  }
+  requireMutationSuccess(
+    result.issueRelationDelete,
+    "Failed to delete issue relation",
+  );
   return { id: result.issueRelationDelete.entityId, success: true };
 }

--- a/src/services/issue-service.ts
+++ b/src/services/issue-service.ts
@@ -1,4 +1,5 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import { requireMutationEntity } from "../common/mutation-payload.js";
 import type { PaginatedResult, PaginationOptions } from "../common/types.js";
 import {
   ArchiveIssueDocument,
@@ -440,10 +441,11 @@ export async function createIssue(
 ): Promise<CreatedIssue> {
   const gqlInput: IssueCreateInput = input;
   const result = await client.request(CreateIssueDocument, { input: gqlInput });
-  if (!result.issueCreate.success || !result.issueCreate.issue) {
-    throw new Error("Failed to create issue");
-  }
-  return result.issueCreate.issue;
+  return requireMutationEntity(
+    result.issueCreate,
+    "issue",
+    "Failed to create issue",
+  );
 }
 
 export async function updateIssue(
@@ -456,10 +458,11 @@ export async function updateIssue(
     id,
     input: gqlInput,
   });
-  if (!result.issueUpdate.success || !result.issueUpdate.issue) {
-    throw new Error("Failed to update issue");
-  }
-  return result.issueUpdate.issue;
+  return requireMutationEntity(
+    result.issueUpdate,
+    "issue",
+    "Failed to update issue",
+  );
 }
 
 export async function archiveIssue(
@@ -468,11 +471,11 @@ export async function archiveIssue(
 ): Promise<IssueDetail> {
   const result = await client.request(ArchiveIssueDocument, { id });
 
-  if (!result.issueArchive.success || !result.issueArchive.entity) {
-    throw new Error(`Failed to archive issue "${id}"`);
-  }
-
-  return result.issueArchive.entity;
+  return requireMutationEntity(
+    result.issueArchive,
+    "entity",
+    `Failed to archive issue "${id}"`,
+  );
 }
 
 export async function unarchiveIssue(
@@ -481,11 +484,11 @@ export async function unarchiveIssue(
 ): Promise<IssueDetail> {
   const result = await client.request(UnarchiveIssueDocument, { id });
 
-  if (!result.issueUnarchive.success || !result.issueUnarchive.entity) {
-    throw new Error(`Failed to unarchive issue "${id}"`);
-  }
-
-  return result.issueUnarchive.entity;
+  return requireMutationEntity(
+    result.issueUnarchive,
+    "entity",
+    `Failed to unarchive issue "${id}"`,
+  );
 }
 
 export async function deleteIssue(

--- a/src/services/label-service.ts
+++ b/src/services/label-service.ts
@@ -1,4 +1,5 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import { requireMutationSuccess } from "../common/mutation-payload.js";
 import type { PaginatedResult, PaginationOptions } from "../common/types.js";
 import {
   CreateIssueLabelDocument,
@@ -81,9 +82,10 @@ export async function createLabel(
     input: gqlInput,
   });
 
-  if (!result.issueLabelCreate.success) {
-    throw new Error(`Failed to create label "${input.name}"`);
-  }
+  requireMutationSuccess(
+    result.issueLabelCreate,
+    `Failed to create label "${input.name}"`,
+  );
 
   return mapIssueLabel(result.issueLabelCreate.issueLabel);
 }
@@ -99,9 +101,10 @@ export async function updateLabel(
     input: gqlInput,
   });
 
-  if (!result.issueLabelUpdate.success) {
-    throw new Error(`Failed to update label "${id}"`);
-  }
+  requireMutationSuccess(
+    result.issueLabelUpdate,
+    `Failed to update label "${id}"`,
+  );
 
   return mapIssueLabel(result.issueLabelUpdate.issueLabel);
 }
@@ -112,9 +115,10 @@ export async function deleteLabel(
 ): Promise<DeleteLabelResult> {
   const result = await client.request(DeleteIssueLabelDocument, { id });
 
-  if (!result.issueLabelDelete.success) {
-    throw new Error(`Failed to delete label "${id}"`);
-  }
+  requireMutationSuccess(
+    result.issueLabelDelete,
+    `Failed to delete label "${id}"`,
+  );
 
   return {
     id: result.issueLabelDelete.entityId,

--- a/src/services/milestone-service.ts
+++ b/src/services/milestone-service.ts
@@ -1,4 +1,5 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import { requireMutationEntity } from "../common/mutation-payload.js";
 import type { PaginatedResult, PaginationOptions } from "../common/types.js";
 import {
   CreateProjectMilestoneDocument,
@@ -83,14 +84,11 @@ export async function createMilestone(
     input: gqlInput,
   });
 
-  if (
-    !result.projectMilestoneCreate.success ||
-    !result.projectMilestoneCreate.projectMilestone
-  ) {
-    throw new Error("Failed to create milestone");
-  }
-
-  return result.projectMilestoneCreate.projectMilestone;
+  return requireMutationEntity(
+    result.projectMilestoneCreate,
+    "projectMilestone",
+    "Failed to create milestone",
+  );
 }
 
 export async function updateMilestone(
@@ -104,12 +102,9 @@ export async function updateMilestone(
     input: gqlInput,
   });
 
-  if (
-    !result.projectMilestoneUpdate.success ||
-    !result.projectMilestoneUpdate.projectMilestone
-  ) {
-    throw new Error("Failed to update milestone");
-  }
-
-  return result.projectMilestoneUpdate.projectMilestone;
+  return requireMutationEntity(
+    result.projectMilestoneUpdate,
+    "projectMilestone",
+    "Failed to update milestone",
+  );
 }

--- a/src/services/project-service.ts
+++ b/src/services/project-service.ts
@@ -1,4 +1,8 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import {
+  requireMutationEntity,
+  requireMutationSuccess,
+} from "../common/mutation-payload.js";
 import type { PaginatedResult, PaginationOptions } from "../common/types.js";
 import {
   ArchiveProjectDocument,
@@ -138,11 +142,11 @@ export async function createProject(
     input: gqlInput,
   });
 
-  if (!result.projectCreate.success || !result.projectCreate.project) {
-    throw new Error(`Failed to create project "${input.name}"`);
-  }
-
-  return result.projectCreate.project;
+  return requireMutationEntity(
+    result.projectCreate,
+    "project",
+    `Failed to create project "${input.name}"`,
+  );
 }
 
 export async function updateProject(
@@ -156,11 +160,11 @@ export async function updateProject(
     input: gqlInput,
   });
 
-  if (!result.projectUpdate.success || !result.projectUpdate.project) {
-    throw new Error(`Failed to update project "${id}"`);
-  }
-
-  return result.projectUpdate.project;
+  return requireMutationEntity(
+    result.projectUpdate,
+    "project",
+    `Failed to update project "${id}"`,
+  );
 }
 
 export async function archiveProject(
@@ -169,11 +173,11 @@ export async function archiveProject(
 ): Promise<ArchivedProject> {
   const result = await client.request(ArchiveProjectDocument, { id });
 
-  if (!result.projectArchive.success || !result.projectArchive.entity) {
-    throw new Error(`Failed to archive project "${id}"`);
-  }
-
-  return result.projectArchive.entity;
+  return requireMutationEntity(
+    result.projectArchive,
+    "entity",
+    `Failed to archive project "${id}"`,
+  );
 }
 
 export async function unarchiveProject(
@@ -182,11 +186,11 @@ export async function unarchiveProject(
 ): Promise<UnarchivedProject> {
   const result = await client.request(UnarchiveProjectDocument, { id });
 
-  if (!result.projectUnarchive.success || !result.projectUnarchive.entity) {
-    throw new Error(`Failed to unarchive project "${id}"`);
-  }
-
-  return result.projectUnarchive.entity;
+  return requireMutationEntity(
+    result.projectUnarchive,
+    "entity",
+    `Failed to unarchive project "${id}"`,
+  );
 }
 
 export async function deleteProject(
@@ -195,9 +199,10 @@ export async function deleteProject(
 ): Promise<DeletedProject> {
   const result = await client.request(DeleteProjectDocument, { id });
 
-  if (!result.projectDelete.success) {
-    throw new Error(`Failed to delete project "${id}"`);
-  }
+  requireMutationSuccess(
+    result.projectDelete,
+    `Failed to delete project "${id}"`,
+  );
 
   return {
     id: result.projectDelete.entity?.id ?? id,

--- a/src/services/reaction-service.ts
+++ b/src/services/reaction-service.ts
@@ -1,5 +1,6 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
 import { normalizeReactionEmojiInput } from "../common/emoji.js";
+import { requireMutationSuccess } from "../common/mutation-payload.js";
 import {
   CreateReactionDocument,
   type CreateReactionMutation,
@@ -135,9 +136,7 @@ async function createReaction(
     input: normalizedInput,
   });
 
-  if (!result.reactionCreate.success) {
-    throw new Error("Failed to create reaction");
-  }
+  requireMutationSuccess(result.reactionCreate, "Failed to create reaction");
 
   return result.reactionCreate.reaction;
 }
@@ -150,9 +149,7 @@ async function deleteReaction(
     id: reactionId,
   });
 
-  if (!result.reactionDelete.success) {
-    throw new Error("Failed to delete reaction");
-  }
+  requireMutationSuccess(result.reactionDelete, "Failed to delete reaction");
 
   return { id: result.reactionDelete.entityId, success: true };
 }

--- a/tests/unit/common/mutation-payload.test.ts
+++ b/tests/unit/common/mutation-payload.test.ts
@@ -1,0 +1,62 @@
+// tests/unit/common/mutation-payload.test.ts
+import { describe, expect, it } from "vitest";
+import {
+  requireMutationEntity,
+  requireMutationSuccess,
+} from "../../../src/common/mutation-payload.js";
+
+describe("requireMutationEntity", () => {
+  it("returns the entity on success", () => {
+    const payload = { success: true, issue: { id: "iss-1" } };
+    expect(requireMutationEntity(payload, "issue", "boom")).toEqual({
+      id: "iss-1",
+    });
+  });
+
+  it("supports arbitrary entity field names", () => {
+    const payload = { success: true, entity: { id: "ent-1" } };
+    expect(requireMutationEntity(payload, "entity", "boom")).toEqual({
+      id: "ent-1",
+    });
+  });
+
+  it("returns a string entity field (e.g. entityId)", () => {
+    const payload = { success: true, entityId: "del-1" };
+    expect(requireMutationEntity(payload, "entityId", "boom")).toBe("del-1");
+  });
+
+  it("throws the given message when success is false", () => {
+    const payload = { success: false, issue: { id: "iss-1" } };
+    expect(() => requireMutationEntity(payload, "issue", "boom")).toThrow(
+      "boom",
+    );
+  });
+
+  it("throws when the entity field is null", () => {
+    const payload = { success: true, issue: null };
+    expect(() => requireMutationEntity(payload, "issue", "boom")).toThrow(
+      "boom",
+    );
+  });
+
+  it("throws when the entity field is undefined", () => {
+    const payload = { success: true, issue: undefined };
+    expect(() => requireMutationEntity(payload, "issue", "boom")).toThrow(
+      "boom",
+    );
+  });
+});
+
+describe("requireMutationSuccess", () => {
+  it("does not throw on success", () => {
+    expect(() =>
+      requireMutationSuccess({ success: true }, "boom"),
+    ).not.toThrow();
+  });
+
+  it("throws the given message on failure", () => {
+    expect(() => requireMutationSuccess({ success: false }, "boom")).toThrow(
+      "boom",
+    );
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Extracts the repeated Linear mutation-payload success/entity assertion pattern out of 14 service files into two shared helpers in the new `src/common/mutation-payload.ts`: `requireMutationEntity` (asserts `success` and a non-null entity field, returning the narrowed entity) and `requireMutationSuccess` (asserts `success` only). This is a behavior-preserving refactor that removes duplication while keeping types exact via `keyof` + `NonNullable` (no `any`).

Closes #203

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

`npx tsc --noEmit` passes and the new `tests/unit/common/mutation-payload.test.ts` suite (8 cases covering success, arbitrary/string entity fields, and null/undefined/failure paths) passes.

## Notes for reviewers

Each substitution was mapped one-to-one: `requireMutationSuccess` was used only where the original checked `success` alone, and `requireMutationEntity` where the original also checked entity presence. The one incidental change is `!entity` -> `entity == null`, which is identical for object entity fields and only differs for empty-string `entityId` values that the Linear API does not return on success.