### PR TITLE
refactor(common): brand resolved IDs with a compile-time UUID type

### DIFF
--- a/src/commands/attachments.ts
+++ b/src/commands/attachments.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { createContext, getRootOpts } from "../common/context.js";
 import { invalidParameterError } from "../common/errors.js";
+import { asUuid } from "../common/identifier.js";
 import { handleCommand, outputSuccess } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import { resolveIssueId } from "../resolvers/issue-resolver.js";
@@ -138,7 +139,7 @@ export function setupAttachmentsCommands(program: Command): void {
       handleCommand(async (...args: unknown[]) => {
         const [id, , command] = args as [string, unknown, Command];
         const ctx = createContext(getRootOpts(command));
-        const result = await deleteAttachment(ctx.gql, id);
+        const result = await deleteAttachment(ctx.gql, asUuid(id));
         outputSuccess(result);
       }),
     );

--- a/src/commands/comments.ts
+++ b/src/commands/comments.ts
@@ -6,6 +6,7 @@ import {
 } from "../common/context.js";
 import { resolveReactionEmojiInput } from "../common/emoji.js";
 import { invalidParameterError } from "../common/errors.js";
+import { asUuid } from "../common/identifier.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { buildPaginationOptions } from "../common/types.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
@@ -171,7 +172,7 @@ export function setupCommentsCommands(program: Command): void {
         }
 
         const result = await replyToDiscussion(ctx.gql, {
-          threadId: thread,
+          threadId: asUuid(thread),
           body: options.body,
           entityKind: "issue",
         });
@@ -200,7 +201,7 @@ export function setupCommentsCommands(program: Command): void {
           throw invalidParameterError("--body", "is required");
         }
 
-        const result = await editDiscussionComment(ctx.gql, comment, {
+        const result = await editDiscussionComment(ctx.gql, asUuid(comment), {
           body: options.body,
         });
 
@@ -219,7 +220,7 @@ export function setupCommentsCommands(program: Command): void {
         const [comment, , command] = args as [string, unknown, Command];
         const ctx = createContext(getRootOpts(command));
 
-        const result = await deleteDiscussionComment(ctx.gql, comment);
+        const result = await deleteDiscussionComment(ctx.gql, asUuid(comment));
 
         outputSuccess(result);
       }),
@@ -246,7 +247,7 @@ export function setupCommentsCommands(program: Command): void {
         const ctx = createContext(getRootOpts(command));
 
         const result = await createIssueDiscussionCommentReaction(ctx.gql, {
-          commentId: comment,
+          commentId: asUuid(comment),
           emoji: resolveReactionEmojiInput(emoji, options.shortcode),
         });
 
@@ -277,7 +278,7 @@ export function setupCommentsCommands(program: Command): void {
         const result = await deleteIssueDiscussionCommentReactionByEmoji(
           ctx.gql,
           {
-            commentId: comment,
+            commentId: asUuid(comment),
             emoji: resolveReactionEmojiInput(emoji, options.shortcode),
           },
         );
@@ -306,8 +307,8 @@ export function setupCommentsCommands(program: Command): void {
         const ctx = createContext(getRootOpts(command));
 
         const result = await deleteIssueDiscussionCommentReactionById(ctx.gql, {
-          commentId: comment,
-          reactionId,
+          commentId: asUuid(comment),
+          reactionId: asUuid(reactionId),
         });
 
         outputSuccess(result);

--- a/src/commands/documents.ts
+++ b/src/commands/documents.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { createContext, getRootOpts } from "../common/context.js";
 import { invalidParameterError } from "../common/errors.js";
+import { asUuid, type UUID } from "../common/identifier.js";
 import { omitUndefined } from "../common/object.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
@@ -119,12 +120,12 @@ export function setupDocumentsCommands(program: Command): void {
 
         const limit = parseLimit(options.limit || "50");
 
-        let projectId: string | undefined;
+        let projectId: UUID | undefined;
         if (options.project) {
           projectId = await resolveProjectId(ctx.sdk, options.project);
         }
 
-        let issueId: string | undefined;
+        let issueId: UUID | undefined;
         if (options.issue) {
           issueId = await resolveIssueId(ctx.sdk, options.issue);
         }
@@ -166,7 +167,7 @@ export function setupDocumentsCommands(program: Command): void {
         const rootOpts = getRootOpts(command);
         const ctx = createContext(rootOpts);
 
-        const documentResult = await getDocument(ctx.gql, document);
+        const documentResult = await getDocument(ctx.gql, asUuid(document));
         outputSuccess(documentResult);
       }),
     );
@@ -247,7 +248,11 @@ export function setupDocumentsCommands(program: Command): void {
         if (options.icon) input.icon = options.icon;
         if (options.color) input.color = options.color;
 
-        const updatedDocument = await updateDocument(ctx.gql, document, input);
+        const updatedDocument = await updateDocument(
+          ctx.gql,
+          asUuid(document),
+          input,
+        );
         outputSuccess(updatedDocument);
       }),
     );
@@ -261,7 +266,7 @@ export function setupDocumentsCommands(program: Command): void {
         const rootOpts = getRootOpts(command);
         const ctx = createContext(rootOpts);
 
-        const result = await deleteDocument(ctx.gql, document);
+        const result = await deleteDocument(ctx.gql, asUuid(document));
         outputSuccess(result);
       }),
     );

--- a/src/commands/initiatives/entity.ts
+++ b/src/commands/initiatives/entity.ts
@@ -3,6 +3,7 @@ import type { LinearSdkClient } from "../../client/linear-client.js";
 import { createContext, getRootOpts } from "../../common/context.js";
 import { resolveReactionEmojiInput } from "../../common/emoji.js";
 import { invalidParameterError } from "../../common/errors.js";
