### PR TITLE
refactor(graphql): add lean filter-based lookup queries for resolvers

### DIFF
--- a/graphql/queries/initiatives.graphql
+++ b/graphql/queries/initiatives.graphql
@@ -182,6 +182,21 @@ query FindInitiativesByName($name: String!, $teamId: ID, $ownerId: ID) {
   }
 }
 
+# Find initiatives by a dynamic filter for ID resolution
+#
+# The filter is supplied by the caller (name plus optional team/owner
+# scope), preserving the resolver's dynamic filter construction and
+# avoiding the nullable-scope behavior of FindInitiativesByName.
+# Emits the InitiativeFilter input type. first: 20 matches the resolver's
+# candidate limit for ambiguity reporting.
+query FindInitiatives($filter: InitiativeFilter, $first: Int = 20) {
+  initiatives(filter: $filter, first: $first) {
+    nodes {
+      ...InitiativeNameLookupFields
+    }
+  }
+}
+
 query FindInitiativeRelationByPair(
   $parentId: String!
   $childId: String!

--- a/graphql/queries/issues.graphql
+++ b/graphql/queries/issues.graphql
@@ -835,6 +835,19 @@ query BatchResolveWorkflowStatesPage($first: Int!, $after: String) {
   }
 }
 
+# Find workflow states by a dynamic filter for status ID resolution
+#
+# The filter is supplied by the caller (name plus optional team scope)
+# so the unscoped case omits the team clause entirely rather than
+# filtering on a null team id. Emits the WorkflowStateFilter input type.
+query FindWorkflowStates($filter: WorkflowStateFilter, $first: Int = 1) {
+  workflowStates(filter: $filter, first: $first) {
+    nodes {
+      id
+    }
+  }
+}
+
 # Complete issue fragment with attachments
 fragment CompleteIssueWithAttachmentsFields on Issue {
   ...CompleteIssueWithDefaultCommentsFields

--- a/graphql/queries/labels.graphql
+++ b/graphql/queries/labels.graphql
@@ -67,3 +67,15 @@ query GetProjectLabels($first: Int = 50, $after: String) {
     }
   }
 }
+
+# Find a project label by case-insensitive name for ID resolution
+#
+# Returns the first match; project label names are treated as unique
+# for resolution purposes (no ambiguity error).
+query FindProjectLabelByName($name: String!) {
+  projectLabels(filter: { name: { eqIgnoreCase: $name } }, first: 1) {
+    nodes {
+      id
+    }
+  }
+}

--- a/graphql/queries/projects.graphql
+++ b/graphql/queries/projects.graphql
@@ -195,3 +195,19 @@ query GetProjectStatuses {
     }
   }
 }
+
+# Find projects by case-insensitive name for ID resolution
+#
+# Returns up to two matches so the resolver can throw on ambiguity.
+# includeArchived is passed through to preserve archive-aware lookups.
+query FindProjectsByName($name: String!, $includeArchived: Boolean) {
+  projects(
+    filter: { name: { eqIgnoreCase: $name } }
+    first: 2
+    includeArchived: $includeArchived
+  ) {
+    nodes {
+      id
+    }
+  }
+}

--- a/graphql/queries/teams.graphql
+++ b/graphql/queries/teams.graphql
@@ -78,3 +78,30 @@ query GetTeamById($id: String!) {
     ...TeamDetailFields
   }
 }
+
+# Lean fields for team ID/estimate resolution
+#
+# Covers both resolveTeamId (id only) and resolveTeamEstimateContext
+# (id, key, name plus the estimation fields) without over-fetching the
+# heavy TeamDetailFields fragment.
+fragment TeamLookupFields on Team {
+  id
+  key
+  name
+  issueEstimationType
+  issueEstimationExtended
+  issueEstimationAllowZero
+}
+
+# Find teams by an arbitrary filter for resolver lookups
+#
+# The filter is supplied dynamically so callers can preserve the
+# key-first-then-name lookup order (two calls) and the id/key/name
+# estimate lookups with a single operation.
+query FindTeams($filter: TeamFilter, $first: Int = 1) {
+  teams(filter: $filter, first: $first) {
+    nodes {
+      ...TeamLookupFields
+    }
+  }
+}


### PR DESCRIPTION
## What does this PR do?

Adds dynamic filter-based lookup queries and lean fragments for ID resolution across teams, projects, project labels, initiatives, and workflow states. Callers supply the filter dynamically, so unscoped lookups omit team/owner clauses entirely instead of filtering on a null id, and a new `TeamLookupFields` fragment covers id/key/name plus estimate fields without over-fetching the heavy detail fragments.

Closes #208

## Type of change

- [x] Refactor (no behavior change)

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Lint/format via lefthook pre-commit (biome) passed. Query additions are consumed by codegen; no runtime behavior changes on their own.