+import { asUuid } from "../../common/identifier.js";
 import { omitUndefined } from "../../common/object.js";
 import {
   commandAction,
@@ -120,7 +121,7 @@ function addCommentReactionCommands(
         async (commentId, emoji, options, command) => {
           const ctx = createContext(getRootOpts(command));
           const result = await createDiscussionCommentReaction(ctx.gql, {
-            commentId,
+            commentId: asUuid(commentId),
             target: noun,
             expectedEntityKind: "initiative",
             emoji: resolveReactionEmojiInput(emoji, options.shortcode),
@@ -139,7 +140,7 @@ function addCommentReactionCommands(
         async (commentId, emoji, options, command) => {
           const ctx = createContext(getRootOpts(command));
           const result = await deleteDiscussionCommentReactionByEmoji(ctx.gql, {
-            commentId,
+            commentId: asUuid(commentId),
             target: noun,
             expectedEntityKind: "initiative",
             emoji: resolveReactionEmojiInput(emoji, options.shortcode),
@@ -159,10 +160,10 @@ function addCommentReactionCommands(
         async (commentId, reactionId, _unused2, command) => {
           const ctx = createContext(getRootOpts(command));
           const result = await deleteDiscussionCommentReactionById(ctx.gql, {
-            commentId,
+            commentId: asUuid(commentId),
             target: noun,
             expectedEntityKind: "initiative",
-            reactionId,
+            reactionId: asUuid(reactionId),
           });
           outputSuccess(result);
         },
@@ -500,13 +501,13 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           const result = options.withReactions
             ? await listDiscussionRepliesWithReactions(
                 ctx.gql,
-                thread,
+                asUuid(thread),
                 paginationOptions,
                 "initiative",
               )
             : await listDiscussionReplies(
                 ctx.gql,
-                thread,
+                asUuid(thread),
                 paginationOptions,
                 "initiative",
               );
@@ -535,7 +536,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           }
 
           const result = await replyToDiscussion(ctx.gql, {
-            threadId: thread,
+            threadId: asUuid(thread),
             body: options.body,
             entityKind: "initiative",
           });
@@ -560,7 +561,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
 
           const result = await editDiscussionComment(
             ctx.gql,
-            comment,
+            asUuid(comment),
             {
               body: options.body,
             },
@@ -587,7 +588,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
 
           const result = await editDiscussionReply(
             ctx.gql,
-            reply,
+            asUuid(reply),
             {
               body: options.body,
             },
@@ -609,7 +610,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
 
           const result = await deleteDiscussionComment(
             ctx.gql,
-            comment,
+            asUuid(comment),
             "initiative",
           );
 
@@ -628,7 +629,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
 
           const result = await deleteDiscussionReply(
             ctx.gql,
-            reply,
+            asUuid(reply),
             "initiative",
           );
 
@@ -647,9 +648,9 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           const ctx = createContext(getRootOpts(command));
 
           const result = await resolveDiscussion(ctx.gql, {
-            threadId: thread,
+            threadId: asUuid(thread),
             ...(options.withComment !== undefined
-              ? { resolvingCommentId: options.withComment }
+              ? { resolvingCommentId: asUuid(options.withComment) }
               : {}),
             entityKind: "initiative",
           });
@@ -669,7 +670,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
 
           const result = await unresolveDiscussion(
             ctx.gql,
-            thread,
+            asUuid(thread),
             "initiative",
           );
 

--- a/src/commands/initiatives/updates.ts
+++ b/src/commands/initiatives/updates.ts
@@ -1,6 +1,7 @@
 import type { Command } from "commander";
 import { createContext, getRootOpts } from "../../common/context.js";
 import { invalidParameterError } from "../../common/errors.js";
+import { asUuid } from "../../common/identifier.js";
 import {
   handleCommand,
   outputSuccess,
@@ -82,7 +83,7 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
       handleCommand(async (...args: unknown[]) => {
         const [updateId, , command] = args as [string, unknown, Command];
         const ctx = createContext(getRootOpts(command));
-        const result = await getInitiativeUpdate(ctx.gql, updateId);
+        const result = await getInitiativeUpdate(ctx.gql, asUuid(updateId));
         outputSuccess(result);
       }),
     );
@@ -154,7 +155,11 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
           );
         }
 
-        const result = await updateInitiativeUpdate(ctx.gql, updateId, input);
+        const result = await updateInitiativeUpdate(
+          ctx.gql,
+          asUuid(updateId),
+          input,
+        );
         outputSuccess(result);
       }),
     );
@@ -166,7 +171,7 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
       handleCommand(async (...args: unknown[]) => {
         const [updateId, , command] = args as [string, unknown, Command];
         const ctx = createContext(getRootOpts(command));
-        const result = await archiveInitiativeUpdate(ctx.gql, updateId);
+        const result = await archiveInitiativeUpdate(ctx.gql, asUuid(updateId));
         outputSuccess(result);
       }),
     );
@@ -178,7 +183,10 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
       handleCommand(async (...args: unknown[]) => {
         const [updateId, , command] = args as [string, unknown, Command];
         const ctx = createContext(getRootOpts(command));
-        const result = await unarchiveInitiativeUpdate(ctx.gql, updateId);
+        const result = await unarchiveInitiativeUpdate(
+          ctx.gql,
+          asUuid(updateId),
+        );
         outputSuccess(result);
       }),
     );

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -7,9 +7,11 @@ import { resolveReactionEmojiInput } from "../common/emoji.js";
 import { invalidParameterError } from "../common/errors.js";
 import { validateEstimateAgainstTeamConfig } from "../common/estimate-validation.js";
 import {
+  asUuid,
   isUuid,
   parseDueDate,
   parseIssueIdentifier,
+  type UUID,
 } from "../common/identifier.js";
 import type { RawFilterFlags } from "../common/issue-filter.js";
 import {
@@ -192,7 +194,7 @@ function addCommentReactionCommands(
         async (commentId, emoji, options, command) => {
           const ctx = createContext(getRootOpts(command));
           const result = await createDiscussionCommentReaction(ctx.gql, {
-            commentId,
+            commentId: asUuid(commentId),
             target: noun,
             expectedEntityKind: "issue",
             emoji: resolveReactionEmojiInput(emoji, options.shortcode),
@@ -212,7 +214,7 @@ function addCommentReactionCommands(
         async (commentId, emoji, options, command) => {
           const ctx = createContext(getRootOpts(command));
           const result = await deleteDiscussionCommentReactionByEmoji(ctx.gql, {
-            commentId,
+            commentId: asUuid(commentId),
             target: noun,
             expectedEntityKind: "issue",
             emoji: resolveReactionEmojiInput(emoji, options.shortcode),
@@ -233,10 +235,10 @@ function addCommentReactionCommands(
         async (commentId, reactionId, _unused2, command) => {
           const ctx = createContext(getRootOpts(command));
           const result = await deleteDiscussionCommentReactionById(ctx.gql, {
-            commentId,
+            commentId: asUuid(commentId),
             target: noun,
             expectedEntityKind: "issue",
-            reactionId,
+            reactionId: asUuid(reactionId),
           });
 
           outputSuccess(result);
@@ -415,12 +417,12 @@ function parseRelationAddOptions(options: RelationAddOptions): {
 
 async function resolveAndApplyRelations(
   ctx: CommandContext,
-  issueId: string,
+  issueId: UUID,
   actions: RelationAction[],
 ): Promise<void> {
   // Resolve all unique targets to UUIDs
   const uniqueTargets = new Set(actions.flatMap((a) => a.targets));
-  const resolved = new Map<string, string>();
+  const resolved = new Map<string, UUID>();
   await Promise.all(
     [...uniqueTargets].map(async (target) => {
       resolved.set(target, await resolveIssueId(ctx.sdk, target));
@@ -580,7 +582,7 @@ export function setupIssuesCommands(program: Command): void {
       commandAction<[string, unknown, Command]>(
         async (relation, _unused1, command) => {
           const ctx = createContext(getRootOpts(command));
-          const result = await deleteIssueRelation(ctx.gql, relation);
+          const result = await deleteIssueRelation(ctx.gql, asUuid(relation));
 
           outputSuccess(result);
         },
@@ -813,7 +815,7 @@ export function setupIssuesCommands(program: Command): void {
           const result = await deleteOwnReactionById(ctx.gql, {
             kind: "issue",
             id: issueId,
-            reactionId,
+            reactionId: asUuid(reactionId),
           });
 
           outputSuccess(result);
@@ -909,13 +911,13 @@ export function setupIssuesCommands(program: Command): void {
           const result = options.withReactions
             ? await listDiscussionRepliesWithReactions(
                 ctx.gql,
-                thread,
+                asUuid(thread),
                 paginationOptions,
                 "issue",
               )
             : await listDiscussionReplies(
                 ctx.gql,
-                thread,
+                asUuid(thread),
                 paginationOptions,
                 "issue",
               );
@@ -944,7 +946,7 @@ export function setupIssuesCommands(program: Command): void {
           }
 
           const result = await replyToDiscussion(ctx.gql, {
-            threadId: thread,
+            threadId: asUuid(thread),
             body: options.body,
             entityKind: "issue",
           });
@@ -969,7 +971,7 @@ export function setupIssuesCommands(program: Command): void {
 
           const result = await editDiscussionComment(
             ctx.gql,
-            comment,
+            asUuid(comment),
             {
               body: options.body,
             },
@@ -996,7 +998,7 @@ export function setupIssuesCommands(program: Command): void {
 
           const result = await editDiscussionReply(
             ctx.gql,
-            reply,
+            asUuid(reply),
             {
               body: options.body,
             },
@@ -1018,7 +1020,7 @@ export function setupIssuesCommands(program: Command): void {
 
           const result = await deleteDiscussionComment(
             ctx.gql,
-            comment,
+            asUuid(comment),
             "issue",
           );
 
@@ -1035,7 +1037,11 @@ export function setupIssuesCommands(program: Command): void {
         async (reply, _unused1, command) => {
           const ctx = createContext(getRootOpts(command));
 
-          const result = await deleteDiscussionReply(ctx.gql, reply, "issue");
+          const result = await deleteDiscussionReply(
+            ctx.gql,
+            asUuid(reply),
+            "issue",
+          );
 
           outputSuccess(result);
         },
@@ -1052,9 +1058,9 @@ export function setupIssuesCommands(program: Command): void {
           const ctx = createContext(getRootOpts(command));
 
           const result = await resolveDiscussion(ctx.gql, {
-            threadId: thread,
+            threadId: asUuid(thread),
             ...(options.withComment !== undefined
-              ? { resolvingCommentId: options.withComment }
+              ? { resolvingCommentId: asUuid(options.withComment) }
               : {}),
             entityKind: "issue",
           });
@@ -1072,7 +1078,11 @@ export function setupIssuesCommands(program: Command): void {
         async (thread, _unused1, command) => {
           const ctx = createContext(getRootOpts(command));
 
-          const result = await unresolveDiscussion(ctx.gql, thread, "issue");
+          const result = await unresolveDiscussion(
+            ctx.gql,
+            asUuid(thread),
+            "issue",
+          );
 
           outputSuccess(result);
         },
@@ -1213,7 +1223,11 @@ export function setupIssuesCommands(program: Command): void {
           const result = await createIssue(ctx.gql, input);
 
           if (relationActions.length > 0) {
-            await resolveAndApplyRelations(ctx, result.id, relationActions);
+            await resolveAndApplyRelations(
+              ctx,
+              asUuid(result.id),
+              relationActions,
+            );
           }
 
           outputSuccess(result);
@@ -1354,7 +1368,7 @@ export function setupIssuesCommands(program: Command): void {
           if (options.status) {
             const teamId =
               issueContext && "team" in issueContext && issueContext.team
-                ? issueContext.team.id
+                ? asUuid(issueContext.team.id)
                 : undefined;
             input.stateId = await resolveStatusId(
               ctx.sdk,
@@ -1392,7 +1406,7 @@ export function setupIssuesCommands(program: Command): void {
                 issueContext &&
                 "labels" in issueContext &&
                 issueContext.labels?.nodes
-                  ? issueContext.labels.nodes.map((l) => l.id)
+                  ? issueContext.labels.nodes.map((l) => asUuid(l.id))
                   : [];
               input.labelIds = [...new Set([...currentLabels, ...labelIds])];
             } else if (labelMode === "remove") {
@@ -1400,7 +1414,7 @@ export function setupIssuesCommands(program: Command): void {
                 issueContext &&
                 "labels" in issueContext &&
                 issueContext.labels?.nodes
-                  ? issueContext.labels.nodes.map((l) => l.id)
+                  ? issueContext.labels.nodes.map((l) => asUuid(l.id))
                   : [];
               input.labelIds = currentLabels.filter(
                 (id) => !labelIds.includes(id),

--- a/src/commands/labels.ts
+++ b/src/commands/labels.ts
@@ -5,6 +5,7 @@ import {
   getRootOpts,
 } from "../common/context.js";
 import { invalidParameterError } from "../common/errors.js";
+import type { UUID } from "../common/identifier.js";
 import { omitUndefined } from "../common/object.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
@@ -86,7 +87,7 @@ async function resolveIssueLabelLookup(
   command: Command,
   label: string,
   options: LabelLookupOptions,
-): Promise<{ ctx: ReturnType<typeof createContext>; labelId: string }> {
+): Promise<{ ctx: ReturnType<typeof createContext>; labelId: UUID }> {
   const ctx = createContext(getRootOpts(command));
   const scope = parseLabelScope(options.scope);
 

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -3,6 +3,7 @@ import { createContext, getRootOpts } from "../common/context.js";
 import { type Priority, parseLabelMode } from "../common/domain-values.js";
 import { resolveReactionEmojiInput } from "../common/emoji.js";
 import { invalidParameterError } from "../common/errors.js";
+import { asUuid } from "../common/identifier.js";
 import { commandAction, outputSuccess, parseLimit } from "../common/output.js";
 import { buildPaginationOptions } from "../common/types.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
@@ -84,7 +85,7 @@ function addCommentReactionCommands(
         async (commentId, emoji, options, command) => {
           const ctx = createContext(getRootOpts(command));
           const result = await createDiscussionCommentReaction(ctx.gql, {
-            commentId,
+            commentId: asUuid(commentId),
             target: noun,
             expectedEntityKind: "project",
             emoji: resolveReactionEmojiInput(emoji, options.shortcode),
@@ -103,7 +104,7 @@ function addCommentReactionCommands(
         async (commentId, emoji, options, command) => {
           const ctx = createContext(getRootOpts(command));
           const result = await deleteDiscussionCommentReactionByEmoji(ctx.gql, {
-            commentId,
+            commentId: asUuid(commentId),
             target: noun,
             expectedEntityKind: "project",
             emoji: resolveReactionEmojiInput(emoji, options.shortcode),
@@ -123,10 +124,10 @@ function addCommentReactionCommands(
         async (commentId, reactionId, _unused2, command) => {
           const ctx = createContext(getRootOpts(command));
           const result = await deleteDiscussionCommentReactionById(ctx.gql, {
-            commentId,
+            commentId: asUuid(commentId),
             target: noun,
             expectedEntityKind: "project",
-            reactionId,
+            reactionId: asUuid(reactionId),
           });
           outputSuccess(result);
         },
@@ -386,13 +387,13 @@ export function setupProjectsCommands(program: Command): void {
           const result = options.withReactions
             ? await listDiscussionRepliesWithReactions(
                 ctx.gql,
-                thread,
+                asUuid(thread),
                 paginationOptions,
                 "project",
               )
             : await listDiscussionReplies(
                 ctx.gql,
-                thread,
+                asUuid(thread),
                 paginationOptions,
                 "project",
               );
@@ -421,7 +422,7 @@ export function setupProjectsCommands(program: Command): void {
           }
 
           const result = await replyToDiscussion(ctx.gql, {
-            threadId: thread,
+            threadId: asUuid(thread),
             body: options.body,
             entityKind: "project",
           });
@@ -446,7 +447,7 @@ export function setupProjectsCommands(program: Command): void {
 
           const result = await editDiscussionComment(
             ctx.gql,
-            comment,
+            asUuid(comment),
             {
               body: options.body,
             },
@@ -473,7 +474,7 @@ export function setupProjectsCommands(program: Command): void {
 
           const result = await editDiscussionReply(
             ctx.gql,
-            reply,
+            asUuid(reply),
             {
               body: options.body,
             },
@@ -495,7 +496,7 @@ export function setupProjectsCommands(program: Command): void {
 
           const result = await deleteDiscussionComment(
             ctx.gql,
-            comment,
+            asUuid(comment),
             "project",
           );
 
@@ -512,7 +513,11 @@ export function setupProjectsCommands(program: Command): void {
         async (reply, _unused1, command) => {
           const ctx = createContext(getRootOpts(command));
 
-          const result = await deleteDiscussionReply(ctx.gql, reply, "project");
+          const result = await deleteDiscussionReply(
+            ctx.gql,
+            asUuid(reply),
+            "project",
+          );
 
           outputSuccess(result);
         },
@@ -529,9 +534,9 @@ export function setupProjectsCommands(program: Command): void {
           const ctx = createContext(getRootOpts(command));
 
           const result = await resolveDiscussion(ctx.gql, {
-            threadId: thread,
+            threadId: asUuid(thread),
             ...(options.withComment !== undefined
-              ? { resolvingCommentId: options.withComment }
+              ? { resolvingCommentId: asUuid(options.withComment) }
               : {}),
             entityKind: "project",
           });
@@ -549,7 +554,11 @@ export function setupProjectsCommands(program: Command): void {
         async (thread, _unused1, command) => {
           const ctx = createContext(getRootOpts(command));
 
-          const result = await unresolveDiscussion(ctx.gql, thread, "project");
+          const result = await unresolveDiscussion(
+            ctx.gql,
+            asUuid(thread),
+            "project",
+          );
 
           outputSuccess(result);
         },
@@ -807,12 +816,12 @@ export function setupProjectsCommands(program: Command): void {
 
             if (labelMode === "add") {
               const currentLabels = projectContext?.labels?.nodes
-                ? projectContext.labels.nodes.map((l) => l.id)
+                ? projectContext.labels.nodes.map((l) => asUuid(l.id))
                 : [];
               input.labelIds = [...new Set([...currentLabels, ...labelIds])];
             } else if (labelMode === "remove") {
               const currentLabels = projectContext?.labels?.nodes
-                ? projectContext.labels.nodes.map((l) => l.id)
+                ? projectContext.labels.nodes.map((l) => asUuid(l.id))
                 : [];
               input.labelIds = currentLabels.filter(
                 (id) => !labelIds.includes(id),

--- a/src/common/identifier.ts
+++ b/src/common/identifier.ts
@@ -1,9 +1,46 @@
 const UUID_REGEX =
   /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 
-export function isUuid(value: string): boolean {
+type Brand<T, TBrand extends string> = T & { readonly __brand: TBrand };
+
+export function isUuid(value: string): value is UUID {
   return UUID_REGEX.test(value);
 }
+
+/**
+ * A resolved Linear entity UUID.
+ *
+ * Branded so the compiler enforces the architecture invariant that services
+ * receive already-resolved IDs: a plain `string` (e.g. a human identifier like
+ * `ENG-123`) is not assignable to `UUID`, but a `UUID` flows into `string`
+ * slots (such as codegen GraphQL inputs) untouched. The brand is erased at
+ * runtime, so a `UUID` behaves exactly like the underlying string.
+ */
+export type UUID = Brand<string, "UUID">;
+
+/**
+ * Brand a string as a resolved UUID at a trust boundary — the output of a
+ * resolver, or a UUID the user supplied directly on the CLI. Performs no
+ * runtime validation.
+ */
+export function asUuid(value: string): UUID {
+  return value as UUID;
+}
+
+/** Replace a `string`/`string[]` core with `UUID`/`UUID[]`, preserving null/undefined. */
+type ReplaceStringWithUuid<V> = V extends string
+  ? UUID
+  : V extends string[]
+    ? UUID[]
+    : V;
+
+/**
+ * Brand selected keys of an input type as UUID, preserving each field's
+ * optional and readonly modifiers (homomorphic over `keyof T`).
+ */
+export type BrandUuidFields<T, K extends keyof T> = {
+  [P in keyof T]: P extends K ? ReplaceStringWithUuid<T[P]> : T[P];
+};
 
 export interface IssueIdentifier {
   teamKey: string;

--- a/src/resolvers/cycle-resolver.ts
+++ b/src/resolvers/cycle-resolver.ts
@@ -1,7 +1,7 @@
 import type { LinearDocument } from "@linear/sdk";
 import type { LinearSdkClient } from "../client/linear-client.js";
 import { multipleMatchesError, notFoundError } from "../common/errors.js";
-import { isUuid } from "../common/identifier.js";
+import { asUuid, isUuid, type UUID } from "../common/identifier.js";
 import { resolveTeamId } from "./team-resolver.js";
 
 /**
@@ -20,8 +20,8 @@ export async function resolveCycleId(
   client: LinearSdkClient,
   nameOrId: string,
   teamFilter?: string,
-): Promise<string> {
-  if (isUuid(nameOrId)) return nameOrId;
+): Promise<UUID> {
+  if (isUuid(nameOrId)) return asUuid(nameOrId);
 
   const filter: LinearDocument.CycleFilter = {
     name: { eq: nameOrId },
@@ -92,5 +92,5 @@ export async function resolveCycleId(
     );
   }
 
-  return chosen.id;
+  return asUuid(chosen.id);
 }

--- a/src/resolvers/initiative-resolver.ts
+++ b/src/resolvers/initiative-resolver.ts
@@ -3,24 +3,24 @@ import type { GraphQLClient } from "../client/graphql-client.js";
 import type { LinearSdkClient } from "../client/linear-client.js";
 import { firstOrThrow } from "../common/array.js";
 import { multipleMatchesError, notFoundError } from "../common/errors.js";
-import { isUuid } from "../common/identifier.js";
+import { asUuid, isUuid, type UUID } from "../common/identifier.js";
 import {
   FindInitiativeProjectLinkByPairDocument,
   FindInitiativeRelationByPairDocument,
 } from "../gql/graphql.js";
 
 export interface InitiativeResolveScope {
-  teamId?: string;
-  ownerId?: string;
+  teamId?: UUID;
+  ownerId?: UUID;
 }
 
 export async function resolveInitiativeId(
   client: LinearSdkClient,
   nameOrId: string,
   scope: InitiativeResolveScope = {},
-): Promise<string> {
+): Promise<UUID> {
   if (isUuid(nameOrId)) {
-    return nameOrId;
+    return asUuid(nameOrId);
   }
 
   const nameClause: LinearDocument.InitiativeFilter = {
@@ -51,9 +51,10 @@ export async function resolveInitiativeId(
   }
 
   if (result.nodes.length === 1) {
-    return firstOrThrow(result.nodes, () =>
-      notFoundError("Initiative", nameOrId),
-    ).id;
+    return asUuid(
+      firstOrThrow(result.nodes, () => notFoundError("Initiative", nameOrId))
+        .id,
+    );
   }
 
   const candidates = result.nodes.map((node) => `${node.name} (${node.id})`);
@@ -70,9 +71,9 @@ export async function resolveInitiativeId(
 
 export async function resolveInitiativeRelationId(
   client: GraphQLClient,
-  parentId: string,
-  childId: string,
-): Promise<string> {
+  parentId: UUID,
+  childId: UUID,
+): Promise<UUID> {
   let after: string | undefined;
 
   while (true) {
@@ -89,7 +90,7 @@ export async function resolveInitiativeRelationId(
     );
 
     if (relation) {
-      return relation.id;
+      return asUuid(relation.id);
     }
 
     if (!result.initiativeRelations.pageInfo.hasNextPage) {
@@ -107,9 +108,9 @@ export async function resolveInitiativeRelationId(
 
 export async function resolveInitiativeProjectLinkId(
   client: GraphQLClient,
-  initiativeId: string,
-  projectId: string,
-): Promise<string> {
+  initiativeId: UUID,
+  projectId: UUID,
+): Promise<UUID> {
   let after: string | undefined;
 
   while (true) {
@@ -124,7 +125,7 @@ export async function resolveInitiativeProjectLinkId(
     );
 
     if (link) {
-      return link.id;
+      return asUuid(link.id);
     }
 
     if (!result.initiativeToProjects.pageInfo.hasNextPage) {

--- a/src/resolvers/issue-filter-resolver.ts
+++ b/src/resolvers/issue-filter-resolver.ts
@@ -1,4 +1,5 @@
 import type { LinearSdkClient } from "../client/linear-client.js";
+import type { UUID } from "../common/identifier.js";
 import { resolveCycleId } from "./cycle-resolver.js";
 import { resolveIssueId } from "./issue-resolver.js";
 import { resolveLabelIds } from "./label-resolver.js";
@@ -19,14 +20,14 @@ export interface SearchFilterResolutionInput {
 }
 
 export interface SearchFilterResolution {
-  teamId?: string;
-  assigneeId?: string;
-  creatorId?: string;
-  projectId?: string;
-  stateIds?: string[];
-  labelIds?: string[];
-  cycleId?: string;
-  parentId?: string;
+  teamId?: UUID;
+  assigneeId?: UUID;
+  creatorId?: UUID;
+  projectId?: UUID;
+  stateIds?: UUID[];
+  labelIds?: UUID[];
+  cycleId?: UUID;
+  parentId?: UUID;
 }
 
 export async function resolveSearchFilterIds(

--- a/src/resolvers/issue-resolver.ts
+++ b/src/resolvers/issue-resolver.ts
@@ -1,7 +1,12 @@
 import type { LinearSdkClient } from "../client/linear-client.js";
 import { firstOrThrow } from "../common/array.js";
 import { notFoundError } from "../common/errors.js";
-import { isUuid, parseIssueIdentifier } from "../common/identifier.js";
+import {
+  asUuid,
+  isUuid,
+  parseIssueIdentifier,
+  type UUID,
+} from "../common/identifier.js";
 import { omitUndefined } from "../common/object.js";
 import {
   resolveTeamEstimateContext,
@@ -77,7 +82,7 @@ async function getIssueTeamLookup(
 }
 
 export interface IssueEstimateContext {
-  issueId: string;
+  issueId: UUID;
   team: TeamEstimateContext;
 }
 
@@ -94,8 +99,8 @@ export interface IssueEstimateContext {
 export async function resolveIssueId(
   client: LinearSdkClient,
   issueIdOrIdentifier: string,
-): Promise<string> {
-  if (isUuid(issueIdOrIdentifier)) return issueIdOrIdentifier;
+): Promise<UUID> {
+  if (isUuid(issueIdOrIdentifier)) return asUuid(issueIdOrIdentifier);
 
   const { teamKey, issueNumber } = parseIssueIdentifier(issueIdOrIdentifier);
 
@@ -107,9 +112,11 @@ export async function resolveIssueId(
     first: 1,
   });
 
-  return firstOrThrow(issues.nodes, () =>
-    notFoundError("Issue", issueIdOrIdentifier),
-  ).id;
+  return asUuid(
+    firstOrThrow(issues.nodes, () =>
+      notFoundError("Issue", issueIdOrIdentifier),
+    ).id,
+  );
 }
 
 export async function resolveIssueEstimateContext(
@@ -152,7 +159,7 @@ export async function resolveIssueEstimateContext(
   }
 
   return {
-    issueId: projection.id,
+    issueId: asUuid(projection.id),
     team: await resolveTeamEstimateContext(client, teamLookup),
   };
 }

--- a/src/resolvers/label-resolver.ts
+++ b/src/resolvers/label-resolver.ts
@@ -1,7 +1,7 @@
 import type { LinearSdkClient } from "../client/linear-client.js";
 import { firstOrThrow } from "../common/array.js";
 import { notFoundError } from "../common/errors.js";
-import { isUuid } from "../common/identifier.js";
+import { asUuid, isUuid, type UUID } from "../common/identifier.js";
 
 export type LabelResolverScope = "workspace" | "team";
 
@@ -42,20 +42,22 @@ export async function resolveLabelId(
   client: LinearSdkClient,
   nameOrId: string,
   options: ResolveLabelOptions = {},
-): Promise<string> {
-  if (isUuid(nameOrId)) return nameOrId;
+): Promise<UUID> {
+  if (isUuid(nameOrId)) return asUuid(nameOrId);
 
   const result = await client.sdk.issueLabels({
     filter: buildLabelFilter(nameOrId, options),
     first: 1,
   });
 
-  return firstOrThrow(result.nodes, () => notFoundError("Label", nameOrId)).id;
+  return asUuid(
+    firstOrThrow(result.nodes, () => notFoundError("Label", nameOrId)).id,
+  );
 }
 
 export async function resolveLabelIds(
   client: LinearSdkClient,
   namesOrIds: string[],
-): Promise<string[]> {
+): Promise<UUID[]> {
   return Promise.all(namesOrIds.map((id) => resolveLabelId(client, id)));
 }

--- a/src/resolvers/milestone-resolver.ts
+++ b/src/resolvers/milestone-resolver.ts
@@ -2,7 +2,7 @@ import type { GraphQLClient } from "../client/graphql-client.js";
 import type { LinearSdkClient } from "../client/linear-client.js";
 import { firstOrThrow } from "../common/array.js";
 import { multipleMatchesError, notFoundError } from "../common/errors.js";
-import { isUuid } from "../common/identifier.js";
+import { asUuid, isUuid, type UUID } from "../common/identifier.js";
 import {
   FindProjectMilestoneGlobalDocument,
   FindProjectMilestoneScopedDocument,
@@ -33,8 +33,8 @@ export async function resolveMilestoneId(
   sdkClient: LinearSdkClient,
   nameOrId: string,
   projectNameOrId?: string,
-): Promise<string> {
-  if (isUuid(nameOrId)) return nameOrId;
+): Promise<UUID> {
+  if (isUuid(nameOrId)) return asUuid(nameOrId);
 
   type MilestoneNode = {
     id: string;
@@ -77,5 +77,7 @@ export async function resolveMilestoneId(
     );
   }
 
-  return firstOrThrow(nodes, () => notFoundError("Milestone", nameOrId)).id;
+  return asUuid(
+    firstOrThrow(nodes, () => notFoundError("Milestone", nameOrId)).id,
+  );
 }

--- a/src/resolvers/project-resolver.ts
+++ b/src/resolvers/project-resolver.ts
@@ -1,7 +1,7 @@
 import type { LinearSdkClient } from "../client/linear-client.js";
 import { firstOrThrow } from "../common/array.js";
 import { multipleMatchesError, notFoundError } from "../common/errors.js";
-import { isUuid } from "../common/identifier.js";
+import { asUuid, isUuid, type UUID } from "../common/identifier.js";
 import { omitUndefined } from "../common/object.js";
 
 export interface ResolveProjectIdOptions {
@@ -12,8 +12,8 @@ export async function resolveProjectId(
   client: LinearSdkClient,
   nameOrId: string,
   options: ResolveProjectIdOptions = {},
-): Promise<string> {
-  if (isUuid(nameOrId)) return nameOrId;
+): Promise<UUID> {
+  if (isUuid(nameOrId)) return asUuid(nameOrId);
 
   const result = await client.sdk.projects(
     omitUndefined({
@@ -36,30 +36,32 @@ export async function resolveProjectId(
     );
   }
 
-  return firstOrThrow(result.nodes, () => notFoundError("Project", nameOrId))
-    .id;
+  return asUuid(
+    firstOrThrow(result.nodes, () => notFoundError("Project", nameOrId)).id,
+  );
 }
 
 export async function resolveProjectLabelId(
   client: LinearSdkClient,
   nameOrId: string,
-): Promise<string> {
-  if (isUuid(nameOrId)) return nameOrId;
+): Promise<UUID> {
+  if (isUuid(nameOrId)) return asUuid(nameOrId);
 
   const result = await client.sdk.projectLabels({
     filter: { name: { eqIgnoreCase: nameOrId } },
     first: 1,
   });
 
-  return firstOrThrow(result.nodes, () =>
-    notFoundError("Project label", nameOrId),
-  ).id;
+  return asUuid(
+    firstOrThrow(result.nodes, () => notFoundError("Project label", nameOrId))
+      .id,
+  );
 }
 
 export async function resolveProjectLabelIds(
   client: LinearSdkClient,
   namesOrIds: string[],
-): Promise<string[]> {
+): Promise<UUID[]> {
   return Promise.all(
     namesOrIds.map((nameOrId) => resolveProjectLabelId(client, nameOrId)),
   );

--- a/src/resolvers/project-status-resolver.ts
+++ b/src/resolvers/project-status-resolver.ts
@@ -1,6 +1,6 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
 import { notFoundError } from "../common/errors.js";
-import { isUuid } from "../common/identifier.js";
+import { asUuid, isUuid, type UUID } from "../common/identifier.js";
 import { GetProjectStatusesDocument } from "../gql/graphql.js";
 
 /**
@@ -23,8 +23,8 @@ import { GetProjectStatusesDocument } from "../gql/graphql.js";
 export async function resolveProjectStatusId(
   client: GraphQLClient,
   nameOrId: string,
-): Promise<string> {
-  if (isUuid(nameOrId)) return nameOrId;
+): Promise<UUID> {
+  if (isUuid(nameOrId)) return asUuid(nameOrId);
 
   const result = await client.request(GetProjectStatusesDocument);
   const match = result.projectStatuses.nodes.find(
@@ -35,5 +35,5 @@ export async function resolveProjectStatusId(
     throw notFoundError("Project status", nameOrId);
   }
 
-  return match.id;
+  return asUuid(match.id);
 }

--- a/src/resolvers/status-resolver.ts
+++ b/src/resolvers/status-resolver.ts
@@ -2,14 +2,14 @@ import type { LinearDocument } from "@linear/sdk";
 import type { LinearSdkClient } from "../client/linear-client.js";
 import { firstOrThrow } from "../common/array.js";
 import { notFoundError } from "../common/errors.js";
-import { isUuid } from "../common/identifier.js";
+import { asUuid, isUuid, type UUID } from "../common/identifier.js";
 
 export async function resolveStatusId(
   client: LinearSdkClient,
   nameOrId: string,
-  teamId?: string,
-): Promise<string> {
-  if (isUuid(nameOrId)) return nameOrId;
+  teamId?: UUID,
+): Promise<UUID> {
+  if (isUuid(nameOrId)) return asUuid(nameOrId);
 
   const filter: LinearDocument.WorkflowStateFilter = {
     name: { eqIgnoreCase: nameOrId },
@@ -24,11 +24,13 @@ export async function resolveStatusId(
     first: 1,
   });
 
-  return firstOrThrow(result.nodes, () =>
-    notFoundError(
-      "Status",
-      nameOrId,
-      teamId ? `for team ${teamId}` : undefined,
-    ),
-  ).id;
+  return asUuid(
+    firstOrThrow(result.nodes, () =>
+      notFoundError(
+        "Status",
+        nameOrId,
+        teamId ? `for team ${teamId}` : undefined,
+      ),
+    ).id,
+  );
 }

--- a/src/resolvers/team-resolver.ts
+++ b/src/resolvers/team-resolver.ts
@@ -1,6 +1,6 @@
 import type { LinearSdkClient } from "../client/linear-client.js";
 import { notFoundError } from "../common/errors.js";
-import { isUuid } from "../common/identifier.js";
+import { asUuid, isUuid, type UUID } from "../common/identifier.js";
 
 type TeamEstimationType =
   | "notUsed"
@@ -10,7 +10,7 @@ type TeamEstimationType =
   | "tShirt";
 
 export interface TeamEstimateContext {
-  teamId: string;
+  teamId: UUID;
   teamKey: string;
   teamName: string;
   issueEstimationType: TeamEstimationType;
@@ -85,7 +85,7 @@ function mapTeamNodeToEstimateContext(
   node: TeamEstimateNode,
 ): TeamEstimateContext {
   return {
-    teamId: node.id,
+    teamId: asUuid(node.id),
     teamKey: node.key,
     teamName: node.name,
     issueEstimationType: node.issueEstimationType,
@@ -137,8 +137,8 @@ export async function resolveTeamEstimateContext(
 export async function resolveTeamId(
   client: LinearSdkClient,
   keyOrNameOrId: string,
-): Promise<string> {
-  if (isUuid(keyOrNameOrId)) return keyOrNameOrId;
+): Promise<UUID> {
+  if (isUuid(keyOrNameOrId)) return asUuid(keyOrNameOrId);
 
   // Try by key first
   const byKey = await client.sdk.teams({
@@ -146,7 +146,7 @@ export async function resolveTeamId(
     first: 1,
   });
   const [byKeyMatch] = byKey.nodes;
-  if (byKeyMatch) return byKeyMatch.id;
+  if (byKeyMatch) return asUuid(byKeyMatch.id);
 
   // Fall back to name
   const byName = await client.sdk.teams({
@@ -154,7 +154,7 @@ export async function resolveTeamId(
     first: 1,
   });
   const [byNameMatch] = byName.nodes;
-  if (byNameMatch) return byNameMatch.id;
+  if (byNameMatch) return asUuid(byNameMatch.id);
 
   throw notFoundError("Team", keyOrNameOrId);
 }

--- a/src/resolvers/user-resolver.ts
+++ b/src/resolvers/user-resolver.ts
@@ -1,12 +1,12 @@
 import type { LinearSdkClient } from "../client/linear-client.js";
 import { multipleMatchesError, notFoundError } from "../common/errors.js";
-import { isUuid } from "../common/identifier.js";
+import { asUuid, isUuid, type UUID } from "../common/identifier.js";
 
 export async function resolveUserId(
   client: LinearSdkClient,
   nameOrEmailOrId: string,
-): Promise<string> {
-  if (isUuid(nameOrEmailOrId)) return nameOrEmailOrId;
+): Promise<UUID> {
+  if (isUuid(nameOrEmailOrId)) return asUuid(nameOrEmailOrId);
 
   // Try by display name first (case-insensitive)
   const byName = await client.sdk.users({
@@ -15,7 +15,7 @@ export async function resolveUserId(
   });
 
   const [byNameMatch] = byName.nodes;
-  if (byName.nodes.length === 1 && byNameMatch) return byNameMatch.id;
+  if (byName.nodes.length === 1 && byNameMatch) return asUuid(byNameMatch.id);
 
   if (byName.nodes.length > 1) {
     throw multipleMatchesError(
@@ -33,7 +33,7 @@ export async function resolveUserId(
   });
 
   const [byEmailMatch] = byEmail.nodes;
-  if (byEmailMatch) return byEmailMatch.id;
+  if (byEmailMatch) return asUuid(byEmailMatch.id);
 
   throw notFoundError("User", nameOrEmailOrId);
 }

--- a/src/services/attachment-service.ts
+++ b/src/services/attachment-service.ts
@@ -1,4 +1,5 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import type { BrandUuidFields, UUID } from "../common/identifier.js";
 import {
   requireMutationEntity,
   requireMutationSuccess,
@@ -20,9 +21,12 @@ export type CreatedAttachment =
   AttachmentCreateMutation["attachmentCreate"]["attachment"];
 
 // Service-owned input type (UUIDs pre-resolved by the command).
-export type CreateAttachmentInput = Pick<
-  AttachmentCreateInput,
-  "issueId" | "title" | "url" | "subtitle" | "commentBody" | "iconUrl"
+export type CreateAttachmentInput = BrandUuidFields<
+  Pick<
+    AttachmentCreateInput,
+    "issueId" | "title" | "url" | "subtitle" | "commentBody" | "iconUrl"
+  >,
+  "issueId"
 >;
 
 export interface AttachmentFilterOptions {
@@ -73,7 +77,7 @@ export async function createAttachment(
 
 export async function deleteAttachment(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<{ id: string; success: boolean }> {
   const result = await client.request(AttachmentDeleteDocument, { id });
 
@@ -87,7 +91,7 @@ export async function deleteAttachment(
 
 export async function listAttachments(
   client: GraphQLClient,
-  issueId: string,
+  issueId: UUID,
   filter?: AttachmentFilter,
 ): Promise<AttachmentListItem[]> {
   const result = await client.request(ListAttachmentsDocument, {

--- a/src/services/comment-service.ts
+++ b/src/services/comment-service.ts
@@ -1,4 +1,5 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import type { BrandUuidFields, UUID } from "../common/identifier.js";
 import {
   requireMutationEntity,
   requireMutationSuccess,
@@ -28,7 +29,7 @@ export type CommentListItem =
 
 export async function createComment(
   client: GraphQLClient,
-  input: CommentCreateInput,
+  input: BrandUuidFields<CommentCreateInput, "issueId" | "parentId">,
 ): Promise<CreatedComment> {
   const result = await client.request(CreateCommentDocument, { input });
 
@@ -41,7 +42,7 @@ export async function createComment(
 
 export async function updateComment(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
   input: CommentUpdateInput,
 ): Promise<UpdatedComment> {
   const result = await client.request(UpdateCommentDocument, { id, input });
@@ -55,7 +56,7 @@ export async function updateComment(
 
 export async function listComments(
   client: GraphQLClient,
-  issueId: string,
+  issueId: UUID,
   options: PaginationOptions = {},
 ): Promise<PaginatedResult<CommentListItem>> {
   const { limit = 25, after } = options;
@@ -81,7 +82,7 @@ export async function listComments(
 
 export async function replyToComment(
   client: GraphQLClient,
-  input: { parentId: string; body: string },
+  input: { parentId: UUID; body: string },
 ): Promise<CreatedComment> {
   const result = await client.request(CreateCommentDocument, {
     input: { parentId: input.parentId, body: input.body },
@@ -96,7 +97,7 @@ export async function replyToComment(
 
 export async function deleteComment(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<{ id: string; success: boolean }> {
   const result = await client.request(DeleteCommentDocument, { id });
 

--- a/src/services/cycle-service.ts
+++ b/src/services/cycle-service.ts
@@ -1,4 +1,5 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import type { UUID } from "../common/identifier.js";
 import type { PaginatedResult, PaginationOptions } from "../common/types.js";
 import {
   type CycleFilter,
@@ -28,7 +29,7 @@ export interface CycleDetail extends Cycle {
 
 export async function listCycles(
   client: GraphQLClient,
-  teamId?: string,
+  teamId?: UUID,
   activeOnly: boolean = false,
   options: PaginationOptions = {},
 ): Promise<PaginatedResult<Cycle>> {
@@ -66,7 +67,7 @@ export async function listCycles(
 
 export async function getCycle(
   client: GraphQLClient,
-  cycleId: string,
+  cycleId: UUID,
   issuesLimit: number = 50,
 ): Promise<CycleDetail> {
   const result = await client.request(GetCycleByIdDocument, {

--- a/src/services/discussion-service.ts
+++ b/src/services/discussion-service.ts
@@ -1,4 +1,5 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import type { UUID } from "../common/identifier.js";
 import {
   requireMutationEntity,
   requireMutationSuccess,
@@ -82,7 +83,7 @@ type DeleteDiscussionReactionResult = Awaited<
 >;
 
 interface DiscussionReactionTargetInput {
-  commentId: string;
+  commentId: UUID;
   target: DiscussionReactionTarget;
   expectedEntityKind?: DiscussionEntityKind;
 }
@@ -98,7 +99,7 @@ interface DeleteDiscussionReactionByEmojiInput
 
 interface DeleteDiscussionReactionByIdInput
   extends DiscussionReactionTargetInput {
-  reactionId: string;
+  reactionId: UUID;
 }
 
 function normalizeDiscussionCommentReactions<
@@ -165,7 +166,7 @@ function assertExpectedDiscussionEntityKind(
 
 async function assertDiscussionCommentExists(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
   expectedEntityKind?: DiscussionEntityKind,
   label: "comment" | "reply" = "comment",
 ): Promise<DiscussionCommentContext> {
@@ -184,7 +185,7 @@ async function assertDiscussionCommentExists(
 
 async function assertRootDiscussionThread(
   client: GraphQLClient,
-  threadId: string,
+  threadId: UUID,
   expectedEntityKind?: DiscussionEntityKind,
 ): Promise<DiscussionThreadContext> {
   const result = await client.request(GetDiscussionCommentContextDocument, {
@@ -212,7 +213,7 @@ async function assertRootDiscussionThread(
 
 async function assertReplyComment(
   client: GraphQLClient,
-  commentId: string,
+  commentId: UUID,
   expectedEntityKind?: DiscussionEntityKind,
 ): Promise<DiscussionCommentContext> {
   const comment = await assertDiscussionCommentExists(
@@ -403,7 +404,7 @@ async function listDiscussionReplyCandidatesWithReactions(
 
 function filterThreadReplies<T extends DiscussionCommentFieldsFragment>(
   comments: readonly T[],
-  threadId: string,
+  threadId: UUID,
 ): T[] {
   const childrenByParentId = new Map<string, T[]>();
 
@@ -499,7 +500,7 @@ export async function createDiscussionCommentReaction(
 
 export async function createIssueDiscussionCommentReaction(
   client: GraphQLClient,
-  input: { commentId: string; emoji: string },
+  input: { commentId: UUID; emoji: string },
 ): Promise<CreateDiscussionReactionResult> {
   await assertDiscussionCommentExists(client, input.commentId, "issue");
 
@@ -524,7 +525,7 @@ export async function deleteDiscussionCommentReactionByEmoji(
 
 export async function deleteIssueDiscussionCommentReactionByEmoji(
   client: GraphQLClient,
-  input: { commentId: string; emoji: string },
+  input: { commentId: UUID; emoji: string },
 ): Promise<DeleteDiscussionReactionResult> {
   await assertDiscussionCommentExists(client, input.commentId, "issue");
 
@@ -550,7 +551,7 @@ export async function deleteDiscussionCommentReactionById(
 
 export async function deleteIssueDiscussionCommentReactionById(
   client: GraphQLClient,
-  input: { commentId: string; reactionId: string },
+  input: { commentId: UUID; reactionId: UUID },
 ): Promise<DeleteDiscussionReactionResult> {
   await assertDiscussionCommentExists(client, input.commentId, "issue");
 
@@ -563,7 +564,7 @@ export async function deleteIssueDiscussionCommentReactionById(
 
 export async function listDiscussionsForIssue(
   client: GraphQLClient,
-  issueId: string,
+  issueId: UUID,
   options: PaginationOptions = {},
 ): Promise<PaginatedResult<DiscussionThread>> {
   const { limit = DEFAULT_ROOT_LIMIT, after } = options;
@@ -585,7 +586,7 @@ export async function listDiscussionsForIssue(
 
 export async function listDiscussionsForIssueWithReactions(
   client: GraphQLClient,
-  issueId: string,
+  issueId: UUID,
   options: PaginationOptions = {},
 ): Promise<PaginatedResult<DiscussionThreadWithReactions>> {
   const { limit = DEFAULT_ROOT_LIMIT, after } = options;
@@ -610,7 +611,7 @@ export async function listDiscussionsForIssueWithReactions(
 
 export async function listDiscussionsForProject(
   client: GraphQLClient,
-  projectId: string,
+  projectId: UUID,
   options: PaginationOptions = {},
 ): Promise<PaginatedResult<DiscussionThread>> {
   const { limit = DEFAULT_ROOT_LIMIT, after } = options;
@@ -632,7 +633,7 @@ export async function listDiscussionsForProject(
 
 export async function listDiscussionsForProjectWithReactions(
   client: GraphQLClient,
-  projectId: string,
+  projectId: UUID,
   options: PaginationOptions = {},
 ): Promise<PaginatedResult<DiscussionThreadWithReactions>> {
   const { limit = DEFAULT_ROOT_LIMIT, after } = options;
@@ -657,7 +658,7 @@ export async function listDiscussionsForProjectWithReactions(
 
 export async function listDiscussionsForInitiative(
   client: GraphQLClient,
-  initiativeId: string,
+  initiativeId: UUID,
   options: PaginationOptions = {},
 ): Promise<PaginatedResult<DiscussionThread>> {
   const { limit = DEFAULT_ROOT_LIMIT, after } = options;
@@ -680,7 +681,7 @@ export async function listDiscussionsForInitiative(
 
 export async function listDiscussionsForInitiativeWithReactions(
   client: GraphQLClient,
-  initiativeId: string,
+  initiativeId: UUID,
   options: PaginationOptions = {},
 ): Promise<PaginatedResult<DiscussionThreadWithReactions>> {
   const { limit = DEFAULT_ROOT_LIMIT, after } = options;
@@ -706,7 +707,7 @@ export async function listDiscussionsForInitiativeWithReactions(
 
 export async function listDiscussionReplies(
   client: GraphQLClient,
-  threadId: string,
+  threadId: UUID,
   options: PaginationOptions = {},
   expectedEntityKind?: DiscussionEntityKind,
 ): Promise<PaginatedResult<DiscussionCommentFieldsFragment>> {
@@ -724,7 +725,7 @@ export async function listDiscussionReplies(
 
 export async function listDiscussionRepliesWithReactions(
   client: GraphQLClient,
-  threadId: string,
+  threadId: UUID,
   options: PaginationOptions = {},
   expectedEntityKind?: DiscussionEntityKind,
 ): Promise<PaginatedResult<DiscussionThreadWithReactions>> {
@@ -745,14 +746,14 @@ export async function listDiscussionRepliesWithReactions(
 
 export async function startIssueDiscussion(
   client: GraphQLClient,
-  input: { issueId: string; body: string },
+  input: { issueId: UUID; body: string },
 ): Promise<StartDiscussionMutation["commentCreate"]["comment"]> {
   return startDiscussion(client, { issueId: input.issueId, body: input.body });
 }
 
 export async function startProjectDiscussion(
   client: GraphQLClient,
-  input: { projectId: string; body: string },
+  input: { projectId: UUID; body: string },
 ): Promise<StartDiscussionMutation["commentCreate"]["comment"]> {
   return startDiscussion(client, {
     projectId: input.projectId,
@@ -762,7 +763,7 @@ export async function startProjectDiscussion(
 
 export async function startInitiativeDiscussion(
   client: GraphQLClient,
-  input: { initiativeId: string; body: string },
+  input: { initiativeId: UUID; body: string },
 ): Promise<StartDiscussionMutation["commentCreate"]["comment"]> {
   return startDiscussion(client, {
     initiativeId: input.initiativeId,
@@ -772,7 +773,7 @@ export async function startInitiativeDiscussion(
 
 export async function replyToDiscussion(
   client: GraphQLClient,
-  input: { threadId: string; body: string; entityKind?: DiscussionEntityKind },
+  input: { threadId: UUID; body: string; entityKind?: DiscussionEntityKind },
 ): Promise<StartDiscussionMutation["commentCreate"]["comment"]> {
   const thread = await assertRootDiscussionThread(
     client,
@@ -804,7 +805,7 @@ export async function replyToDiscussion(
 
 export async function editDiscussionReply(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
   input: CommentUpdateInput,
   expectedEntityKind?: DiscussionEntityKind,
 ): Promise<EditDiscussionReplyMutation["commentUpdate"]["comment"]> {
@@ -824,7 +825,7 @@ export async function editDiscussionReply(
 
 export async function deleteDiscussionReply(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
   expectedEntityKind?: DiscussionEntityKind,
 ): Promise<{ id: string; success: true }> {
   await assertReplyComment(client, id, expectedEntityKind);
@@ -844,7 +845,7 @@ export async function deleteDiscussionReply(
 
 export async function editDiscussionComment(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
   input: CommentUpdateInput,
   expectedEntityKind?: DiscussionEntityKind,
 ): Promise<EditDiscussionReplyMutation["commentUpdate"]["comment"]> {
@@ -864,7 +865,7 @@ export async function editDiscussionComment(
 
 export async function deleteDiscussionComment(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
   expectedEntityKind?: DiscussionEntityKind,
 ): Promise<{ id: string; success: true }> {
   await assertDiscussionCommentExists(client, id, expectedEntityKind);
@@ -885,8 +886,8 @@ export async function deleteDiscussionComment(
 export async function resolveDiscussion(
   client: GraphQLClient,
   input: {
-    threadId: string;
-    resolvingCommentId?: string;
+    threadId: UUID;
+    resolvingCommentId?: UUID;
     entityKind?: DiscussionEntityKind;
   },
 ): Promise<ResolveDiscussionMutation["commentResolve"]["comment"]> {
@@ -906,7 +907,7 @@ export async function resolveDiscussion(
 
 export async function unresolveDiscussion(
   client: GraphQLClient,
-  threadId: string,
+  threadId: UUID,
   expectedEntityKind?: DiscussionEntityKind,
 ): Promise<UnresolveDiscussionMutation["commentUnresolve"]["comment"]> {
   await assertRootDiscussionThread(client, threadId, expectedEntityKind);

--- a/src/services/document-service.ts
+++ b/src/services/document-service.ts
@@ -1,4 +1,5 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import type { BrandUuidFields, UUID } from "../common/identifier.js";
 import {
   requireMutationEntity,
   requireMutationSuccess,
@@ -28,21 +29,27 @@ export type UpdatedDocument =
   DocumentUpdateMutation["documentUpdate"]["document"];
 
 // Service-owned input types (UUIDs pre-resolved by the command).
-export type CreateDocumentInput = Pick<
-  DocumentCreateInput,
-  "title" | "content" | "projectId" | "teamId" | "issueId" | "icon" | "color"
+export type CreateDocumentInput = BrandUuidFields<
+  Pick<
+    DocumentCreateInput,
+    "title" | "content" | "projectId" | "teamId" | "issueId" | "icon" | "color"
+  >,
+  "projectId" | "teamId" | "issueId"
 >;
-export type UpdateDocumentInput = Pick<
-  DocumentUpdateInput,
-  "title" | "content" | "projectId" | "icon" | "color"
+export type UpdateDocumentInput = BrandUuidFields<
+  Pick<
+    DocumentUpdateInput,
+    "title" | "content" | "projectId" | "icon" | "color"
+  >,
+  "projectId"
 >;
 
-export function buildProjectDocumentFilter(projectId: string): DocumentFilter {
+export function buildProjectDocumentFilter(projectId: UUID): DocumentFilter {
   return { project: { id: { eq: projectId } } };
 }
 
 export function buildIssueDocumentFilter(
-  issueId: string,
+  issueId: UUID,
   legacyDocumentSlugIds: string[],
 ): DocumentFilter {
   const issueFilter: DocumentFilter = { issue: { id: { eq: issueId } } };
@@ -62,7 +69,7 @@ export function buildIssueDocumentFilter(
 
 export async function getDocument(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<DocumentDetail> {
   const result = await client.request(GetDocumentDocument, {
     id,
@@ -93,7 +100,7 @@ export async function createDocument(
 
 export async function updateDocument(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
   input: UpdateDocumentInput,
 ): Promise<UpdatedDocument> {
   const gqlInput: DocumentUpdateInput = input;
@@ -134,7 +141,7 @@ export async function listDocuments(
 
 export async function deleteDocument(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<{ id: string; success: boolean }> {
   const result = await client.request(DocumentDeleteDocument, { id });
 

--- a/src/services/initiative-project-service.ts
+++ b/src/services/initiative-project-service.ts
@@ -1,4 +1,5 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import type { UUID } from "../common/identifier.js";
 import { requireMutationEntity } from "../common/mutation-payload.js";
 import {
   CreateInitiativeToProjectDocument,
@@ -20,7 +21,7 @@ export type DeletedInitiativeProjectLink = {
 
 export async function createInitiativeProjectLink(
   client: GraphQLClient,
-  input: { initiativeId: string; projectId: string },
+  input: { initiativeId: UUID; projectId: UUID },
 ): Promise<InitiativeProjectLink> {
   const result = await client.request(CreateInitiativeToProjectDocument, {
     input,
@@ -35,7 +36,7 @@ export async function createInitiativeProjectLink(
 
 export async function deleteInitiativeProjectLink(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<DeletedInitiativeProjectLink> {
   const result = await client.request(DeleteInitiativeToProjectDocument, {
     id,

--- a/src/services/initiative-relation-service.ts
+++ b/src/services/initiative-relation-service.ts
@@ -1,4 +1,5 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import type { UUID } from "../common/identifier.js";
 import { requireMutationEntity } from "../common/mutation-payload.js";
 import {
   CreateInitiativeRelationDocument,
@@ -20,7 +21,7 @@ export type DeletedInitiativeRelation = {
 
 export async function createInitiativeRelation(
   client: GraphQLClient,
-  input: { parentId: string; childId: string },
+  input: { parentId: UUID; childId: UUID },
 ): Promise<InitiativeRelation> {
   const result = await client.request(CreateInitiativeRelationDocument, {
     input: {
@@ -38,7 +39,7 @@ export async function createInitiativeRelation(
 
 export async function deleteInitiativeRelation(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<DeletedInitiativeRelation> {
   const result = await client.request(DeleteInitiativeRelationDocument, { id });
 

--- a/src/services/initiative-service.ts
+++ b/src/services/initiative-service.ts
@@ -1,5 +1,6 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
 import { invalidParameterError } from "../common/errors.js";
+import type { BrandUuidFields, UUID } from "../common/identifier.js";
 import { requireMutationEntity } from "../common/mutation-payload.js";
 import type { PaginatedResult } from "../common/types.js";
 import {
@@ -47,25 +48,31 @@ export type DeletedInitiative = {
 };
 
 // Service-owned input types (UUIDs pre-resolved by the command).
-export type CreateInitiativeInput = Pick<
-  InitiativeCreateInput,
-  | "name"
-  | "description"
-  | "content"
-  | "ownerId"
-  | "status"
-  | "targetDate"
-  | "sortOrder"
+export type CreateInitiativeInput = BrandUuidFields<
+  Pick<
+    InitiativeCreateInput,
+    | "name"
+    | "description"
+    | "content"
+    | "ownerId"
+    | "status"
+    | "targetDate"
+    | "sortOrder"
+  >,
+  "ownerId"
 >;
-export type UpdateInitiativeInput = Pick<
-  InitiativeUpdateInput,
-  | "name"
-  | "description"
-  | "content"
-  | "ownerId"
-  | "status"
-  | "targetDate"
-  | "sortOrder"
+export type UpdateInitiativeInput = BrandUuidFields<
+  Pick<
+    InitiativeUpdateInput,
+    | "name"
+    | "description"
+    | "content"
+    | "ownerId"
+    | "status"
+    | "targetDate"
+    | "sortOrder"
+  >,
+  "ownerId"
 >;
 
 export type InitiativeSortBy =
@@ -143,9 +150,9 @@ export interface InitiativeFilterInput {
   status?: InitiativeStatus;
   health?: string;
   healthWithAge?: string;
-  ownerId?: string;
-  creatorId?: string;
-  teamId?: string;
+  ownerId?: UUID;
+  creatorId?: UUID;
+  teamId?: UUID;
   targetAfter?: string;
   targetBefore?: string;
   startedAfter?: string;
@@ -156,7 +163,7 @@ export interface InitiativeFilterInput {
   createdBefore?: string;
   updatedAfter?: string;
   updatedBefore?: string;
-  ancestorId?: string;
+  ancestorId?: UUID;
 }
 
 function applyNullableDateRange(
@@ -309,7 +316,7 @@ export async function listInitiatives(
 
 export async function getInitiative(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<InitiativeDetail> {
   const result = await client.request(GetInitiativeDocument, {
     id,
@@ -340,7 +347,7 @@ export async function createInitiative(
 
 export async function updateInitiative(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
   input: UpdateInitiativeInput,
 ): Promise<UpdatedInitiative> {
   const hasAtLeastOneField = Object.values(input).some(
@@ -369,7 +376,7 @@ export async function updateInitiative(
 
 export async function archiveInitiative(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<ArchivedInitiative> {
   const result = await client.request(ArchiveInitiativeDocument, { id });
 
@@ -382,7 +389,7 @@ export async function archiveInitiative(
 
 export async function unarchiveInitiative(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<UnarchivedInitiative> {
   const result = await client.request(UnarchiveInitiativeDocument, { id });
 
@@ -395,7 +402,7 @@ export async function unarchiveInitiative(
 
 export async function deleteInitiative(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<DeletedInitiative> {
   const result = await client.request(DeleteInitiativeDocument, { id });
 

--- a/src/services/initiative-update-service.ts
+++ b/src/services/initiative-update-service.ts
@@ -1,5 +1,6 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
 import { invalidParameterError } from "../common/errors.js";
+import type { BrandUuidFields, UUID } from "../common/identifier.js";
 import { requireMutationEntity } from "../common/mutation-payload.js";
 import type { PaginatedResult } from "../common/types.js";
 import {
@@ -40,16 +41,16 @@ export type UnarchivedInitiativeUpdate = NonNullable<
 >;
 
 export interface InitiativeUpdateListOptions {
-  initiativeId: string;
+  initiativeId: UUID;
   limit?: number;
   after?: string;
   includeArchived?: boolean;
 }
 
 // Service-owned input types (UUIDs pre-resolved by the command).
-export type CreateInitiativeUpdateInput = Pick<
-  InitiativeUpdateCreateInput,
-  "initiativeId" | "body" | "health"
+export type CreateInitiativeUpdateInput = BrandUuidFields<
+  Pick<InitiativeUpdateCreateInput, "initiativeId" | "body" | "health">,
+  "initiativeId"
 >;
 export type UpdateInitiativeUpdateInput = Pick<
   InitiativeUpdateUpdateInput,
@@ -93,7 +94,7 @@ export async function listInitiativeUpdates(
 
 export async function getInitiativeUpdate(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<InitiativeUpdateDetail> {
   const result = await client.request(GetInitiativeUpdateDocument, { id });
 
@@ -122,7 +123,7 @@ export async function createInitiativeUpdate(
 
 export async function updateInitiativeUpdate(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
   input: UpdateInitiativeUpdateInput,
 ): Promise<UpdatedInitiativeUpdate> {
   const hasAtLeastOneField = Object.values(input).some(
@@ -151,7 +152,7 @@ export async function updateInitiativeUpdate(
 
 export async function archiveInitiativeUpdate(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<ArchivedInitiativeUpdate> {
   const result = await client.request(ArchiveInitiativeUpdateDocument, { id });
 
@@ -164,7 +165,7 @@ export async function archiveInitiativeUpdate(
 
 export async function unarchiveInitiativeUpdate(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<UnarchivedInitiativeUpdate> {
   const result = await client.request(UnarchiveInitiativeUpdateDocument, {
     id,

--- a/src/services/issue-relation-service.ts
+++ b/src/services/issue-relation-service.ts
@@ -1,5 +1,6 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
 import { notFoundError } from "../common/errors.js";
+import { asUuid, type UUID } from "../common/identifier.js";
 import { requireMutationSuccess } from "../common/mutation-payload.js";
 import {
   CreateIssueRelationDocument,
@@ -19,8 +20,8 @@ type IssueRelationsIssue = NonNullable<GetIssueRelationsQuery["issue"]>;
 export async function createIssueRelation(
   client: GraphQLClient,
   input: {
-    issueId: string;
-    relatedIssueId: string;
+    issueId: UUID;
+    relatedIssueId: UUID;
     type: IssueRelationType;
   },
 ): Promise<CreatedIssueRelation> {
@@ -34,7 +35,7 @@ export async function createIssueRelation(
 
 export async function listIssueRelations(
   client: GraphQLClient,
-  issueId: string,
+  issueId: UUID,
 ): Promise<{
   issueId: string;
   identifier: string;
@@ -61,9 +62,9 @@ export async function listIssueRelations(
 
 export async function findIssueRelation(
   client: GraphQLClient,
-  issueId: string,
-  relatedIssueId: string,
-): Promise<string> {
+  issueId: UUID,
+  relatedIssueId: UUID,
+): Promise<UUID> {
   const result = await client.request(GetIssueRelationsDocument, { issueId });
 
   if (!result.issue) {
@@ -74,20 +75,20 @@ export async function findIssueRelation(
   const forwardMatch = result.issue.relations.nodes.find(
     (r) => r.relatedIssue.id === relatedIssueId,
   );
-  if (forwardMatch) return forwardMatch.id;
+  if (forwardMatch) return asUuid(forwardMatch.id);
 
   // Check inverse relations
   const inverseMatch = result.issue.inverseRelations.nodes.find(
     (r) => r.issue.id === relatedIssueId,
   );
-  if (inverseMatch) return inverseMatch.id;
+  if (inverseMatch) return asUuid(inverseMatch.id);
 
   throw notFoundError("Relation", `between ${issueId} and ${relatedIssueId}`);
 }
 
 export async function deleteIssueRelation(
   client: GraphQLClient,
-  relationId: string,
+  relationId: UUID,
 ): Promise<{ id: string; success: boolean }> {
   const result = await client.request(DeleteIssueRelationDocument, {
     id: relationId,

--- a/src/services/issue-service.ts
+++ b/src/services/issue-service.ts
@@ -1,5 +1,6 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
 import { firstOrThrow } from "../common/array.js";
+import type { BrandUuidFields, UUID } from "../common/identifier.js";
 import { requireMutationEntity } from "../common/mutation-payload.js";
 import type { PaginatedResult, PaginationOptions } from "../common/types.js";
 import {
@@ -79,36 +80,55 @@ export type UpdatedIssue = NonNullable<
 >;
 
 // Service-owned input types (UUIDs pre-resolved by the command).
-export type CreateIssueInput = Pick<
-  IssueCreateInput,
-  | "title"
+export type CreateIssueInput = BrandUuidFields<
+  Pick<
+    IssueCreateInput,
+    | "title"
+    | "teamId"
+    | "description"
+    | "assigneeId"
+    | "priority"
+    | "estimate"
+    | "projectId"
+    | "labelIds"
+    | "projectMilestoneId"
+    | "cycleId"
+    | "stateId"
+    | "parentId"
+    | "dueDate"
+  >,
   | "teamId"
-  | "description"
   | "assigneeId"
-  | "priority"
-  | "estimate"
   | "projectId"
   | "labelIds"
   | "projectMilestoneId"
   | "cycleId"
   | "stateId"
   | "parentId"
-  | "dueDate"
 >;
-export type UpdateIssueInput = Pick<
-  IssueUpdateInput,
-  | "title"
-  | "description"
+export type UpdateIssueInput = BrandUuidFields<
+  Pick<
+    IssueUpdateInput,
+    | "title"
+    | "description"
+    | "stateId"
+    | "priority"
+    | "estimate"
+    | "assigneeId"
+    | "projectId"
+    | "labelIds"
+    | "parentId"
+    | "projectMilestoneId"
+    | "cycleId"
+    | "dueDate"
+  >,
   | "stateId"
-  | "priority"
-  | "estimate"
   | "assigneeId"
   | "projectId"
   | "labelIds"
   | "parentId"
   | "projectMilestoneId"
   | "cycleId"
-  | "dueDate"
 >;
 
 const NON_COMPLETED_ISSUES_FILTER: IssueFilter = {
@@ -279,7 +299,7 @@ export async function listIssues(
 
 export async function getIssue(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<IssueDetail> {
   const result = await client.request(GetIssueByIdDocument, {
     id,
@@ -292,7 +312,7 @@ export async function getIssue(
 
 export async function getIssueWithComments(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<IssueDetailWithComments> {
   const result = await client.request(GetIssueByIdWithCommentsDocument, { id });
   if (!result.issue) {
@@ -303,7 +323,7 @@ export async function getIssueWithComments(
 
 export async function getIssueWithCommentThreads(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<IssueDetailWithCommentThreads> {
   const issue = await getIssueWithComments(client, id);
   return threadIssueComments(issue);
@@ -354,7 +374,7 @@ export async function getIssueByIdentifierWithCommentThreads(
 
 export async function getIssueWithReactions(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<IssueDetailWithReactions> {
   const result = await client.request(GetIssueByIdWithReactionsDocument, {
     id,
@@ -384,7 +404,7 @@ export async function getIssueByIdentifierWithReactions(
 
 export async function getIssueWithAttachments(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<IssueDetailWithAttachments> {
   const result = await client.request(GetIssueByIdWithAttachmentsDocument, {
     id,
@@ -445,7 +465,7 @@ export async function createIssue(
 
 export async function updateIssue(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
   input: UpdateIssueInput,
 ): Promise<UpdatedIssue> {
   const gqlInput: IssueUpdateInput = input;
@@ -462,7 +482,7 @@ export async function updateIssue(
 
 export async function archiveIssue(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<IssueDetail> {
   const result = await client.request(ArchiveIssueDocument, { id });
 
@@ -475,7 +495,7 @@ export async function archiveIssue(
 
 export async function unarchiveIssue(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<IssueDetail> {
   const result = await client.request(UnarchiveIssueDocument, { id });
 
@@ -488,7 +508,7 @@ export async function unarchiveIssue(
 
 export async function deleteIssue(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<{ id: string; success: true }> {
   const result = await client.request(DeleteIssueDocument, {
     id,

--- a/src/services/label-service.ts
+++ b/src/services/label-service.ts
@@ -1,4 +1,5 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import type { BrandUuidFields, UUID } from "../common/identifier.js";
 import { requireMutationSuccess } from "../common/mutation-payload.js";
 import type { PaginatedResult, PaginationOptions } from "../common/types.js";
 import {
@@ -34,9 +35,9 @@ export interface ListLabelOptions extends PaginationOptions {
 }
 
 // Service-owned input types (UUIDs pre-resolved by the command).
-export type CreateLabelInput = Pick<
-  IssueLabelCreateInput,
-  "name" | "teamId" | "color" | "description"
+export type CreateLabelInput = BrandUuidFields<
+  Pick<IssueLabelCreateInput, "name" | "teamId" | "color" | "description">,
+  "teamId"
 >;
 export type UpdateLabelInput = Pick<
   IssueLabelUpdateInput,
@@ -60,7 +61,7 @@ function mapIssueLabel(label: {
 
 export async function getLabel(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<Label> {
   const result = await client.request(GetIssueLabelDocument, {
     id,
@@ -92,7 +93,7 @@ export async function createLabel(
 
 export async function updateLabel(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
   input: UpdateLabelInput,
 ): Promise<Label> {
   const gqlInput: IssueLabelUpdateInput = input;
@@ -111,7 +112,7 @@ export async function updateLabel(
 
 export async function deleteLabel(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<DeleteLabelResult> {
   const result = await client.request(DeleteIssueLabelDocument, { id });
 
@@ -127,7 +128,7 @@ export async function deleteLabel(
 }
 
 function buildIssueLabelFilter(
-  teamId?: string,
+  teamId?: UUID,
   scope?: LabelScope,
 ): IssueLabelFilter | undefined {
   if (scope === "workspace") {
@@ -147,7 +148,7 @@ function buildIssueLabelFilter(
 
 export async function listLabels(
   client: GraphQLClient,
-  teamId?: string,
+  teamId?: UUID,
   options: ListLabelOptions = {},
 ): Promise<PaginatedResult<Label>> {
   const { limit = 50, after, scope } = options;

--- a/src/services/milestone-service.ts
+++ b/src/services/milestone-service.ts
@@ -1,4 +1,5 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import type { BrandUuidFields, UUID } from "../common/identifier.js";
 import { requireMutationEntity } from "../common/mutation-payload.js";
 import type { PaginatedResult, PaginationOptions } from "../common/types.js";
 import {
@@ -28,9 +29,12 @@ export type UpdatedMilestone = NonNullable<
 >;
 
 // Service-owned input types (UUIDs pre-resolved by the command).
-export type CreateMilestoneInput = Pick<
-  ProjectMilestoneCreateInput,
-  "projectId" | "name" | "description" | "targetDate"
+export type CreateMilestoneInput = BrandUuidFields<
+  Pick<
+    ProjectMilestoneCreateInput,
+    "projectId" | "name" | "description" | "targetDate"
+  >,
+  "projectId"
 >;
 export type UpdateMilestoneInput = Pick<
   ProjectMilestoneUpdateInput,
@@ -39,7 +43,7 @@ export type UpdateMilestoneInput = Pick<
 
 export async function listMilestones(
   client: GraphQLClient,
-  projectId: string,
+  projectId: UUID,
   options: PaginationOptions = {},
 ): Promise<PaginatedResult<MilestoneListItem>> {
   const { limit = 50, after } = options;
@@ -60,7 +64,7 @@ export async function listMilestones(
 
 export async function getMilestone(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
   issuesLimit?: number,
 ): Promise<MilestoneDetail> {
   const result = await client.request(GetProjectMilestoneByIdDocument, {
@@ -93,7 +97,7 @@ export async function createMilestone(
 
 export async function updateMilestone(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
   input: UpdateMilestoneInput,
 ): Promise<UpdatedMilestone> {
   const gqlInput: ProjectMilestoneUpdateInput = input;

--- a/src/services/project-service.ts
+++ b/src/services/project-service.ts
@@ -1,4 +1,5 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import type { BrandUuidFields, UUID } from "../common/identifier.js";
 import {
   requireMutationEntity,
   requireMutationSuccess,
@@ -43,37 +44,43 @@ export type DeletedProject = {
 };
 
 // Service-owned input types (UUIDs pre-resolved by the command).
-export type CreateProjectInput = Pick<
-  ProjectCreateInput,
-  | "name"
-  | "teamIds"
-  | "description"
-  | "content"
-  | "icon"
-  | "color"
-  | "leadId"
-  | "memberIds"
-  | "priority"
-  | "statusId"
-  | "startDate"
-  | "targetDate"
-  | "labelIds"
+export type CreateProjectInput = BrandUuidFields<
+  Pick<
+    ProjectCreateInput,
+    | "name"
+    | "teamIds"
+    | "description"
+    | "content"
+    | "icon"
+    | "color"
+    | "leadId"
+    | "memberIds"
+    | "priority"
+    | "statusId"
+    | "startDate"
+    | "targetDate"
+    | "labelIds"
+  >,
+  "teamIds" | "leadId" | "memberIds" | "statusId" | "labelIds"
 >;
-export type UpdateProjectInput = Pick<
-  ProjectUpdateInput,
-  | "name"
-  | "description"
-  | "content"
-  | "icon"
-  | "color"
-  | "leadId"
-  | "memberIds"
-  | "priority"
-  | "statusId"
-  | "startDate"
-  | "targetDate"
-  | "teamIds"
-  | "labelIds"
+export type UpdateProjectInput = BrandUuidFields<
+  Pick<
+    ProjectUpdateInput,
+    | "name"
+    | "description"
+    | "content"
+    | "icon"
+    | "color"
+    | "leadId"
+    | "memberIds"
+    | "priority"
+    | "statusId"
+    | "startDate"
+    | "targetDate"
+    | "teamIds"
+    | "labelIds"
+  >,
+  "teamIds" | "leadId" | "memberIds" | "statusId" | "labelIds"
 >;
 
 export interface ProjectListOptions extends PaginationOptions {
@@ -111,7 +118,7 @@ export async function listProjects(
 
 export async function getProject(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
   options: ProjectDetailOptions = {},
 ): Promise<ProjectDetail> {
   const milestonesFirst =
@@ -151,7 +158,7 @@ export async function createProject(
 
 export async function updateProject(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
   input: UpdateProjectInput,
 ): Promise<UpdatedProject> {
   const gqlInput: ProjectUpdateInput = input;
@@ -169,7 +176,7 @@ export async function updateProject(
 
 export async function archiveProject(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<ArchivedProject> {
   const result = await client.request(ArchiveProjectDocument, { id });
 
@@ -182,7 +189,7 @@ export async function archiveProject(
 
 export async function unarchiveProject(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<UnarchivedProject> {
   const result = await client.request(UnarchiveProjectDocument, { id });
 
@@ -195,7 +202,7 @@ export async function unarchiveProject(
 
 export async function deleteProject(
   client: GraphQLClient,
-  id: string,
+  id: UUID,
 ): Promise<DeletedProject> {
   const result = await client.request(DeleteProjectDocument, { id });
 

--- a/src/services/reaction-service.ts
+++ b/src/services/reaction-service.ts
@@ -1,6 +1,7 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
 import { firstOrThrow } from "../common/array.js";
 import { normalizeReactionEmojiInput } from "../common/emoji.js";
+import type { UUID } from "../common/identifier.js";
 import { requireMutationSuccess } from "../common/mutation-payload.js";
 import {
   CreateReactionDocument,
@@ -30,7 +31,7 @@ interface NormalizedReactionGroup {
 
 interface ReactionLookupInput {
   kind: "issue" | "comment";
-  id: string;
+  id: UUID;
 }
 
 interface DeleteOwnReactionByEmojiInput extends ReactionLookupInput {
@@ -38,7 +39,7 @@ interface DeleteOwnReactionByEmojiInput extends ReactionLookupInput {
 }
 
 interface DeleteOwnReactionByIdInput extends ReactionLookupInput {
-  reactionId: string;
+  reactionId: UUID;
 }
 
 function compareNormalizedUsers(
@@ -205,7 +206,7 @@ export function normalizeReactions(
 export async function createReactionForIssue(
   client: GraphQLClient,
   input: {
-    issueId: string;
+    issueId: UUID;
     emoji: string;
   },
 ): Promise<CreateReactionMutation["reactionCreate"]["reaction"]> {
@@ -219,7 +220,7 @@ export async function createReactionForIssue(
 export async function createReactionForComment(
   client: GraphQLClient,
   input: {
-    commentId: string;
+    commentId: UUID;
     emoji: string;
   },
 ): Promise<CreateReactionMutation["reactionCreate"]["reaction"]> {

--- a/src/services/team-service.ts
+++ b/src/services/team-service.ts
@@ -1,4 +1,5 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
+import type { UUID } from "../common/identifier.js";
 import type { PaginatedResult, PaginationOptions } from "../common/types.js";
 import {
   GetTeamByIdDocument,
@@ -26,7 +27,7 @@ export interface Team {
 }
 
 interface GetTeamInput {
-  id: string;
+  id: UUID;
 }
 
 type TeamConfigSource = Pick<

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -1,6 +1,8 @@
 // tests/unit/commands/issues.test.ts
+
 import { Command } from "commander";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+import { asUuid } from "../../../src/common/identifier.js";
 
 // Mock all external dependencies before importing the module under test
 vi.mock("../../../src/common/context.js", () => ({
@@ -366,7 +368,7 @@ describe("issues create --estimate", () => {
 
   it("passes estimate 0 through to createIssue when team allows zero", async () => {
     vi.mocked(resolveTeamEstimateContext).mockResolvedValueOnce({
-      teamId: "resolved-team-uuid",
+      teamId: asUuid("resolved-team-uuid"),
       teamKey: "ENG",
       teamName: "Engineering",
       issueEstimationType: "fibonacci",
@@ -437,7 +439,7 @@ describe("issues create --estimate", () => {
 
   it("rejects create estimate when team estimation disabled", async () => {
     vi.mocked(resolveTeamEstimateContext).mockResolvedValueOnce({
-      teamId: "resolved-team-uuid",
+      teamId: asUuid("resolved-team-uuid"),
       teamKey: "ENG",
       teamName: "Engineering",
       issueEstimationType: "notUsed",

--- a/tests/unit/resolvers/initiative-resolver.test.ts
+++ b/tests/unit/resolvers/initiative-resolver.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import type { LinearSdkClient } from "../../../src/client/linear-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import {
   resolveInitiativeId,
   resolveInitiativeProjectLinkId,
@@ -87,8 +88,8 @@ describe("resolveInitiativeId", () => {
 
     await expect(
       resolveInitiativeId(sdk, "Growth", {
-        teamId: "team-1",
-        ownerId: "user-1",
+        teamId: asUuid("team-1"),
+        ownerId: asUuid("user-1"),
       }),
     ).resolves.toBe("init-2");
 
@@ -128,7 +129,7 @@ describe("resolveInitiativeRelationId", () => {
     });
 
     await expect(
-      resolveInitiativeRelationId(gql, "parent-id", "child-id"),
+      resolveInitiativeRelationId(gql, asUuid("parent-id"), asUuid("child-id")),
     ).resolves.toBe("rel-1");
   });
 
@@ -143,7 +144,7 @@ describe("resolveInitiativeRelationId", () => {
     });
 
     await expect(
-      resolveInitiativeRelationId(gql, "parent-id", "child-id"),
+      resolveInitiativeRelationId(gql, asUuid("parent-id"), asUuid("child-id")),
     ).rejects.toThrow(
       'Initiative relation "between parent-id and child-id" not found',
     );
@@ -182,7 +183,7 @@ describe("resolveInitiativeRelationId", () => {
     ]);
 
     await expect(
-      resolveInitiativeRelationId(gql, "parent-id", "child-id"),
+      resolveInitiativeRelationId(gql, asUuid("parent-id"), asUuid("child-id")),
     ).resolves.toBe("rel-2");
 
     expect(gql.request).toHaveBeenNthCalledWith(1, expect.anything(), {
@@ -218,7 +219,7 @@ describe("resolveInitiativeRelationId", () => {
     ]);
 
     await expect(
-      resolveInitiativeRelationId(gql, "parent-id", "child-id"),
+      resolveInitiativeRelationId(gql, asUuid("parent-id"), asUuid("child-id")),
     ).rejects.toThrow(
       'Initiative relation "between parent-id and child-id" not found',
     );
@@ -248,7 +249,11 @@ describe("resolveInitiativeProjectLinkId", () => {
     });
 
     await expect(
-      resolveInitiativeProjectLinkId(gql, "init-id", "project-id"),
+      resolveInitiativeProjectLinkId(
+        gql,
+        asUuid("init-id"),
+        asUuid("project-id"),
+      ),
     ).resolves.toBe("link-1");
   });
 
@@ -263,7 +268,11 @@ describe("resolveInitiativeProjectLinkId", () => {
     });
 
     await expect(
-      resolveInitiativeProjectLinkId(gql, "init-id", "project-id"),
+      resolveInitiativeProjectLinkId(
+        gql,
+        asUuid("init-id"),
+        asUuid("project-id"),
+      ),
     ).rejects.toThrow(
       'Initiative project link "between init-id and project-id" not found',
     );
@@ -302,7 +311,11 @@ describe("resolveInitiativeProjectLinkId", () => {
     ]);
 
     await expect(
-      resolveInitiativeProjectLinkId(gql, "init-id", "project-id"),
+      resolveInitiativeProjectLinkId(
+        gql,
+        asUuid("init-id"),
+        asUuid("project-id"),
+      ),
     ).resolves.toBe("link-2");
 
     expect(gql.request).toHaveBeenNthCalledWith(1, expect.anything(), {
@@ -338,7 +351,11 @@ describe("resolveInitiativeProjectLinkId", () => {
     ]);
 
     await expect(
-      resolveInitiativeProjectLinkId(gql, "init-id", "project-id"),
+      resolveInitiativeProjectLinkId(
+        gql,
+        asUuid("init-id"),
+        asUuid("project-id"),
+      ),
     ).rejects.toThrow(
       'Initiative project link "between init-id and project-id" not found',
     );

--- a/tests/unit/resolvers/status-resolver.test.ts
+++ b/tests/unit/resolvers/status-resolver.test.ts
@@ -1,6 +1,8 @@
 // tests/unit/resolvers/status-resolver.test.ts
+
 import { describe, expect, it, vi } from "vitest";
 import type { LinearSdkClient } from "../../../src/client/linear-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import { resolveStatusId } from "../../../src/resolvers/status-resolver.js";
 
 function mockSdkClient(nodes: Array<{ id: string }>) {
@@ -29,7 +31,7 @@ describe("resolveStatusId", () => {
 
   it("resolves status by name with team context", async () => {
     const client = mockSdkClient([{ id: "status-uuid" }]);
-    await resolveStatusId(client, "In Progress", "team-uuid");
+    await resolveStatusId(client, "In Progress", asUuid("team-uuid"));
     expect(client.sdk.workflowStates).toHaveBeenCalledWith({
       filter: {
         name: { eqIgnoreCase: "In Progress" },

--- a/tests/unit/services/attachment-service.test.ts
+++ b/tests/unit/services/attachment-service.test.ts
@@ -1,6 +1,8 @@
 // tests/unit/services/attachment-service.test.ts
+
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import {
   createAttachment,
   deleteAttachment,
@@ -26,7 +28,7 @@ describe("createAttachment", () => {
       },
     });
     const result = await createAttachment(client, {
-      issueId: "issue-1",
+      issueId: asUuid("issue-1"),
       title: "Test.pdf",
       url: "https://example.com/test.pdf",
     });
@@ -39,7 +41,7 @@ describe("createAttachment", () => {
     });
     await expect(
       createAttachment(client, {
-        issueId: "issue-1",
+        issueId: asUuid("issue-1"),
         title: "Test.pdf",
         url: "https://example.com/test.pdf",
       }),
@@ -52,13 +54,13 @@ describe("deleteAttachment", () => {
     const client = mockGqlClient({
       attachmentDelete: { success: true, entityId: "att-1" },
     });
-    const result = await deleteAttachment(client, "att-1");
+    const result = await deleteAttachment(client, asUuid("att-1"));
     expect(result).toEqual({ id: "att-1", success: true });
   });
 
   it("throws when delete fails", async () => {
     const client = mockGqlClient({ attachmentDelete: { success: false } });
-    await expect(deleteAttachment(client, "att-1")).rejects.toThrow(
+    await expect(deleteAttachment(client, asUuid("att-1"))).rejects.toThrow(
       "Failed to delete attachment",
     );
   });
@@ -76,7 +78,7 @@ describe("listAttachments", () => {
         },
       },
     });
-    const result = await listAttachments(client, "issue-1");
+    const result = await listAttachments(client, asUuid("issue-1"));
     expect(result).toHaveLength(2);
   });
 
@@ -84,13 +86,13 @@ describe("listAttachments", () => {
     const client = mockGqlClient({
       issue: { attachments: { nodes: [] } },
     });
-    const result = await listAttachments(client, "issue-1");
+    const result = await listAttachments(client, asUuid("issue-1"));
     expect(result).toEqual([]);
   });
 
   it("throws when issue not found", async () => {
     const client = mockGqlClient({ issue: null });
-    await expect(listAttachments(client, "missing")).rejects.toThrow(
+    await expect(listAttachments(client, asUuid("missing"))).rejects.toThrow(
       "not found",
     );
   });
@@ -104,7 +106,7 @@ describe("listAttachments", () => {
       },
     });
     const filter = { sourceType: { eq: "github" } };
-    const result = await listAttachments(client, "issue-1", filter);
+    const result = await listAttachments(client, asUuid("issue-1"), filter);
     expect(result).toHaveLength(1);
     expect(client.request).toHaveBeenCalledWith(
       expect.anything(),

--- a/tests/unit/services/comment-service.test.ts
+++ b/tests/unit/services/comment-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import {
   createComment,
   deleteComment,
@@ -33,7 +34,7 @@ describe("createComment", () => {
     });
 
     const result = await createComment(client, {
-      issueId: "issue-1",
+      issueId: asUuid("issue-1"),
       body: "This is a comment",
     });
 
@@ -59,7 +60,7 @@ describe("createComment", () => {
     });
 
     await expect(
-      createComment(client, { issueId: "issue-1", body: "test" }),
+      createComment(client, { issueId: asUuid("issue-1"), body: "test" }),
     ).rejects.toThrow("Failed to create comment");
   });
 
@@ -72,7 +73,7 @@ describe("createComment", () => {
     });
 
     await expect(
-      createComment(client, { issueId: "issue-1", body: "test" }),
+      createComment(client, { issueId: asUuid("issue-1"), body: "test" }),
     ).rejects.toThrow("Failed to create comment");
   });
 });
@@ -108,7 +109,7 @@ describe("listComments", () => {
       },
     });
 
-    const result = await listComments(client, "issue-1");
+    const result = await listComments(client, asUuid("issue-1"));
 
     expect(result.nodes).toHaveLength(2);
     expect(result.nodes[0]).toEqual({
@@ -141,7 +142,7 @@ describe("listComments", () => {
       },
     });
 
-    const result = await listComments(client, "issue-1");
+    const result = await listComments(client, asUuid("issue-1"));
 
     expect(result.nodes).toEqual([]);
     expect(result.pageInfo).toEqual({ hasNextPage: false, endCursor: null });
@@ -150,9 +151,9 @@ describe("listComments", () => {
   it("throws when issue does not exist", async () => {
     const client = mockGqlClient({ issue: null });
 
-    await expect(listComments(client, "nonexistent-id")).rejects.toThrow(
-      'Issue with ID "nonexistent-id" not found',
-    );
+    await expect(
+      listComments(client, asUuid("nonexistent-id")),
+    ).rejects.toThrow('Issue with ID "nonexistent-id" not found');
   });
 
   it("passes pagination options to request", async () => {
@@ -165,7 +166,10 @@ describe("listComments", () => {
       },
     });
 
-    await listComments(client, "issue-1", { limit: 10, after: "cursor-xyz" });
+    await listComments(client, asUuid("issue-1"), {
+      limit: 10,
+      after: "cursor-xyz",
+    });
 
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       issueId: "issue-1",
@@ -192,7 +196,7 @@ describe("replyToComment", () => {
     });
 
     const result = await replyToComment(client, {
-      parentId: "comment-1",
+      parentId: asUuid("comment-1"),
       body: "This is a reply",
     });
 
@@ -218,7 +222,7 @@ describe("replyToComment", () => {
     });
 
     await expect(
-      replyToComment(client, { parentId: "comment-1", body: "reply" }),
+      replyToComment(client, { parentId: asUuid("comment-1"), body: "reply" }),
     ).rejects.toThrow("Failed to create reply");
   });
 });
@@ -239,7 +243,7 @@ describe("updateComment", () => {
       },
     });
 
-    const result = await updateComment(client, "comment-1", {
+    const result = await updateComment(client, asUuid("comment-1"), {
       body: "Updated body",
     });
 
@@ -266,7 +270,7 @@ describe("updateComment", () => {
     });
 
     await expect(
-      updateComment(client, "comment-1", { body: "new" }),
+      updateComment(client, asUuid("comment-1"), { body: "new" }),
     ).rejects.toThrow("Failed to update comment");
   });
 });
@@ -280,7 +284,7 @@ describe("deleteComment", () => {
       },
     });
 
-    const result = await deleteComment(client, "comment-1");
+    const result = await deleteComment(client, asUuid("comment-1"));
 
     expect(result).toEqual({ id: "comment-1", success: true });
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
@@ -296,7 +300,7 @@ describe("deleteComment", () => {
       },
     });
 
-    await expect(deleteComment(client, "comment-1")).rejects.toThrow(
+    await expect(deleteComment(client, asUuid("comment-1"))).rejects.toThrow(
       "Failed to delete comment",
     );
   });

--- a/tests/unit/services/cycle-service.test.ts
+++ b/tests/unit/services/cycle-service.test.ts
@@ -1,6 +1,8 @@
 // tests/unit/services/cycle-service.test.ts
+
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import { getCycle, listCycles } from "../../../src/services/cycle-service.js";
 
 function mockGqlClient(response: Record<string, unknown>): GraphQLClient {
@@ -88,7 +90,7 @@ describe("listCycles", () => {
         pageInfo: { hasNextPage: false, endCursor: null },
       },
     });
-    await listCycles(client, "team-1");
+    await listCycles(client, asUuid("team-1"));
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       first: 50,
       after: undefined,
@@ -158,7 +160,7 @@ describe("getCycle", () => {
         },
       },
     });
-    const result = await getCycle(client, "cyc-1");
+    const result = await getCycle(client, asUuid("cyc-1"));
     expect(result.id).toBe("cyc-1");
     expect(result.name).toBe("Sprint 1");
     expect(result.issues).toHaveLength(1);
@@ -168,6 +170,8 @@ describe("getCycle", () => {
 
   it("throws when cycle not found", async () => {
     const client = mockGqlClient({ cycle: null });
-    await expect(getCycle(client, "missing-id")).rejects.toThrow("not found");
+    await expect(getCycle(client, asUuid("missing-id"))).rejects.toThrow(
+      "not found",
+    );
   });
 });

--- a/tests/unit/services/discussion-service.test.ts
+++ b/tests/unit/services/discussion-service.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import {
   GetDiscussionCommentContextDocument,
   type ListIssueDiscussionRootsQuery,
@@ -110,7 +111,7 @@ describe("discussion comment reactions", () => {
 
     await expect(
       createDiscussionCommentReaction(client, {
-        commentId: "thread-1",
+        commentId: asUuid("thread-1"),
         target: "thread",
         expectedEntityKind: "issue",
         emoji: "👍",
@@ -140,7 +141,7 @@ describe("discussion comment reactions", () => {
 
     await expect(
       createDiscussionCommentReaction(client, {
-        commentId: "reply-1",
+        commentId: asUuid("reply-1"),
         target: "thread",
         expectedEntityKind: "issue",
         emoji: "👍",
@@ -165,7 +166,7 @@ describe("discussion comment reactions", () => {
 
     await expect(
       deleteDiscussionCommentReactionByEmoji(client, {
-        commentId: "reply-1",
+        commentId: asUuid("reply-1"),
         target: "reply",
         expectedEntityKind: "issue",
         emoji: "👍",
@@ -190,10 +191,10 @@ describe("discussion comment reactions", () => {
 
     await expect(
       deleteDiscussionCommentReactionById(client, {
-        commentId: "reply-1",
+        commentId: asUuid("reply-1"),
         target: "reply",
         expectedEntityKind: "initiative",
-        reactionId: "reaction-1",
+        reactionId: asUuid("reaction-1"),
       }),
     ).resolves.toEqual({ id: "reaction-1", success: true });
 
@@ -217,7 +218,7 @@ describe("discussion comment reactions", () => {
 
     await expect(
       createIssueDiscussionCommentReaction(client, {
-        commentId: "comment-1",
+        commentId: asUuid("comment-1"),
         emoji: "👍",
       }),
     ).resolves.toEqual({ id: "reaction-1" });
@@ -241,7 +242,7 @@ describe("discussion comment reactions", () => {
 
     await expect(
       createIssueDiscussionCommentReaction(client, {
-        commentId: "comment-1",
+        commentId: asUuid("comment-1"),
         emoji: "👍",
       }),
     ).rejects.toThrow(
@@ -257,7 +258,7 @@ describe("discussion comment reactions", () => {
 
     await expect(
       deleteIssueDiscussionCommentReactionByEmoji(client, {
-        commentId: "comment-1",
+        commentId: asUuid("comment-1"),
         emoji: "👍",
       }),
     ).rejects.toThrow('Discussion comment ID "comment-1" not found');
@@ -278,8 +279,8 @@ describe("discussion comment reactions", () => {
 
     await expect(
       deleteIssueDiscussionCommentReactionById(client, {
-        commentId: "comment-1",
-        reactionId: "reaction-1",
+        commentId: asUuid("comment-1"),
+        reactionId: asUuid("reaction-1"),
       }),
     ).resolves.toEqual({ id: "reaction-1", success: true });
 
@@ -303,7 +304,7 @@ describe("listDiscussionsForIssue", () => {
       },
     } satisfies ListIssueDiscussionRootsQuery);
 
-    const result = await listDiscussionsForIssue(client, "issue-1", {
+    const result = await listDiscussionsForIssue(client, asUuid("issue-1"), {
       limit: 2,
       after: "root-cursor-0",
     });
@@ -325,7 +326,7 @@ describe("listDiscussionsForIssue", () => {
     vi.mocked(client.request).mockResolvedValue({ issue: null });
 
     await expect(
-      listDiscussionsForIssue(client, "issue-missing"),
+      listDiscussionsForIssue(client, asUuid("issue-missing")),
     ).rejects.toThrow('Issue with ID "issue-missing" not found');
   });
 
@@ -342,7 +343,7 @@ describe("listDiscussionsForIssue", () => {
 
     const result = await listDiscussionsForIssueWithReactions(
       client,
-      "issue-1",
+      asUuid("issue-1"),
       { limit: 10 },
     );
 
@@ -369,10 +370,14 @@ describe("listDiscussionsForProject", () => {
       },
     });
 
-    const result = await listDiscussionsForProject(client, "project-1", {
-      limit: 10,
-      after: "cur-0",
-    });
+    const result = await listDiscussionsForProject(
+      client,
+      asUuid("project-1"),
+      {
+        limit: 10,
+        after: "cur-0",
+      },
+    );
 
     expect(result.nodes).toHaveLength(1);
     expect(result.pageInfo).toEqual({ hasNextPage: false, endCursor: null });
@@ -388,7 +393,7 @@ describe("listDiscussionsForProject", () => {
     vi.mocked(client.request).mockResolvedValue({ project: null });
 
     await expect(
-      listDiscussionsForProject(client, "project-missing"),
+      listDiscussionsForProject(client, asUuid("project-missing")),
     ).rejects.toThrow('Project with ID "project-missing" not found');
   });
 
@@ -405,7 +410,7 @@ describe("listDiscussionsForProject", () => {
 
     const result = await listDiscussionsForProjectWithReactions(
       client,
-      "project-1",
+      asUuid("project-1"),
       { limit: 10 },
     );
 
@@ -431,7 +436,10 @@ describe("listDiscussionsForInitiative", () => {
       },
     });
 
-    const result = await listDiscussionsForInitiative(client, "initiative-1");
+    const result = await listDiscussionsForInitiative(
+      client,
+      asUuid("initiative-1"),
+    );
 
     expect(result.nodes).toHaveLength(1);
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
@@ -447,7 +455,7 @@ describe("listDiscussionsForInitiative", () => {
     vi.mocked(client.request).mockResolvedValue({ initiative: null });
 
     await expect(
-      listDiscussionsForInitiative(client, "initiative-missing"),
+      listDiscussionsForInitiative(client, asUuid("initiative-missing")),
     ).rejects.toThrow('Initiative with ID "initiative-missing" not found');
   });
 
@@ -463,7 +471,7 @@ describe("listDiscussionsForInitiative", () => {
 
     const result = await listDiscussionsForInitiativeWithReactions(
       client,
-      "initiative-1",
+      asUuid("initiative-1"),
       { limit: 10 },
     );
 
@@ -503,7 +511,7 @@ describe("listDiscussionReplies", () => {
         },
       });
 
-    const result = await listDiscussionReplies(client, "root-1", {
+    const result = await listDiscussionReplies(client, asUuid("root-1"), {
       limit: 5,
     });
 
@@ -543,7 +551,7 @@ describe("listDiscussionReplies", () => {
         },
       });
 
-    const result = await listDiscussionReplies(client, "root-1", {
+    const result = await listDiscussionReplies(client, asUuid("root-1"), {
       limit: 1,
       after: "reply-1",
     });
@@ -582,7 +590,9 @@ describe("listDiscussionReplies", () => {
         },
       });
 
-    const result = await listDiscussionReplies(client, "root-1", { limit: 10 });
+    const result = await listDiscussionReplies(client, asUuid("root-1"), {
+      limit: 10,
+    });
 
     expect(result.nodes.map((node) => node.id)).toEqual([
       "z-parent",
@@ -595,7 +605,7 @@ describe("listDiscussionReplies", () => {
     vi.mocked(client.request).mockResolvedValueOnce({ comment: null });
 
     await expect(
-      listDiscussionReplies(client, "missing-thread"),
+      listDiscussionReplies(client, asUuid("missing-thread")),
     ).rejects.toThrow('Discussion thread ID "missing-thread" not found');
   });
 
@@ -605,7 +615,9 @@ describe("listDiscussionReplies", () => {
       comment: comment("reply-1", "root-1"),
     });
 
-    await expect(listDiscussionReplies(client, "reply-1")).rejects.toThrow(
+    await expect(
+      listDiscussionReplies(client, asUuid("reply-1")),
+    ).rejects.toThrow(
       'Discussion thread ID "reply-1" must reference a root comment',
     );
   });
@@ -630,7 +642,7 @@ describe("listDiscussionReplies", () => {
 
     const result = await listDiscussionRepliesWithReactions(
       client,
-      "root-1",
+      asUuid("root-1"),
       { limit: 10 },
       "issue",
     );
@@ -652,7 +664,10 @@ describe("replyToDiscussion", () => {
     vi.mocked(client.request).mockResolvedValueOnce({ comment: null });
 
     await expect(
-      replyToDiscussion(client, { threadId: "missing-thread", body: "nested" }),
+      replyToDiscussion(client, {
+        threadId: asUuid("missing-thread"),
+        body: "nested",
+      }),
     ).rejects.toThrow('Discussion thread ID "missing-thread" not found');
   });
 
@@ -668,7 +683,10 @@ describe("replyToDiscussion", () => {
     });
 
     await expect(
-      replyToDiscussion(client, { threadId: "reply-2", body: "nested reply" }),
+      replyToDiscussion(client, {
+        threadId: asUuid("reply-2"),
+        body: "nested reply",
+      }),
     ).rejects.toThrow(
       'Discussion thread ID "reply-2" must reference a root comment',
     );
@@ -695,7 +713,7 @@ describe("replyToDiscussion", () => {
 
     await expect(
       replyToDiscussion(client, {
-        threadId: "root-1",
+        threadId: asUuid("root-1"),
         body: "nested reply",
         entityKind: "issue",
       }),
@@ -723,7 +741,7 @@ describe("replyToDiscussion", () => {
       });
 
     const result = await replyToDiscussion(client, {
-      threadId: "root-1",
+      threadId: asUuid("root-1"),
       body: "hello",
     });
 
@@ -754,17 +772,20 @@ describe("discussion mutation flows", () => {
       });
 
     await expect(
-      startIssueDiscussion(client, { issueId: "issue-1", body: "issue body" }),
+      startIssueDiscussion(client, {
+        issueId: asUuid("issue-1"),
+        body: "issue body",
+      }),
     ).resolves.toMatchObject({ id: "c-issue" });
     await expect(
       startProjectDiscussion(client, {
-        projectId: "project-1",
+        projectId: asUuid("project-1"),
         body: "project body",
       }),
     ).resolves.toMatchObject({ id: "c-project" });
     await expect(
       startInitiativeDiscussion(client, {
-        initiativeId: "initiative-1",
+        initiativeId: asUuid("initiative-1"),
         body: "initiative body",
       }),
     ).resolves.toMatchObject({ id: "c-initiative" });
@@ -777,7 +798,10 @@ describe("discussion mutation flows", () => {
     });
 
     await expect(
-      startIssueDiscussion(client, { issueId: "issue-1", body: "issue body" }),
+      startIssueDiscussion(client, {
+        issueId: asUuid("issue-1"),
+        body: "issue body",
+      }),
     ).rejects.toThrow("Failed to start discussion");
   });
 
@@ -797,9 +821,11 @@ describe("discussion mutation flows", () => {
       });
 
     await expect(
-      editDiscussionReply(client, "reply-1", { body: "updated" }),
+      editDiscussionReply(client, asUuid("reply-1"), { body: "updated" }),
     ).resolves.toMatchObject({ id: "reply-1", body: "updated" });
-    await expect(deleteDiscussionReply(client, "reply-1")).resolves.toEqual({
+    await expect(
+      deleteDiscussionReply(client, asUuid("reply-1")),
+    ).resolves.toEqual({
       id: "reply-1",
       success: true,
     });
@@ -812,7 +838,7 @@ describe("discussion mutation flows", () => {
     });
 
     await expect(
-      editDiscussionReply(client, "root-1", { body: "updated" }),
+      editDiscussionReply(client, asUuid("root-1"), { body: "updated" }),
     ).rejects.toThrow(
       'Discussion reply ID "root-1" must reference a reply comment',
     );
@@ -824,7 +850,9 @@ describe("discussion mutation flows", () => {
       comment: comment("root-1"),
     });
 
-    await expect(deleteDiscussionReply(client, "root-1")).rejects.toThrow(
+    await expect(
+      deleteDiscussionReply(client, asUuid("root-1")),
+    ).rejects.toThrow(
       'Discussion reply ID "root-1" must reference a reply comment',
     );
   });
@@ -845,9 +873,11 @@ describe("discussion mutation flows", () => {
       });
 
     await expect(
-      editDiscussionComment(client, "root-1", { body: "updated" }),
+      editDiscussionComment(client, asUuid("root-1"), { body: "updated" }),
     ).resolves.toMatchObject({ id: "root-1", body: "updated" });
-    await expect(deleteDiscussionComment(client, "root-1")).resolves.toEqual({
+    await expect(
+      deleteDiscussionComment(client, asUuid("root-1")),
+    ).resolves.toEqual({
       id: "root-1",
       success: true,
     });
@@ -865,7 +895,12 @@ describe("discussion mutation flows", () => {
     });
 
     await expect(
-      editDiscussionReply(client, "reply-1", { body: "updated" }, "issue"),
+      editDiscussionReply(
+        client,
+        asUuid("reply-1"),
+        { body: "updated" },
+        "issue",
+      ),
     ).rejects.toThrow(
       'Discussion reply ID "reply-1" belongs to project, not issue',
     );
@@ -887,9 +922,11 @@ describe("discussion mutation flows", () => {
       });
 
     await expect(
-      editDiscussionComment(client, "reply-1", { body: "updated" }),
+      editDiscussionComment(client, asUuid("reply-1"), { body: "updated" }),
     ).resolves.toMatchObject({ id: "reply-1", body: "updated" });
-    await expect(deleteDiscussionComment(client, "reply-1")).resolves.toEqual({
+    await expect(
+      deleteDiscussionComment(client, asUuid("reply-1")),
+    ).resolves.toEqual({
       id: "reply-1",
       success: true,
     });
@@ -900,7 +937,7 @@ describe("discussion mutation flows", () => {
     vi.mocked(client.request).mockResolvedValueOnce({ comment: null });
 
     await expect(
-      editDiscussionComment(client, "missing", { body: "updated" }),
+      editDiscussionComment(client, asUuid("missing"), { body: "updated" }),
     ).rejects.toThrow('Discussion comment ID "missing" not found');
   });
 
@@ -913,7 +950,7 @@ describe("discussion mutation flows", () => {
       });
 
     await expect(
-      editDiscussionComment(client, "root-1", { body: "updated" }),
+      editDiscussionComment(client, asUuid("root-1"), { body: "updated" }),
     ).rejects.toThrow("Failed to edit discussion comment");
   });
 
@@ -925,9 +962,9 @@ describe("discussion mutation flows", () => {
         commentDelete: { success: false, entityId: "root-1" },
       });
 
-    await expect(deleteDiscussionComment(client, "root-1")).rejects.toThrow(
-      "Failed to delete discussion comment",
-    );
+    await expect(
+      deleteDiscussionComment(client, asUuid("root-1")),
+    ).rejects.toThrow("Failed to delete discussion comment");
   });
 
   it("resolves and unresolves root discussion", async () => {
@@ -953,11 +990,13 @@ describe("discussion mutation flows", () => {
 
     await expect(
       resolveDiscussion(client, {
-        threadId: "root-1",
-        resolvingCommentId: "reply-1",
+        threadId: asUuid("root-1"),
+        resolvingCommentId: asUuid("reply-1"),
       }),
     ).resolves.toMatchObject({ id: "root-1" });
-    await expect(unresolveDiscussion(client, "root-1")).resolves.toMatchObject({
+    await expect(
+      unresolveDiscussion(client, asUuid("root-1")),
+    ).resolves.toMatchObject({
       id: "root-1",
     });
   });

--- a/tests/unit/services/document-service.test.ts
+++ b/tests/unit/services/document-service.test.ts
@@ -1,6 +1,8 @@
 // tests/unit/services/document-service.test.ts
+
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import {
   createDocument,
   deleteDocument,
@@ -18,13 +20,15 @@ function mockGqlClient(response: Record<string, unknown>) {
 describe("getDocument", () => {
   it("returns document by ID", async () => {
     const client = mockGqlClient({ document: { id: "doc-1", title: "Test" } });
-    const result = await getDocument(client, "doc-1");
+    const result = await getDocument(client, asUuid("doc-1"));
     expect(result.id).toBe("doc-1");
   });
 
   it("throws when not found", async () => {
     const client = mockGqlClient({ document: null });
-    await expect(getDocument(client, "missing")).rejects.toThrow("not found");
+    await expect(getDocument(client, asUuid("missing"))).rejects.toThrow(
+      "not found",
+    );
   });
 });
 
@@ -58,7 +62,9 @@ describe("updateDocument", () => {
         document: { id: "doc-1", title: "Updated" },
       },
     });
-    const result = await updateDocument(client, "doc-1", { title: "Updated" });
+    const result = await updateDocument(client, asUuid("doc-1"), {
+      title: "Updated",
+    });
     expect(result.title).toBe("Updated");
   });
 
@@ -67,7 +73,7 @@ describe("updateDocument", () => {
       documentUpdate: { success: false },
     });
     await expect(
-      updateDocument(client, "doc-1", { title: "Updated" }),
+      updateDocument(client, asUuid("doc-1"), { title: "Updated" }),
     ).rejects.toThrow("Failed to update document");
   });
 });
@@ -135,13 +141,13 @@ describe("deleteDocument", () => {
     const client = mockGqlClient({
       documentDelete: { success: true, entity: { id: "doc-1" } },
     });
-    const result = await deleteDocument(client, "doc-1");
+    const result = await deleteDocument(client, asUuid("doc-1"));
     expect(result).toEqual({ id: "doc-1", success: true });
   });
 
   it("throws when delete fails", async () => {
     const client = mockGqlClient({ documentDelete: { success: false } });
-    await expect(deleteDocument(client, "doc-1")).rejects.toThrow(
+    await expect(deleteDocument(client, asUuid("doc-1"))).rejects.toThrow(
       "Failed to delete document",
     );
   });

--- a/tests/unit/services/initiative-project-service.test.ts
+++ b/tests/unit/services/initiative-project-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import {
   CreateInitiativeToProjectDocument,
   DeleteInitiativeToProjectDocument,
@@ -38,8 +39,8 @@ describe("createInitiativeProjectLink", () => {
 
     await expect(
       createInitiativeProjectLink(client, {
-        initiativeId: "init-1",
-        projectId: "proj-1",
+        initiativeId: asUuid("init-1"),
+        projectId: asUuid("proj-1"),
       }),
     ).resolves.toEqual(link);
 
@@ -63,8 +64,8 @@ describe("createInitiativeProjectLink", () => {
 
     await expect(
       createInitiativeProjectLink(client, {
-        initiativeId: "init-1",
-        projectId: "proj-1",
+        initiativeId: asUuid("init-1"),
+        projectId: asUuid("proj-1"),
       }),
     ).rejects.toThrow(
       'Failed to create initiative-project link for initiative "init-1" and project "proj-1"',
@@ -81,8 +82,8 @@ describe("createInitiativeProjectLink", () => {
 
     await expect(
       createInitiativeProjectLink(client, {
-        initiativeId: "init-1",
-        projectId: "proj-1",
+        initiativeId: asUuid("init-1"),
+        projectId: asUuid("proj-1"),
       }),
     ).rejects.toThrow(
       'Failed to create initiative-project link for initiative "init-1" and project "proj-1"',
@@ -100,7 +101,7 @@ describe("deleteInitiativeProjectLink", () => {
     });
 
     await expect(
-      deleteInitiativeProjectLink(client, "link-1"),
+      deleteInitiativeProjectLink(client, asUuid("link-1")),
     ).resolves.toEqual({
       id: "link-1",
       success: true,
@@ -119,9 +120,9 @@ describe("deleteInitiativeProjectLink", () => {
       },
     });
 
-    await expect(deleteInitiativeProjectLink(client, "link-1")).rejects.toThrow(
-      'Failed to delete initiative-project link "link-1"',
-    );
+    await expect(
+      deleteInitiativeProjectLink(client, asUuid("link-1")),
+    ).rejects.toThrow('Failed to delete initiative-project link "link-1"');
   });
 
   it("throws when payload is missing", async () => {
@@ -132,8 +133,8 @@ describe("deleteInitiativeProjectLink", () => {
       },
     });
 
-    await expect(deleteInitiativeProjectLink(client, "link-1")).rejects.toThrow(
-      'Failed to delete initiative-project link "link-1"',
-    );
+    await expect(
+      deleteInitiativeProjectLink(client, asUuid("link-1")),
+    ).rejects.toThrow('Failed to delete initiative-project link "link-1"');
   });
 });

--- a/tests/unit/services/initiative-relation-service.test.ts
+++ b/tests/unit/services/initiative-relation-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import {
   CreateInitiativeRelationDocument,
   DeleteInitiativeRelationDocument,
@@ -38,8 +39,8 @@ describe("createInitiativeRelation", () => {
 
     await expect(
       createInitiativeRelation(client, {
-        parentId: "init-parent",
-        childId: "init-child",
+        parentId: asUuid("init-parent"),
+        childId: asUuid("init-child"),
       }),
     ).resolves.toEqual(relation);
 
@@ -63,8 +64,8 @@ describe("createInitiativeRelation", () => {
 
     await expect(
       createInitiativeRelation(client, {
-        parentId: "init-parent",
-        childId: "init-child",
+        parentId: asUuid("init-parent"),
+        childId: asUuid("init-child"),
       }),
     ).rejects.toThrow(
       'Failed to create initiative relation from "init-parent" to "init-child"',
@@ -81,8 +82,8 @@ describe("createInitiativeRelation", () => {
 
     await expect(
       createInitiativeRelation(client, {
-        parentId: "init-parent",
-        childId: "init-child",
+        parentId: asUuid("init-parent"),
+        childId: asUuid("init-child"),
       }),
     ).rejects.toThrow(
       'Failed to create initiative relation from "init-parent" to "init-child"',
@@ -99,7 +100,9 @@ describe("deleteInitiativeRelation", () => {
       },
     });
 
-    await expect(deleteInitiativeRelation(client, "rel-1")).resolves.toEqual({
+    await expect(
+      deleteInitiativeRelation(client, asUuid("rel-1")),
+    ).resolves.toEqual({
       id: "rel-1",
       success: true,
     });
@@ -117,9 +120,9 @@ describe("deleteInitiativeRelation", () => {
       },
     });
 
-    await expect(deleteInitiativeRelation(client, "rel-1")).rejects.toThrow(
-      'Failed to delete initiative relation "rel-1"',
-    );
+    await expect(
+      deleteInitiativeRelation(client, asUuid("rel-1")),
+    ).rejects.toThrow('Failed to delete initiative relation "rel-1"');
   });
 
   it("throws when payload is missing", async () => {
@@ -130,8 +133,8 @@ describe("deleteInitiativeRelation", () => {
       },
     });
 
-    await expect(deleteInitiativeRelation(client, "rel-1")).rejects.toThrow(
-      'Failed to delete initiative relation "rel-1"',
-    );
+    await expect(
+      deleteInitiativeRelation(client, asUuid("rel-1")),
+    ).rejects.toThrow('Failed to delete initiative relation "rel-1"');
   });
 });

--- a/tests/unit/services/initiative-service.test.ts
+++ b/tests/unit/services/initiative-service.test.ts
@@ -1,6 +1,7 @@
 import { type DocumentNode, type FragmentDefinitionNode, Kind } from "graphql";
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import { GetInitiativeDocument } from "../../../src/gql/graphql.js";
 import {
   archiveInitiative,
@@ -104,7 +105,7 @@ describe("getInitiative", () => {
       },
     });
 
-    await expect(getInitiative(client, "init-1")).resolves.toEqual({
+    await expect(getInitiative(client, asUuid("init-1"))).resolves.toEqual({
       id: "init-1",
       name: "Growth",
     });
@@ -113,7 +114,7 @@ describe("getInitiative", () => {
   it("throws when initiative is not found", async () => {
     const client = mockGqlClient({ initiative: null });
 
-    await expect(getInitiative(client, "missing")).rejects.toThrow(
+    await expect(getInitiative(client, asUuid("missing"))).rejects.toThrow(
       'Initiative with ID "missing" not found',
     );
   });
@@ -151,7 +152,9 @@ describe("updateInitiative", () => {
   it("rejects empty update input", async () => {
     const client = mockGqlClient({});
 
-    await expect(updateInitiative(client, "init-1", {})).rejects.toThrow(
+    await expect(
+      updateInitiative(client, asUuid("init-1"), {}),
+    ).rejects.toThrow(
       "Invalid update options: at least one update field must be provided",
     );
   });
@@ -165,7 +168,7 @@ describe("updateInitiative", () => {
     });
 
     await expect(
-      updateInitiative(client, "init-1", { name: "Updated" }),
+      updateInitiative(client, asUuid("init-1"), { name: "Updated" }),
     ).resolves.toEqual({
       id: "init-1",
       name: "Updated",
@@ -178,7 +181,7 @@ describe("updateInitiative", () => {
     });
 
     await expect(
-      updateInitiative(client, "init-1", { name: "Updated" }),
+      updateInitiative(client, asUuid("init-1"), { name: "Updated" }),
     ).rejects.toThrow('Failed to update initiative "init-1"');
   });
 });
@@ -192,7 +195,7 @@ describe("archiveInitiative", () => {
       },
     });
 
-    await expect(archiveInitiative(client, "init-1")).resolves.toEqual({
+    await expect(archiveInitiative(client, asUuid("init-1"))).resolves.toEqual({
       id: "init-1",
       name: "Growth",
     });
@@ -203,7 +206,7 @@ describe("archiveInitiative", () => {
       initiativeArchive: { success: false, entity: null },
     });
 
-    await expect(archiveInitiative(client, "init-1")).rejects.toThrow(
+    await expect(archiveInitiative(client, asUuid("init-1"))).rejects.toThrow(
       'Failed to archive initiative "init-1"',
     );
   });
@@ -218,7 +221,9 @@ describe("unarchiveInitiative", () => {
       },
     });
 
-    await expect(unarchiveInitiative(client, "init-1")).resolves.toEqual({
+    await expect(
+      unarchiveInitiative(client, asUuid("init-1")),
+    ).resolves.toEqual({
       id: "init-1",
       name: "Growth",
     });
@@ -229,7 +234,7 @@ describe("unarchiveInitiative", () => {
       initiativeUnarchive: { success: false, entity: null },
     });
 
-    await expect(unarchiveInitiative(client, "init-1")).rejects.toThrow(
+    await expect(unarchiveInitiative(client, asUuid("init-1"))).rejects.toThrow(
       'Failed to unarchive initiative "init-1"',
     );
   });
@@ -241,7 +246,7 @@ describe("deleteInitiative", () => {
       initiativeDelete: { success: true, entityId: "init-1" },
     });
 
-    await expect(deleteInitiative(client, "init-1")).resolves.toEqual({
+    await expect(deleteInitiative(client, asUuid("init-1"))).resolves.toEqual({
       id: "init-1",
       success: true,
     });
@@ -252,7 +257,7 @@ describe("deleteInitiative", () => {
       initiativeDelete: { success: false, entityId: null },
     });
 
-    await expect(deleteInitiative(client, "init-1")).rejects.toThrow(
+    await expect(deleteInitiative(client, asUuid("init-1"))).rejects.toThrow(
       'Failed to delete initiative "init-1"',
     );
   });

--- a/tests/unit/services/initiative-update-service.test.ts
+++ b/tests/unit/services/initiative-update-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import {
   ArchiveInitiativeUpdateDocument,
   CreateInitiativeUpdateDocument,
@@ -40,7 +41,7 @@ describe("listInitiativeUpdates", () => {
     });
 
     await listInitiativeUpdates(client, {
-      initiativeId: "init-1",
+      initiativeId: asUuid("init-1"),
       limit: 5,
       after: "cursor-1",
       includeArchived: true,
@@ -62,7 +63,7 @@ describe("listInitiativeUpdates", () => {
     } as unknown as GraphQLClient;
 
     await expect(
-      listInitiativeUpdates(client, { initiativeId: "init-1" }),
+      listInitiativeUpdates(client, { initiativeId: asUuid("init-1") }),
     ).rejects.toThrow(requestError);
 
     expect(request).toHaveBeenCalledWith(ListInitiativeUpdatesDocument, {
@@ -88,7 +89,9 @@ describe("getInitiativeUpdate", () => {
     };
     const { client, request } = mockGqlClient({ initiativeUpdate: update });
 
-    await expect(getInitiativeUpdate(client, "upd-1")).resolves.toEqual(update);
+    await expect(getInitiativeUpdate(client, asUuid("upd-1"))).resolves.toEqual(
+      update,
+    );
 
     expect(request).toHaveBeenCalledWith(GetInitiativeUpdateDocument, {
       id: "upd-1",
@@ -98,9 +101,9 @@ describe("getInitiativeUpdate", () => {
   it("throws when update is not found", async () => {
     const { client } = mockGqlClient({ initiativeUpdate: null });
 
-    await expect(getInitiativeUpdate(client, "upd-missing")).rejects.toThrow(
-      'Initiative update with ID "upd-missing" not found',
-    );
+    await expect(
+      getInitiativeUpdate(client, asUuid("upd-missing")),
+    ).rejects.toThrow('Initiative update with ID "upd-missing" not found');
   });
 });
 
@@ -122,7 +125,7 @@ describe("createInitiativeUpdate", () => {
 
     await expect(
       createInitiativeUpdate(client, {
-        initiativeId: "init-1",
+        initiativeId: asUuid("init-1"),
         body: "Week 1",
       }),
     ).resolves.toEqual(update);
@@ -142,7 +145,7 @@ describe("createInitiativeUpdate", () => {
 
     await expect(
       createInitiativeUpdate(client, {
-        initiativeId: "init-1",
+        initiativeId: asUuid("init-1"),
         body: "Week 1",
       }),
     ).rejects.toThrow("Failed to create initiative update");
@@ -155,7 +158,7 @@ describe("createInitiativeUpdate", () => {
 
     await expect(
       createInitiativeUpdate(client, {
-        initiativeId: "init-1",
+        initiativeId: asUuid("init-1"),
         body: "Week 1",
       }),
     ).rejects.toThrow("Failed to create initiative update");
@@ -166,7 +169,9 @@ describe("updateInitiativeUpdate", () => {
   it("rejects no-op update input", async () => {
     const { client } = mockGqlClient({});
 
-    await expect(updateInitiativeUpdate(client, "upd-1", {})).rejects.toThrow(
+    await expect(
+      updateInitiativeUpdate(client, asUuid("upd-1"), {}),
+    ).rejects.toThrow(
       "Invalid update options: at least one update field must be provided",
     );
   });
@@ -187,7 +192,7 @@ describe("updateInitiativeUpdate", () => {
     });
 
     await expect(
-      updateInitiativeUpdate(client, "upd-1", { body: "Week 2" }),
+      updateInitiativeUpdate(client, asUuid("upd-1"), { body: "Week 2" }),
     ).resolves.toEqual(update);
 
     expect(request).toHaveBeenCalledWith(UpdateInitiativeUpdateDocument, {
@@ -205,7 +210,7 @@ describe("updateInitiativeUpdate", () => {
     });
 
     await expect(
-      updateInitiativeUpdate(client, "upd-1", { body: "Week 2" }),
+      updateInitiativeUpdate(client, asUuid("upd-1"), { body: "Week 2" }),
     ).rejects.toThrow('Failed to update initiative update "upd-1"');
   });
 
@@ -215,7 +220,7 @@ describe("updateInitiativeUpdate", () => {
     });
 
     await expect(
-      updateInitiativeUpdate(client, "upd-1", { body: "Week 2" }),
+      updateInitiativeUpdate(client, asUuid("upd-1"), { body: "Week 2" }),
     ).rejects.toThrow('Failed to update initiative update "upd-1"');
   });
 });
@@ -236,9 +241,9 @@ describe("archiveInitiativeUpdate", () => {
       initiativeUpdateArchive: { success: true, entity: archived },
     });
 
-    await expect(archiveInitiativeUpdate(client, "upd-1")).resolves.toEqual(
-      archived,
-    );
+    await expect(
+      archiveInitiativeUpdate(client, asUuid("upd-1")),
+    ).resolves.toEqual(archived);
 
     expect(request).toHaveBeenCalledWith(ArchiveInitiativeUpdateDocument, {
       id: "upd-1",
@@ -250,9 +255,9 @@ describe("archiveInitiativeUpdate", () => {
       initiativeUpdateArchive: { success: false, entity: { id: "upd-1" } },
     });
 
-    await expect(archiveInitiativeUpdate(client, "upd-1")).rejects.toThrow(
-      'Failed to archive initiative update "upd-1"',
-    );
+    await expect(
+      archiveInitiativeUpdate(client, asUuid("upd-1")),
+    ).rejects.toThrow('Failed to archive initiative update "upd-1"');
   });
 
   it("throws when mutation payload is missing", async () => {
@@ -260,9 +265,9 @@ describe("archiveInitiativeUpdate", () => {
       initiativeUpdateArchive: { success: true, entity: null },
     });
 
-    await expect(archiveInitiativeUpdate(client, "upd-1")).rejects.toThrow(
-      'Failed to archive initiative update "upd-1"',
-    );
+    await expect(
+      archiveInitiativeUpdate(client, asUuid("upd-1")),
+    ).rejects.toThrow('Failed to archive initiative update "upd-1"');
   });
 });
 
@@ -282,9 +287,9 @@ describe("unarchiveInitiativeUpdate", () => {
       initiativeUpdateUnarchive: { success: true, entity: unarchived },
     });
 
-    await expect(unarchiveInitiativeUpdate(client, "upd-1")).resolves.toEqual(
-      unarchived,
-    );
+    await expect(
+      unarchiveInitiativeUpdate(client, asUuid("upd-1")),
+    ).resolves.toEqual(unarchived);
 
     expect(request).toHaveBeenCalledWith(UnarchiveInitiativeUpdateDocument, {
       id: "upd-1",
@@ -296,9 +301,9 @@ describe("unarchiveInitiativeUpdate", () => {
       initiativeUpdateUnarchive: { success: false, entity: { id: "upd-1" } },
     });
 
-    await expect(unarchiveInitiativeUpdate(client, "upd-1")).rejects.toThrow(
-      'Failed to unarchive initiative update "upd-1"',
-    );
+    await expect(
+      unarchiveInitiativeUpdate(client, asUuid("upd-1")),
+    ).rejects.toThrow('Failed to unarchive initiative update "upd-1"');
   });
 
   it("throws when mutation payload is missing", async () => {
@@ -306,8 +311,8 @@ describe("unarchiveInitiativeUpdate", () => {
       initiativeUpdateUnarchive: { success: true, entity: null },
     });
 
-    await expect(unarchiveInitiativeUpdate(client, "upd-1")).rejects.toThrow(
-      'Failed to unarchive initiative update "upd-1"',
-    );
+    await expect(
+      unarchiveInitiativeUpdate(client, asUuid("upd-1")),
+    ).rejects.toThrow('Failed to unarchive initiative update "upd-1"');
   });
 });

--- a/tests/unit/services/issue-relation-service.test.ts
+++ b/tests/unit/services/issue-relation-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import {
   createIssueRelation,
   deleteIssueRelation,
@@ -25,8 +26,8 @@ describe("createIssueRelation", () => {
     });
 
     const result = await createIssueRelation(client, {
-      issueId: "issue-1",
-      relatedIssueId: "issue-2",
+      issueId: asUuid("issue-1"),
+      relatedIssueId: asUuid("issue-2"),
       type: "blocks",
     });
 
@@ -41,8 +42,8 @@ describe("createIssueRelation", () => {
 
     await expect(
       createIssueRelation(client, {
-        issueId: "issue-1",
-        relatedIssueId: "issue-2",
+        issueId: asUuid("issue-1"),
+        relatedIssueId: asUuid("issue-2"),
         type: "blocks",
       }),
     ).rejects.toThrow("Failed to create issue relation");
@@ -66,7 +67,11 @@ describe("findIssueRelation", () => {
       },
     });
 
-    const result = await findIssueRelation(client, "source-id", "target-id");
+    const result = await findIssueRelation(
+      client,
+      asUuid("source-id"),
+      asUuid("target-id"),
+    );
     expect(result).toBe("rel-1");
   });
 
@@ -86,7 +91,11 @@ describe("findIssueRelation", () => {
       },
     });
 
-    const result = await findIssueRelation(client, "source-id", "target-id");
+    const result = await findIssueRelation(
+      client,
+      asUuid("source-id"),
+      asUuid("target-id"),
+    );
     expect(result).toBe("rel-2");
   });
 
@@ -94,7 +103,7 @@ describe("findIssueRelation", () => {
     const client = mockGqlClient({ issue: null });
 
     await expect(
-      findIssueRelation(client, "non-existent-id", "target-id"),
+      findIssueRelation(client, asUuid("non-existent-id"), asUuid("target-id")),
     ).rejects.toThrow("not found");
   });
 
@@ -107,7 +116,7 @@ describe("findIssueRelation", () => {
     });
 
     await expect(
-      findIssueRelation(client, "source-id", "target-id"),
+      findIssueRelation(client, asUuid("source-id"), asUuid("target-id")),
     ).rejects.toThrow("not found");
   });
 });
@@ -139,7 +148,7 @@ describe("listIssueRelations", () => {
       },
     });
 
-    const result = await listIssueRelations(client, "source-id");
+    const result = await listIssueRelations(client, asUuid("source-id"));
 
     expect(result).toEqual({
       issueId: "source-id",
@@ -162,7 +171,7 @@ describe("listIssueRelations", () => {
   it("throws when issue is not found", async () => {
     const client = mockGqlClient({ issue: null });
 
-    await expect(listIssueRelations(client, "missing")).rejects.toThrow(
+    await expect(listIssueRelations(client, asUuid("missing"))).rejects.toThrow(
       "not found",
     );
   });
@@ -174,7 +183,7 @@ describe("deleteIssueRelation", () => {
       issueRelationDelete: { success: true, entityId: "rel-1" },
     });
 
-    const result = await deleteIssueRelation(client, "rel-1");
+    const result = await deleteIssueRelation(client, asUuid("rel-1"));
     expect(result).toEqual({ id: "rel-1", success: true });
   });
 
@@ -183,7 +192,7 @@ describe("deleteIssueRelation", () => {
       issueRelationDelete: { success: false },
     });
 
-    await expect(deleteIssueRelation(client, "rel-1")).rejects.toThrow(
+    await expect(deleteIssueRelation(client, asUuid("rel-1"))).rejects.toThrow(
       "Failed to delete issue relation",
     );
   });

--- a/tests/unit/services/issue-service.test.ts
+++ b/tests/unit/services/issue-service.test.ts
@@ -1,6 +1,7 @@
 import { type DocumentNode, type FragmentDefinitionNode, Kind } from "graphql";
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import {
   ArchiveIssueDocument,
   DeleteIssueDocument,
@@ -253,7 +254,7 @@ describe("getIssue", () => {
     });
     const result = await getIssue(
       client,
-      "550e8400-e29b-41d4-a716-446655440000",
+      asUuid("550e8400-e29b-41d4-a716-446655440000"),
     );
     expect(result.id).toBe("550e8400-e29b-41d4-a716-446655440000");
     expect(result.comments.nodes).toEqual([{ id: "comment-1", body: "First" }]);
@@ -265,7 +266,7 @@ describe("getIssue", () => {
   it("throws when issue not found by UUID", async () => {
     const client = mockGqlClient({ issue: null });
     await expect(
-      getIssue(client, "550e8400-e29b-41d4-a716-446655440000"),
+      getIssue(client, asUuid("550e8400-e29b-41d4-a716-446655440000")),
     ).rejects.toThrow("not found");
   });
 });
@@ -322,7 +323,7 @@ describe("getIssueWithComments", () => {
         },
       },
     });
-    const result = await getIssueWithComments(client, "issue-1");
+    const result = await getIssueWithComments(client, asUuid("issue-1"));
 
     expect(result.comments.nodes[0]).toEqual({
       id: "comment-1",
@@ -431,7 +432,7 @@ describe("getIssueWithCommentThreads", () => {
       },
     });
 
-    const result = await getIssueWithCommentThreads(client, "issue-1");
+    const result = await getIssueWithCommentThreads(client, asUuid("issue-1"));
 
     expect(result.comments.nodes).toHaveLength(2);
     expect(result.comments.nodes[0]?.id).toBe("comment-1");
@@ -506,7 +507,7 @@ describe("createIssue", () => {
     });
     const result = await createIssue(client, {
       title: "New",
-      teamId: "team-uuid",
+      teamId: asUuid("team-uuid"),
       estimate: 5,
     });
     expect(result.id).toBe("new-id");
@@ -520,7 +521,7 @@ describe("createIssue", () => {
       issueCreate: { success: false, issue: null },
     });
     await expect(
-      createIssue(client, { title: "Fail", teamId: "team-uuid" }),
+      createIssue(client, { title: "Fail", teamId: asUuid("team-uuid") }),
     ).rejects.toThrow("Failed to create issue");
   });
 });
@@ -538,7 +539,9 @@ describe("updateIssue", () => {
         },
       },
     });
-    const result = await updateIssue(client, "issue-id", { estimate: 8 });
+    const result = await updateIssue(client, asUuid("issue-id"), {
+      estimate: 8,
+    });
     expect(result.id).toBe("issue-id");
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       id: "issue-id",
@@ -553,7 +556,9 @@ describe("updateIssue", () => {
         issue: { id: "issue-id", identifier: "ENG-1", title: "Cleared" },
       },
     });
-    const result = await updateIssue(client, "issue-id", { estimate: null });
+    const result = await updateIssue(client, asUuid("issue-id"), {
+      estimate: null,
+    });
     expect(result.id).toBe("issue-id");
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       id: "issue-id",
@@ -566,7 +571,7 @@ describe("updateIssue", () => {
       issueUpdate: { success: false, issue: null },
     });
     await expect(
-      updateIssue(client, "issue-id", { title: "Fail" }),
+      updateIssue(client, asUuid("issue-id"), { title: "Fail" }),
     ).rejects.toThrow("Failed to update issue");
   });
 });
@@ -601,7 +606,7 @@ describe("getIssueWithReactions", () => {
       },
     });
 
-    const result = await getIssueWithReactions(client, "issue-1");
+    const result = await getIssueWithReactions(client, asUuid("issue-1"));
 
     expect(result.reactions).toEqual([
       {
@@ -629,9 +634,9 @@ describe("getIssueWithReactions", () => {
   it("throws when issue not found by UUID", async () => {
     const client = mockGqlClient({ issue: null });
 
-    await expect(getIssueWithReactions(client, "missing")).rejects.toThrow(
-      'Issue with ID "missing" not found',
-    );
+    await expect(
+      getIssueWithReactions(client, asUuid("missing")),
+    ).rejects.toThrow('Issue with ID "missing" not found');
   });
 });
 
@@ -705,7 +710,7 @@ describe("getIssueWithAttachments", () => {
         },
       },
     });
-    const result = await getIssueWithAttachments(client, "issue-1");
+    const result = await getIssueWithAttachments(client, asUuid("issue-1"));
     expect(result.id).toBe("issue-1");
     expect(client.request).toHaveBeenCalledWith(
       GetIssueByIdWithAttachmentsDocument,
@@ -715,9 +720,9 @@ describe("getIssueWithAttachments", () => {
 
   it("throws when issue not found", async () => {
     const client = mockGqlClient({ issue: null });
-    await expect(getIssueWithAttachments(client, "missing")).rejects.toThrow(
-      "not found",
-    );
+    await expect(
+      getIssueWithAttachments(client, asUuid("missing")),
+    ).rejects.toThrow("not found");
   });
 });
 
@@ -827,7 +832,7 @@ describe("archiveIssue", () => {
       },
     });
 
-    const result = await archiveIssue(client, "issue-1");
+    const result = await archiveIssue(client, asUuid("issue-1"));
 
     expect(result.id).toBe("issue-1");
     expect(client.request).toHaveBeenCalledWith(ArchiveIssueDocument, {
@@ -840,7 +845,7 @@ describe("archiveIssue", () => {
       issueArchive: { success: false, entity: null },
     });
 
-    await expect(archiveIssue(client, "issue-1")).rejects.toThrow(
+    await expect(archiveIssue(client, asUuid("issue-1"))).rejects.toThrow(
       'Failed to archive issue "issue-1"',
     );
   });
@@ -855,7 +860,7 @@ describe("unarchiveIssue", () => {
       },
     });
 
-    const result = await unarchiveIssue(client, "issue-1");
+    const result = await unarchiveIssue(client, asUuid("issue-1"));
 
     expect(result.id).toBe("issue-1");
     expect(client.request).toHaveBeenCalledWith(UnarchiveIssueDocument, {
@@ -868,7 +873,7 @@ describe("unarchiveIssue", () => {
       issueUnarchive: { success: false, entity: null },
     });
 
-    await expect(unarchiveIssue(client, "issue-1")).rejects.toThrow(
+    await expect(unarchiveIssue(client, asUuid("issue-1"))).rejects.toThrow(
       'Failed to unarchive issue "issue-1"',
     );
   });
@@ -880,7 +885,7 @@ describe("deleteIssue", () => {
       issueDelete: { success: true, entity: { id: "issue-1" } },
     });
 
-    await expect(deleteIssue(client, "issue-1")).resolves.toEqual({
+    await expect(deleteIssue(client, asUuid("issue-1"))).resolves.toEqual({
       id: "issue-1",
       success: true,
     });
@@ -895,7 +900,7 @@ describe("deleteIssue", () => {
       issueDelete: { success: false, entity: null },
     });
 
-    await expect(deleteIssue(client, "issue-1")).rejects.toThrow(
+    await expect(deleteIssue(client, asUuid("issue-1"))).rejects.toThrow(
       'Failed to delete issue "issue-1"',
     );
   });

--- a/tests/unit/services/label-service.test.ts
+++ b/tests/unit/services/label-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import {
   createLabel,
   deleteLabel,
@@ -26,7 +27,7 @@ describe("getLabel", () => {
       },
     });
 
-    const result = await getLabel(client, "lbl-1");
+    const result = await getLabel(client, asUuid("lbl-1"));
 
     expect(result).toEqual({
       id: "lbl-1",
@@ -40,7 +41,7 @@ describe("getLabel", () => {
   it("throws when label not found", async () => {
     const client = mockGqlClient({ issueLabel: null });
 
-    await expect(getLabel(client, "lbl-1")).rejects.toThrow(
+    await expect(getLabel(client, asUuid("lbl-1"))).rejects.toThrow(
       'Label with ID "lbl-1" not found',
     );
   });
@@ -62,7 +63,7 @@ describe("createLabel", () => {
 
     const result = await createLabel(client, {
       name: "branch:unmerged",
-      teamId: "team-1",
+      teamId: asUuid("team-1"),
       color: "#B45309",
       description: "Created from DBL branch workflow",
     });
@@ -136,7 +137,7 @@ describe("updateLabel", () => {
       },
     });
 
-    const result = await updateLabel(client, "lbl-1", {
+    const result = await updateLabel(client, asUuid("lbl-1"), {
       name: "branch:merged",
       color: "#1D4ED8",
       description: "Updated from DBL branch workflow",
@@ -173,7 +174,7 @@ describe("updateLabel", () => {
     });
 
     await expect(
-      updateLabel(client, "lbl-1", { name: "branch:merged" }),
+      updateLabel(client, asUuid("lbl-1"), { name: "branch:merged" }),
     ).rejects.toThrow('Failed to update label "lbl-1"');
   });
 });
@@ -187,7 +188,7 @@ describe("deleteLabel", () => {
       },
     });
 
-    const result = await deleteLabel(client, "lbl-1");
+    const result = await deleteLabel(client, asUuid("lbl-1"));
 
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       id: "lbl-1",
@@ -203,7 +204,7 @@ describe("deleteLabel", () => {
       },
     });
 
-    await expect(deleteLabel(client, "lbl-1")).rejects.toThrow(
+    await expect(deleteLabel(client, asUuid("lbl-1"))).rejects.toThrow(
       'Failed to delete label "lbl-1"',
     );
   });
@@ -290,7 +291,7 @@ describe("listLabels", () => {
       },
     });
 
-    await listLabels(client, "team-1");
+    await listLabels(client, asUuid("team-1"));
 
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       first: 50,
@@ -324,7 +325,7 @@ describe("listLabels", () => {
       },
     });
 
-    await listLabels(client, "team-1", { scope: "team" });
+    await listLabels(client, asUuid("team-1"), { scope: "team" });
 
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       first: 50,

--- a/tests/unit/services/milestone-service.test.ts
+++ b/tests/unit/services/milestone-service.test.ts
@@ -1,6 +1,8 @@
 // tests/unit/services/milestone-service.test.ts
+
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import {
   createMilestone,
   getMilestone,
@@ -32,7 +34,7 @@ describe("listMilestones", () => {
         },
       },
     });
-    const result = await listMilestones(client, "proj-1");
+    const result = await listMilestones(client, asUuid("proj-1"));
     expect(result.nodes).toHaveLength(1);
     expect(result.nodes[0]).toEqual({
       id: "ms-1",
@@ -46,7 +48,7 @@ describe("listMilestones", () => {
 
   it("returns empty when project is null", async () => {
     const client = mockGqlClient({ project: null });
-    const result = await listMilestones(client, "missing-proj");
+    const result = await listMilestones(client, asUuid("missing-proj"));
     expect(result.nodes).toEqual([]);
     expect(result.pageInfo).toEqual({ hasNextPage: false, endCursor: null });
   });
@@ -60,7 +62,7 @@ describe("listMilestones", () => {
         },
       },
     });
-    await listMilestones(client, "proj-1", { after: "cur1" });
+    await listMilestones(client, asUuid("proj-1"), { after: "cur1" });
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       projectId: "proj-1",
       first: 50,
@@ -77,7 +79,7 @@ describe("listMilestones", () => {
         },
       },
     });
-    await listMilestones(client, "proj-1");
+    await listMilestones(client, asUuid("proj-1"));
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       projectId: "proj-1",
       first: 50,
@@ -99,14 +101,14 @@ describe("getMilestone", () => {
         issues: { nodes: [] },
       },
     });
-    const result = await getMilestone(client, "ms-1");
+    const result = await getMilestone(client, asUuid("ms-1"));
     expect(result.id).toBe("ms-1");
     expect(result.name).toBe("v1.0");
   });
 
   it("throws when not found", async () => {
     const client = mockGqlClient({ projectMilestone: null });
-    await expect(getMilestone(client, "missing-id")).rejects.toThrow(
+    await expect(getMilestone(client, asUuid("missing-id"))).rejects.toThrow(
       "not found",
     );
   });
@@ -127,7 +129,7 @@ describe("createMilestone", () => {
       },
     });
     const result = await createMilestone(client, {
-      projectId: "proj-1",
+      projectId: asUuid("proj-1"),
       name: "v2.0",
     });
     expect(result.id).toBe("ms-new");
@@ -148,7 +150,7 @@ describe("createMilestone", () => {
       },
     });
     const input = {
-      projectId: "proj-1",
+      projectId: asUuid("proj-1"),
       name: "v2.0",
       description: "desc",
       targetDate: "2025-12-01",
@@ -165,7 +167,7 @@ describe("createMilestone", () => {
       },
     });
     await expect(
-      createMilestone(client, { projectId: "proj-1", name: "Bad" }),
+      createMilestone(client, { projectId: asUuid("proj-1"), name: "Bad" }),
     ).rejects.toThrow("Failed to create milestone");
   });
 });
@@ -184,7 +186,9 @@ describe("updateMilestone", () => {
         },
       },
     });
-    const result = await updateMilestone(client, "ms-1", { name: "v1.1" });
+    const result = await updateMilestone(client, asUuid("ms-1"), {
+      name: "v1.1",
+    });
     expect(result.id).toBe("ms-1");
     expect(result.name).toBe("v1.1");
   });
@@ -203,7 +207,7 @@ describe("updateMilestone", () => {
       },
     });
     const input = { name: "v1.1", description: "updated" };
-    await updateMilestone(client, "ms-1", input);
+    await updateMilestone(client, asUuid("ms-1"), input);
     expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       id: "ms-1",
       input,
@@ -218,7 +222,7 @@ describe("updateMilestone", () => {
       },
     });
     await expect(
-      updateMilestone(client, "ms-1", { name: "Bad" }),
+      updateMilestone(client, asUuid("ms-1"), { name: "Bad" }),
     ).rejects.toThrow("Failed to update milestone");
   });
 });

--- a/tests/unit/services/milestone-service.variables.test.ts
+++ b/tests/unit/services/milestone-service.variables.test.ts
@@ -1,6 +1,7 @@
 import type { DocumentNode } from "graphql";
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import {
   createMilestone,
   updateMilestone,
@@ -42,7 +43,7 @@ describe("milestone service variable shapes (issues #223 / #228)", () => {
     });
 
     await createMilestone(client, {
-      projectId: "proj-1",
+      projectId: asUuid("proj-1"),
       name: "v2.0",
       description: "Second release",
       targetDate: "2025-12-01",
@@ -61,7 +62,7 @@ describe("milestone service variable shapes (issues #223 / #228)", () => {
       },
     });
 
-    await updateMilestone(client, "ms-1", {
+    await updateMilestone(client, asUuid("ms-1"), {
       name: "v1.1",
       description: "Updated",
       targetDate: "2026-01-01",

--- a/tests/unit/services/project-service.test.ts
+++ b/tests/unit/services/project-service.test.ts
@@ -1,7 +1,9 @@
 // tests/unit/services/project-service.test.ts
+
 import { type DocumentNode, type FragmentDefinitionNode, Kind } from "graphql";
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import {
   ArchiveProjectDocument,
   GetProjectDocument,
@@ -278,7 +280,7 @@ describe("getProject", () => {
         initiatives: { nodes: [{ id: "init-1", name: "Growth" }] },
       },
     });
-    const result = await getProject(client, "proj-1");
+    const result = await getProject(client, asUuid("proj-1"));
     expect(result.id).toBe("proj-1");
     expect(result.name).toBe("Project Alpha");
     expect(result.status.name).toBe("Started");
@@ -301,7 +303,7 @@ describe("getProject", () => {
       },
     });
 
-    await getProject(client, "proj-1", {
+    await getProject(client, asUuid("proj-1"), {
       milestonesFirst: 0,
       issuesFirst: 0,
     });
@@ -323,7 +325,7 @@ describe("getProject", () => {
       },
     });
 
-    await getProject(client, "proj-1", {
+    await getProject(client, asUuid("proj-1"), {
       milestonesFirst: 5,
       issuesFirst: 10,
     });
@@ -339,7 +341,7 @@ describe("getProject", () => {
 
   it("throws when project not found", async () => {
     const client = mockGqlClient({ project: null });
-    await expect(getProject(client, "nonexistent")).rejects.toThrow(
+    await expect(getProject(client, asUuid("nonexistent"))).rejects.toThrow(
       'Project with ID "nonexistent" not found',
     );
   });
@@ -384,7 +386,7 @@ describe("createProject", () => {
     });
     const result = await createProject(client, {
       name: "New Project",
-      teamIds: ["team-1"],
+      teamIds: [asUuid("team-1")],
     });
     expect(result.id).toBe("proj-new");
     expect(result.name).toBe("New Project");
@@ -395,7 +397,7 @@ describe("createProject", () => {
       projectCreate: { success: false, project: null },
     });
     await expect(
-      createProject(client, { name: "Fail", teamIds: ["team-1"] }),
+      createProject(client, { name: "Fail", teamIds: [asUuid("team-1")] }),
     ).rejects.toThrow('Failed to create project "Fail"');
   });
 });
@@ -437,7 +439,7 @@ describe("updateProject", () => {
         },
       },
     });
-    const result = await updateProject(client, "proj-1", {
+    const result = await updateProject(client, asUuid("proj-1"), {
       name: "Updated Name",
     });
     expect(result.id).toBe("proj-1");
@@ -450,7 +452,7 @@ describe("updateProject", () => {
       projectUpdate: { success: false, project: null },
     });
     await expect(
-      updateProject(client, "proj-1", { name: "Fail" }),
+      updateProject(client, asUuid("proj-1"), { name: "Fail" }),
     ).rejects.toThrow('Failed to update project "proj-1"');
   });
 });
@@ -464,7 +466,7 @@ describe("archiveProject", () => {
       },
     });
 
-    await expect(archiveProject(client, "proj-1")).resolves.toEqual({
+    await expect(archiveProject(client, asUuid("proj-1"))).resolves.toEqual({
       id: "proj-1",
       name: "Archived Project",
     });
@@ -479,7 +481,7 @@ describe("archiveProject", () => {
       projectArchive: { success: false, entity: null },
     });
 
-    await expect(archiveProject(client, "proj-1")).rejects.toThrow(
+    await expect(archiveProject(client, asUuid("proj-1"))).rejects.toThrow(
       'Failed to archive project "proj-1"',
     );
   });
@@ -494,7 +496,7 @@ describe("unarchiveProject", () => {
       },
     });
 
-    await expect(unarchiveProject(client, "proj-1")).resolves.toEqual({
+    await expect(unarchiveProject(client, asUuid("proj-1"))).resolves.toEqual({
       id: "proj-1",
       name: "Active Project",
     });
@@ -509,7 +511,7 @@ describe("unarchiveProject", () => {
       projectUnarchive: { success: false, entity: null },
     });
 
-    await expect(unarchiveProject(client, "proj-1")).rejects.toThrow(
+    await expect(unarchiveProject(client, asUuid("proj-1"))).rejects.toThrow(
       'Failed to unarchive project "proj-1"',
     );
   });
@@ -521,7 +523,7 @@ describe("deleteProject", () => {
       projectDelete: { success: true, entity: { id: "proj-1" } },
     });
 
-    await expect(deleteProject(client, "proj-1")).resolves.toEqual({
+    await expect(deleteProject(client, asUuid("proj-1"))).resolves.toEqual({
       id: "proj-1",
       success: true,
     });
@@ -536,7 +538,7 @@ describe("deleteProject", () => {
       projectDelete: { success: true, entity: null },
     });
 
-    await expect(deleteProject(client, "proj-1")).resolves.toEqual({
+    await expect(deleteProject(client, asUuid("proj-1"))).resolves.toEqual({
       id: "proj-1",
       success: true,
     });
@@ -547,7 +549,7 @@ describe("deleteProject", () => {
       projectDelete: { success: false, entity: null },
     });
 
-    await expect(deleteProject(client, "proj-1")).rejects.toThrow(
+    await expect(deleteProject(client, asUuid("proj-1"))).rejects.toThrow(
       'Failed to delete project "proj-1"',
     );
   });

--- a/tests/unit/services/reaction-service.test.ts
+++ b/tests/unit/services/reaction-service.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import {
   createReactionForComment,
   createReactionForIssue,
@@ -45,7 +46,10 @@ describe("createReactionForIssue", () => {
       });
 
     await expect(
-      createReactionForIssue(client, { issueId: "issue-1", emoji: "👍" }),
+      createReactionForIssue(client, {
+        issueId: asUuid("issue-1"),
+        emoji: "👍",
+      }),
     ).resolves.toEqual({
       id: "r-2",
       emoji: "👍",
@@ -78,7 +82,10 @@ describe("createReactionForIssue", () => {
       });
 
     await expect(
-      createReactionForIssue(client, { issueId: "issue-1", emoji: "👍" }),
+      createReactionForIssue(client, {
+        issueId: asUuid("issue-1"),
+        emoji: "👍",
+      }),
     ).rejects.toThrow("Already reacted with emoji 👍");
   });
 
@@ -103,7 +110,10 @@ describe("createReactionForIssue", () => {
       });
 
     await expect(
-      createReactionForIssue(client, { issueId: "issue-1", emoji: "  👍  " }),
+      createReactionForIssue(client, {
+        issueId: asUuid("issue-1"),
+        emoji: "  👍  ",
+      }),
     ).rejects.toThrow("Already reacted with emoji 👍");
     expect(client.request).toHaveBeenCalledTimes(2);
   });
@@ -118,7 +128,7 @@ describe("createReactionForIssue", () => {
 
     await expect(
       createReactionForIssue(client, {
-        issueId: "issue-missing",
+        issueId: asUuid("issue-missing"),
         emoji: "👍",
       }),
     ).rejects.toThrow('Issue with ID "issue-missing" not found');
@@ -159,7 +169,10 @@ describe("createReactionForComment", () => {
       });
 
     await expect(
-      createReactionForComment(client, { commentId: "comment-1", emoji: "👍" }),
+      createReactionForComment(client, {
+        commentId: asUuid("comment-1"),
+        emoji: "👍",
+      }),
     ).resolves.toEqual({
       id: "r-2",
       emoji: "👍",
@@ -178,7 +191,7 @@ describe("createReactionForComment", () => {
 
     await expect(
       createReactionForComment(client, {
-        commentId: "comment-missing",
+        commentId: asUuid("comment-missing"),
         emoji: "👍",
       }),
     ).rejects.toThrow('Discussion comment ID "comment-missing" not found');
@@ -213,7 +226,7 @@ describe("deleteOwnReactionByEmoji", () => {
     await expect(
       deleteOwnReactionByEmoji(client, {
         kind: "comment",
-        id: "comment-1",
+        id: asUuid("comment-1"),
         emoji: "👍",
       }),
     ).resolves.toEqual({ id: "r-1", success: true });
@@ -246,7 +259,7 @@ describe("deleteOwnReactionByEmoji", () => {
     await expect(
       deleteOwnReactionByEmoji(client, {
         kind: "comment",
-        id: "comment-1",
+        id: asUuid("comment-1"),
         emoji: "  👍  ",
       }),
     ).resolves.toEqual({ id: "r-1", success: true });
@@ -276,7 +289,7 @@ describe("deleteOwnReactionByEmoji", () => {
     await expect(
       deleteOwnReactionByEmoji(client, {
         kind: "comment",
-        id: "comment-1",
+        id: asUuid("comment-1"),
         emoji: "👍",
       }),
     ).rejects.toThrow("No own reaction found with emoji 👍");
@@ -312,7 +325,7 @@ describe("deleteOwnReactionByEmoji", () => {
     await expect(
       deleteOwnReactionByEmoji(client, {
         kind: "comment",
-        id: "comment-1",
+        id: asUuid("comment-1"),
         emoji: "👍",
       }),
     ).rejects.toThrow("Multiple own reactions found with emoji 👍");
@@ -346,8 +359,8 @@ describe("deleteOwnReactionById", () => {
     await expect(
       deleteOwnReactionById(client, {
         kind: "issue",
-        id: "issue-1",
-        reactionId: "r-1",
+        id: asUuid("issue-1"),
+        reactionId: asUuid("r-1"),
       }),
     ).resolves.toEqual({ id: "r-1", success: true });
   });
@@ -375,8 +388,8 @@ describe("deleteOwnReactionById", () => {
     await expect(
       deleteOwnReactionById(client, {
         kind: "issue",
-        id: "issue-1",
-        reactionId: "missing-reaction",
+        id: asUuid("issue-1"),
+        reactionId: asUuid("missing-reaction"),
       }),
     ).rejects.toThrow('Reaction "missing-reaction" not found');
   });
@@ -404,8 +417,8 @@ describe("deleteOwnReactionById", () => {
     await expect(
       deleteOwnReactionById(client, {
         kind: "issue",
-        id: "issue-1",
-        reactionId: "r-1",
+        id: asUuid("issue-1"),
+        reactionId: asUuid("r-1"),
       }),
     ).rejects.toThrow('Reaction "r-1" is not owned by viewer');
   });

--- a/tests/unit/services/team-service.test.ts
+++ b/tests/unit/services/team-service.test.ts
@@ -1,6 +1,8 @@
 // tests/unit/services/team-service.test.ts
+
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
 import {
   getTeam,
   listTeams,
@@ -129,7 +131,7 @@ describe("getTeam", () => {
     ]);
 
     const result = assertTeamDetailShape(
-      await getTeam(client, { id: "team-1" }),
+      await getTeam(client, { id: asUuid("team-1") }),
     );
 
     expect(assertEstimationSource(result.estimationSource)).toBe("self");
@@ -207,7 +209,7 @@ describe("getTeam", () => {
     ]);
 
     const result = assertTeamDetailShape(
-      await getTeam(client, { id: "team-child" }),
+      await getTeam(client, { id: asUuid("team-child") }),
     );
 
     expect(assertEstimationSource(result.estimationSource)).toBe("parent");
@@ -257,7 +259,7 @@ describe("getTeam", () => {
       },
     ]);
 
-    const result = await getTeam(client, { id: "team-2" });
+    const result = await getTeam(client, { id: asUuid("team-2") });
     expect(result.validEstimates).toEqual([]);
     expect(result.estimationSource).toBe("self");
   });
@@ -296,7 +298,7 @@ describe("getTeam", () => {
       },
     ]);
 
-    const result = await getTeam(client, { id: "team-unknown" });
+    const result = await getTeam(client, { id: asUuid("team-unknown") });
     expect(result.validEstimates).toEqual([]);
     expect(result.estimationSource).toBe("self");
   });
@@ -335,7 +337,7 @@ describe("getTeam", () => {
       },
     ]);
 
-    const result = await getTeam(client, { id: "team-3" });
+    const result = await getTeam(client, { id: asUuid("team-3") });
     expect(result.validEstimates).toEqual([
       { value: 1, label: "XS" },
       { value: 2, label: "S" },
@@ -384,7 +386,7 @@ describe("getTeam", () => {
         .mockRejectedValueOnce(new Error("parent lookup failed")),
     } as unknown as GraphQLClient;
 
-    const result = await getTeam(client, { id: "team-child" });
+    const result = await getTeam(client, { id: asUuid("team-child") });
 
     expect(result.estimationSource).toBe("self_fallback");
     expect(result.validEstimates).toEqual([


### PR DESCRIPTION
## What does this PR do?

Introduces a branded `UUID` type in `src/common/identifier.ts` (`UUID`, `asUuid`, `BrandUuidFields`) and threads it through every resolver return type, service parameter/input type, and the command call sites that feed them. This makes the compiler enforce the P0 architecture invariant that services only ever receive already-resolved IDs — a plain identifier string (e.g. `ENG-123`) is no longer assignable to a service's UUID slot, while a `UUID` still flows into codegen GraphQL string inputs untouched. The brand is erased at runtime, so there is no behavior change; the change is type-level only.

Closes #196

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- `npx tsc --noEmit` — passes clean; the green type-check is the proof that no unresolved identifier string can reach a service UUID parameter.
- `npm test` — 837 tests pass across 61 files.
- `npm run check:ci` — passes (exit 0).

## Notes for reviewers

Purely mechanical, compile-time-only change: `asUuid()` is applied at trust boundaries (resolver outputs, and raw CLI args for entities with no human-friendly alias such as comment/thread/document/reaction UUIDs). `BrandUuidFields<T, K>` is homomorphic (preserves optional/readonly modifiers) and preserves `null`/`undefined` on nullable GraphQL fields; only genuine UUID-bearing keys are branded (e.g. `dueDate`, `startDate`, `priority` are deliberately excluded). Test changes are mechanical `asUuid("…")` wrapping plus Biome reformatting — no assertions were weakened.