### PR TITLE
refactor(resolvers): migrate ID resolvers to GraphQLClient and drop Linear SDK

### DIFF
--- a/graphql/queries/issues.graphql
+++ b/graphql/queries/issues.graphql
@@ -848,6 +848,25 @@ query FindWorkflowStates($filter: WorkflowStateFilter, $first: Int = 1) {
   }
 }
 
+# Find issues by a dynamic filter for ID resolution
+#
+# The filter is supplied by the caller so the resolver can preserve both the
+# UUID lookup ({ id: { eq } }) and the identifier lookup
+# ({ number: { eq }, team: { key: { eq } } }). team { id key } is selected so
+# the estimate-context resolver can derive the owning team without a second
+# round-trip.
+query FindIssues($filter: IssueFilter, $first: Int = 1) {
+  issues(filter: $filter, first: $first) {
+    nodes {
+      id
+      team {
+        id
+        key
+      }
+    }
+  }
+}
+
 # Complete issue fragment with attachments
 fragment CompleteIssueWithAttachmentsFields on Issue {
   ...CompleteIssueWithDefaultCommentsFields

--- a/graphql/queries/labels.graphql
+++ b/graphql/queries/labels.graphql
@@ -79,3 +79,16 @@ query FindProjectLabelByName($name: String!) {
     }
   }
 }
+
+# Find issue labels by a dynamic filter for ID resolution
+#
+# The filter is supplied by the caller so the resolver can preserve its
+# scope-aware filter construction (workspace/team/team-scoped) rather than
+# baking the scope clauses into the query.
+query FindIssueLabels($filter: IssueLabelFilter, $first: Int = 1) {
+  issueLabels(filter: $filter, first: $first) {
+    nodes {
+      id
+    }
+  }
+}

--- a/graphql/queries/users.graphql
+++ b/graphql/queries/users.graphql
@@ -42,3 +42,18 @@ query GetUsers($first: Int = 50, $after: String, $filter: UserFilter) {
     }
   }
 }
+
+# Find users by a dynamic filter for ID resolution
+#
+# The filter is supplied by the caller so the resolver can preserve its
+# display-name-first (first: 10) then email-fallback (first: 1) lookup order.
+# name/email are selected so the resolver can report ambiguous matches.
+query FindUsers($filter: UserFilter, $first: Int = 1) {
+  users(filter: $filter, first: $first) {
+    nodes {
+      id
+      name
+      email
+    }
+  }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,6 @@
       "version": "2026.6.0-next.9",
       "license": "MIT",
       "dependencies": {
-        "@linear/sdk": "82.1.0",
         "commander": "14.0.3",
         "graphql": "16.12.0",
         "node-emoji": "2.2.0"
@@ -2205,6 +2204,7 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/@graphql-typed-document-node/core/-/core-3.2.0.tgz",
       "integrity": "sha512-mB9oAsNCm9aM3/SOv4YtBMqZbYj10R7dkq8byBqxGY/ncFwhf2oQzMV+LCRlWoDSEBJ3COiR1yeDvMtsoOsuFQ==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "graphql": "^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0"
@@ -2602,18 +2602,6 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
-      }
-    },
-    "node_modules/@linear/sdk": {
-      "version": "82.1.0",
-      "resolved": "https://registry.npmjs.org/@linear/sdk/-/sdk-82.1.0.tgz",
-      "integrity": "sha512-Ok7o+LqXaenx6Um58NQqjQoQanDsCgAIe9yNgpVbqRSh5APz3Ds1kZUz2vWmSNTNATFZm1zDQtEktTMga2X7UQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@graphql-typed-document-node/core": "^3.2.0"
-      },
-      "engines": {
-        "node": ">=18.x"
       }
     },
     "node_modules/@napi-rs/wasm-runtime": {

--- a/package.json
+++ b/package.json
@@ -70,7 +70,6 @@
   },
   "homepage": "https://github.com/linearis-oss/linearis#readme",
   "dependencies": {
-    "@linear/sdk": "82.1.0",
     "commander": "14.0.3",
     "graphql": "16.12.0",
     "node-emoji": "2.2.0"

--- a/src/client/linear-client.ts
+++ b/src/client/linear-client.ts
@@ -1,9 +1,0 @@
-import { LinearClient } from "@linear/sdk";
-
-export class LinearSdkClient {
-  readonly sdk: LinearClient;
-
-  constructor(apiToken: string) {
-    this.sdk = new LinearClient({ apiKey: apiToken });
-  }
-}

--- a/src/commands/attachments.ts
+++ b/src/commands/attachments.ts
@@ -93,7 +93,7 @@ export function setupAttachmentsCommands(program: Command): void {
         ];
         const issueIdentifier = resolveIssueArgument(issue, options.issue);
         const ctx = createContext(getRootOpts(command));
-        const issueId = await resolveIssueId(ctx.sdk, issueIdentifier);
+        const issueId = await resolveIssueId(ctx.gql, issueIdentifier);
         const filter = buildAttachmentFilter(options);
         const result = await listAttachments(ctx.gql, issueId, filter);
         outputSuccess(result);
@@ -118,7 +118,7 @@ export function setupAttachmentsCommands(program: Command): void {
         ];
         const issueIdentifier = resolveIssueArgument(issue, options.issue);
         const ctx = createContext(getRootOpts(command));
-        const issueId = await resolveIssueId(ctx.sdk, issueIdentifier);
+        const issueId = await resolveIssueId(ctx.gql, issueIdentifier);
         const input: CreateAttachmentInput = {
           issueId,
           title: options.title,

--- a/src/commands/comments.ts
+++ b/src/commands/comments.ts
@@ -98,7 +98,7 @@ export function setupCommentsCommands(program: Command): void {
         const ctx = createContext(getRootOpts(command));
 
         const limit = parseLimit(options.limit || "25");
-        const resolvedIssueId = await resolveIssueId(ctx.sdk, issue);
+        const resolvedIssueId = await resolveIssueId(ctx.gql, issue);
         const result = await listDiscussionsForIssue(
           ctx.gql,
           resolvedIssueId,
@@ -133,7 +133,7 @@ export function setupCommentsCommands(program: Command): void {
           throw invalidParameterError("--body", "is required");
         }
 
-        const resolvedIssueId = await resolveIssueId(ctx.sdk, issue);
+        const resolvedIssueId = await resolveIssueId(ctx.gql, issue);
         const result = await startIssueDiscussion(ctx.gql, {
           issueId: resolvedIssueId,
           body: options.body,

--- a/src/commands/cycles.ts
+++ b/src/commands/cycles.ts
@@ -72,7 +72,7 @@ export function setupCyclesCommands(program: Command): void {
 
         // Resolve team filter if provided
         const teamId = options.team
-          ? await resolveTeamId(ctx.sdk, options.team)
+          ? await resolveTeamId(ctx.gql, options.team)
           : undefined;
 
         // Fetch cycles
@@ -130,7 +130,7 @@ export function setupCyclesCommands(program: Command): void {
         ];
         const ctx = createContext(getRootOpts(command));
 
-        const cycleId = await resolveCycleId(ctx.sdk, cycle, options.team);
+        const cycleId = await resolveCycleId(ctx.gql, cycle, options.team);
 
         const cycleResult = await getCycle(
           ctx.gql,

--- a/src/commands/documents.ts
+++ b/src/commands/documents.ts
@@ -122,12 +122,12 @@ export function setupDocumentsCommands(program: Command): void {
 
         let projectId: UUID | undefined;
         if (options.project) {
-          projectId = await resolveProjectId(ctx.sdk, options.project);
+          projectId = await resolveProjectId(ctx.gql, options.project);
         }
 
         let issueId: UUID | undefined;
         if (options.issue) {
-          issueId = await resolveIssueId(ctx.sdk, options.issue);
+          issueId = await resolveIssueId(ctx.gql, options.issue);
         }
 
         let filter: ReturnType<typeof buildIssueDocumentFilter> | undefined;
@@ -198,13 +198,13 @@ export function setupDocumentsCommands(program: Command): void {
         const ctx = createContext(rootOpts);
 
         const projectId = options.project
-          ? await resolveProjectId(ctx.sdk, options.project)
+          ? await resolveProjectId(ctx.gql, options.project)
           : undefined;
         const teamId = options.team
-          ? await resolveTeamId(ctx.sdk, options.team)
+          ? await resolveTeamId(ctx.gql, options.team)
           : undefined;
         const issueId = issueIdentifier
-          ? await resolveIssueId(ctx.sdk, issueIdentifier)
+          ? await resolveIssueId(ctx.gql, issueIdentifier)
           : undefined;
 
         const document = await createDocument(ctx.gql, {
@@ -243,7 +243,7 @@ export function setupDocumentsCommands(program: Command): void {
         if (options.title) input.title = options.title;
         if (options.content) input.content = options.content;
         if (options.project) {
-          input.projectId = await resolveProjectId(ctx.sdk, options.project);
+          input.projectId = await resolveProjectId(ctx.gql, options.project);
         }
         if (options.icon) input.icon = options.icon;
         if (options.color) input.color = options.color;

--- a/src/commands/initiatives/entity.ts
+++ b/src/commands/initiatives/entity.ts
@@ -1,5 +1,5 @@
 import type { Command } from "commander";
-import type { LinearSdkClient } from "../../client/linear-client.js";
+import type { GraphQLClient } from "../../client/graphql-client.js";
 import { createContext, getRootOpts } from "../../common/context.js";
 import { resolveReactionEmojiInput } from "../../common/emoji.js";
 import { invalidParameterError } from "../../common/errors.js";
@@ -246,7 +246,7 @@ function getExpandFlags(options: InitiativeExpandOptions): string[] {
 }
 
 async function resolveInitiativeFilterInput(
-  sdk: LinearSdkClient,
+  gql: GraphQLClient,
   options: InitiativeListOptions,
 ): Promise<InitiativeFilterInput> {
   if (options.parent) {
@@ -276,19 +276,19 @@ async function resolveInitiativeFilterInput(
   });
 
   if (options.owner) {
-    input.ownerId = await resolveUserId(sdk, options.owner);
+    input.ownerId = await resolveUserId(gql, options.owner);
   }
 
   if (options.creator) {
-    input.creatorId = await resolveUserId(sdk, options.creator);
+    input.creatorId = await resolveUserId(gql, options.creator);
   }
 
   if (options.team) {
-    input.teamId = await resolveTeamId(sdk, options.team);
+    input.teamId = await resolveTeamId(gql, options.team);
   }
 
   if (options.ancestor) {
-    input.ancestorId = await resolveInitiativeId(sdk, options.ancestor);
+    input.ancestorId = await resolveInitiativeId(gql, options.ancestor);
   }
 
   return input;
@@ -367,7 +367,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           const sort = mapSortByToInitiativeSort(sortBy, sortOrder);
 
           const filterInput = await resolveInitiativeFilterInput(
-            ctx.sdk,
+            ctx.gql,
             options,
           );
           const filter = buildInitiativeFilter(filterInput);
@@ -409,7 +409,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
       commandAction<[string, InitiativeReadOptions, Command]>(
         async (initiative, options, command) => {
           const ctx = createContext(getRootOpts(command));
-          const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+          const initiativeId = await resolveInitiativeId(ctx.gql, initiative);
 
           // Read query already returns expanded fields. Keep flags accepted for
           // CLI contract compatibility until conditional field selection is added.
@@ -434,7 +434,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
             throw invalidParameterError("--body", "is required");
           }
 
-          const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+          const initiativeId = await resolveInitiativeId(ctx.gql, initiative);
           const result = await startInitiativeDiscussion(ctx.gql, {
             initiativeId,
             body: options.body,
@@ -456,7 +456,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
         async (initiative, options, command) => {
           const ctx = createContext(getRootOpts(command));
 
-          const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+          const initiativeId = await resolveInitiativeId(ctx.gql, initiative);
           const paginationOptions = buildPaginationOptions(
             parseLimit(options.limit || "25"),
             options.after,
@@ -704,7 +704,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           }
 
           if (options.owner) {
-            input.ownerId = await resolveUserId(ctx.sdk, options.owner);
+            input.ownerId = await resolveUserId(ctx.gql, options.owner);
           }
 
           const status = parseInitiativeStatus(options.status);
@@ -741,7 +741,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
       commandAction<[string, InitiativeUpdateOptions, Command]>(
         async (initiative, options, command) => {
           const ctx = createContext(getRootOpts(command));
-          const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+          const initiativeId = await resolveInitiativeId(ctx.gql, initiative);
 
           const input: UpdateInitiativeInput = {};
 
@@ -758,7 +758,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
           }
 
           if (options.owner) {
-            input.ownerId = await resolveUserId(ctx.sdk, options.owner);
+            input.ownerId = await resolveUserId(ctx.gql, options.owner);
           }
 
           const status = parseInitiativeStatus(options.status);
@@ -795,7 +795,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
       commandAction<[string, unknown, Command]>(
         async (initiative, _unused1, command) => {
           const ctx = createContext(getRootOpts(command));
-          const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+          const initiativeId = await resolveInitiativeId(ctx.gql, initiative);
           const result = await archiveInitiative(ctx.gql, initiativeId);
           outputSuccess(result);
         },
@@ -809,7 +809,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
       commandAction<[string, unknown, Command]>(
         async (initiative, _unused1, command) => {
           const ctx = createContext(getRootOpts(command));
-          const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+          const initiativeId = await resolveInitiativeId(ctx.gql, initiative);
           const result = await unarchiveInitiative(ctx.gql, initiativeId);
           outputSuccess(result);
         },
@@ -823,7 +823,7 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
       commandAction<[string, unknown, Command]>(
         async (initiative, _unused1, command) => {
           const ctx = createContext(getRootOpts(command));
-          const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
+          const initiativeId = await resolveInitiativeId(ctx.gql, initiative);
           const result = await deleteInitiative(ctx.gql, initiativeId);
           outputSuccess(result);
         },

--- a/src/commands/initiatives/projects.ts
+++ b/src/commands/initiatives/projects.ts
@@ -25,8 +25,8 @@ export function setupInitiativeProjectCommands(initiatives: Command): void {
         ];
         const ctx = createContext(getRootOpts(command));
 
-        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
-        const projectId = await resolveProjectId(ctx.sdk, project);
+        const initiativeId = await resolveInitiativeId(ctx.gql, initiative);
+        const projectId = await resolveProjectId(ctx.gql, project);
 
         const result = await createInitiativeProjectLink(ctx.gql, {
           initiativeId,
@@ -50,8 +50,8 @@ export function setupInitiativeProjectCommands(initiatives: Command): void {
         ];
         const ctx = createContext(getRootOpts(command));
 
-        const initiativeId = await resolveInitiativeId(ctx.sdk, initiative);
-        const projectId = await resolveProjectId(ctx.sdk, project);
+        const initiativeId = await resolveInitiativeId(ctx.gql, initiative);
+        const projectId = await resolveProjectId(ctx.gql, project);
 
         const linkId = await resolveInitiativeProjectLinkId(
           ctx.gql,

--- a/src/commands/initiatives/relations.ts
+++ b/src/commands/initiatives/relations.ts
@@ -24,8 +24,8 @@ export function setupInitiativeRelationCommands(initiatives: Command): void {
         ];
         const ctx = createContext(getRootOpts(command));
 
-        const parentId = await resolveInitiativeId(ctx.sdk, parent);
-        const childId = await resolveInitiativeId(ctx.sdk, child);
+        const parentId = await resolveInitiativeId(ctx.gql, parent);
+        const childId = await resolveInitiativeId(ctx.gql, child);
 
         const result = await createInitiativeRelation(ctx.gql, {
           parentId,
@@ -49,8 +49,8 @@ export function setupInitiativeRelationCommands(initiatives: Command): void {
         ];
         const ctx = createContext(getRootOpts(command));
 
-        const parentId = await resolveInitiativeId(ctx.sdk, parent);
-        const childId = await resolveInitiativeId(ctx.sdk, child);
+        const parentId = await resolveInitiativeId(ctx.gql, parent);
+        const childId = await resolveInitiativeId(ctx.gql, child);
 
         const relationId = await resolveInitiativeRelationId(
           ctx.gql,

--- a/src/commands/initiatives/updates.ts
+++ b/src/commands/initiatives/updates.ts
@@ -62,7 +62,7 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
         const ctx = createContext(getRootOpts(command));
 
         const initiativeId = await resolveInitiativeId(
-          ctx.sdk,
+          ctx.gql,
           options.initiative,
         );
 
@@ -103,7 +103,7 @@ export function setupInitiativeUpdateCommands(initiatives: Command): void {
         const ctx = createContext(getRootOpts(command));
 
         const initiativeId = await resolveInitiativeId(
-          ctx.sdk,
+          ctx.gql,
           options.initiative,
         );
 

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -425,7 +425,7 @@ async function resolveAndApplyRelations(
   const resolved = new Map<string, UUID>();
   await Promise.all(
     [...uniqueTargets].map(async (target) => {
-      resolved.set(target, await resolveIssueId(ctx.sdk, target));
+      resolved.set(target, await resolveIssueId(ctx.gql, target));
     }),
   );
 
@@ -532,7 +532,7 @@ export function setupIssuesCommands(program: Command): void {
       commandAction<[string, unknown, Command]>(
         async (issue, _unused1, command) => {
           const ctx = createContext(getRootOpts(command));
-          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const issueId = await resolveIssueId(ctx.gql, issue);
           const result = await listIssueRelations(ctx.gql, issueId);
 
           outputSuccess(result);
@@ -555,9 +555,9 @@ export function setupIssuesCommands(program: Command): void {
         async (issue, options, command) => {
           const relation = parseRelationAddOptions(options);
           const ctx = createContext(getRootOpts(command));
-          const sourceIssueId = await resolveIssueId(ctx.sdk, issue);
+          const sourceIssueId = await resolveIssueId(ctx.gql, issue);
           const targetIds = await Promise.all(
-            relation.targets.map((target) => resolveIssueId(ctx.sdk, target)),
+            relation.targets.map((target) => resolveIssueId(ctx.gql, target)),
           );
 
           const created = await Promise.all(
@@ -765,7 +765,7 @@ export function setupIssuesCommands(program: Command): void {
       commandAction<[string, string | undefined, ReactionOptions, Command]>(
         async (issue, emoji, options, command) => {
           const ctx = createContext(getRootOpts(command));
-          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const issueId = await resolveIssueId(ctx.gql, issue);
           const result = await createReactionForIssue(ctx.gql, {
             issueId,
             emoji: resolveReactionEmojiInput(emoji, options.shortcode),
@@ -788,7 +788,7 @@ export function setupIssuesCommands(program: Command): void {
       commandAction<[string, string | undefined, ReactionOptions, Command]>(
         async (issue, emoji, options, command) => {
           const ctx = createContext(getRootOpts(command));
-          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const issueId = await resolveIssueId(ctx.gql, issue);
           const result = await deleteOwnReactionByEmoji(ctx.gql, {
             kind: "issue",
             id: issueId,
@@ -811,7 +811,7 @@ export function setupIssuesCommands(program: Command): void {
       commandAction<[string, string, unknown, Command]>(
         async (issue, reactionId, _unused2, command) => {
           const ctx = createContext(getRootOpts(command));
-          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const issueId = await resolveIssueId(ctx.gql, issue);
           const result = await deleteOwnReactionById(ctx.gql, {
             kind: "issue",
             id: issueId,
@@ -840,7 +840,7 @@ export function setupIssuesCommands(program: Command): void {
             throw invalidParameterError("--body", "is required");
           }
 
-          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const issueId = await resolveIssueId(ctx.gql, issue);
           const result = await startIssueDiscussion(ctx.gql, {
             issueId,
             body: options.body,
@@ -866,7 +866,7 @@ export function setupIssuesCommands(program: Command): void {
         async (issue, options, command) => {
           const ctx = createContext(getRootOpts(command));
 
-          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const issueId = await resolveIssueId(ctx.gql, issue);
           const paginationOptions = buildPaginationOptions(
             parseLimit(options.limit || "25"),
             options.after,
@@ -1131,12 +1131,12 @@ export function setupIssuesCommands(program: Command): void {
 
           const teamEstimateContext =
             parsedEstimate !== undefined
-              ? await resolveTeamEstimateContext(ctx.sdk, options.team)
+              ? await resolveTeamEstimateContext(ctx.gql, options.team)
               : undefined;
 
           const teamId = teamEstimateContext
             ? teamEstimateContext.teamId
-            : await resolveTeamId(ctx.sdk, options.team);
+            : await resolveTeamId(ctx.gql, options.team);
 
           if (parsedEstimate !== undefined && teamEstimateContext) {
             validateEstimateAgainstTeamConfig(parsedEstimate, {
@@ -1159,7 +1159,7 @@ export function setupIssuesCommands(program: Command): void {
           }
 
           if (options.assignee) {
-            input.assigneeId = await resolveUserId(ctx.sdk, options.assignee);
+            input.assigneeId = await resolveUserId(ctx.gql, options.assignee);
           }
 
           if (parsedPriority !== undefined) {
@@ -1171,12 +1171,12 @@ export function setupIssuesCommands(program: Command): void {
           }
 
           if (options.project) {
-            input.projectId = await resolveProjectId(ctx.sdk, options.project);
+            input.projectId = await resolveProjectId(ctx.gql, options.project);
           }
 
           if (options.labels) {
             const labelNames = options.labels.split(",").map((l) => l.trim());
-            input.labelIds = await resolveLabelIds(ctx.sdk, labelNames);
+            input.labelIds = await resolveLabelIds(ctx.gql, labelNames);
           }
 
           if (options.projectMilestone) {
@@ -1187,7 +1187,6 @@ export function setupIssuesCommands(program: Command): void {
             }
             input.projectMilestoneId = await resolveMilestoneId(
               ctx.gql,
-              ctx.sdk,
               options.projectMilestone,
               options.project,
             );
@@ -1195,7 +1194,7 @@ export function setupIssuesCommands(program: Command): void {
 
           if (options.cycle) {
             input.cycleId = await resolveCycleId(
-              ctx.sdk,
+              ctx.gql,
               options.cycle,
               options.team,
             );
@@ -1203,7 +1202,7 @@ export function setupIssuesCommands(program: Command): void {
 
           if (options.status) {
             input.stateId = await resolveStatusId(
-              ctx.sdk,
+              ctx.gql,
               options.status,
               teamId,
             );
@@ -1211,7 +1210,7 @@ export function setupIssuesCommands(program: Command): void {
 
           if (options.parentTicket) {
             input.parentId = await resolveIssueId(
-              ctx.sdk,
+              ctx.gql,
               options.parentTicket,
             );
           }
@@ -1327,12 +1326,12 @@ export function setupIssuesCommands(program: Command): void {
 
           const issueEstimateContext =
             parsedEstimate !== undefined
-              ? await resolveIssueEstimateContext(ctx.sdk, issue)
+              ? await resolveIssueEstimateContext(ctx.gql, issue)
               : undefined;
 
           const resolvedIssueId = issueEstimateContext
             ? issueEstimateContext.issueId
-            : await resolveIssueId(ctx.sdk, issue);
+            : await resolveIssueId(ctx.gql, issue);
 
           if (parsedEstimate !== undefined && issueEstimateContext) {
             validateEstimateAgainstTeamConfig(parsedEstimate, {
@@ -1371,7 +1370,7 @@ export function setupIssuesCommands(program: Command): void {
                 ? asUuid(issueContext.team.id)
                 : undefined;
             input.stateId = await resolveStatusId(
-              ctx.sdk,
+              ctx.gql,
               options.status,
               teamId,
             );
@@ -1388,18 +1387,18 @@ export function setupIssuesCommands(program: Command): void {
           }
 
           if (options.assignee) {
-            input.assigneeId = await resolveUserId(ctx.sdk, options.assignee);
+            input.assigneeId = await resolveUserId(ctx.gql, options.assignee);
           }
 
           if (options.project) {
-            input.projectId = await resolveProjectId(ctx.sdk, options.project);
+            input.projectId = await resolveProjectId(ctx.gql, options.project);
           }
 
           if (options.clearLabels) {
             input.labelIds = [];
           } else if (options.labels) {
             const labelNames = options.labels.split(",").map((l) => l.trim());
-            const labelIds = await resolveLabelIds(ctx.sdk, labelNames);
+            const labelIds = await resolveLabelIds(ctx.gql, labelNames);
 
             if (labelMode === "add") {
               const currentLabels =
@@ -1428,7 +1427,7 @@ export function setupIssuesCommands(program: Command): void {
             input.parentId = null;
           } else if (options.parentTicket) {
             input.parentId = await resolveIssueId(
-              ctx.sdk,
+              ctx.gql,
               options.parentTicket,
             );
           }
@@ -1444,7 +1443,6 @@ export function setupIssuesCommands(program: Command): void {
                 : undefined;
             input.projectMilestoneId = await resolveMilestoneId(
               ctx.gql,
-              ctx.sdk,
               options.projectMilestone,
               projectName,
             );
@@ -1458,7 +1456,7 @@ export function setupIssuesCommands(program: Command): void {
                 ? issueContext.team.key
                 : undefined;
             input.cycleId = await resolveCycleId(
-              ctx.sdk,
+              ctx.gql,
               options.cycle,
               teamKey,
             );
@@ -1492,7 +1490,7 @@ export function setupIssuesCommands(program: Command): void {
       commandAction<[string, unknown, Command]>(
         async (issue, _unused1, command) => {
           const ctx = createContext(getRootOpts(command));
-          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const issueId = await resolveIssueId(ctx.gql, issue);
           const result = await archiveIssue(ctx.gql, issueId);
           outputSuccess(result);
         },
@@ -1506,7 +1504,7 @@ export function setupIssuesCommands(program: Command): void {
       commandAction<[string, unknown, Command]>(
         async (issue, _unused1, command) => {
           const ctx = createContext(getRootOpts(command));
-          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const issueId = await resolveIssueId(ctx.gql, issue);
           const result = await unarchiveIssue(ctx.gql, issueId);
           outputSuccess(result);
         },
@@ -1520,7 +1518,7 @@ export function setupIssuesCommands(program: Command): void {
       commandAction<[string, unknown, Command]>(
         async (issue, _unused1, command) => {
           const ctx = createContext(getRootOpts(command));
-          const issueId = await resolveIssueId(ctx.sdk, issue);
+          const issueId = await resolveIssueId(ctx.gql, issue);
           const result = await deleteIssue(ctx.gql, issueId);
           outputSuccess(result);
         },

--- a/src/commands/labels.ts
+++ b/src/commands/labels.ts
@@ -103,10 +103,10 @@ async function resolveIssueLabelLookup(
   }
 
   const teamId = options.team
-    ? await resolveTeamId(ctx.sdk, options.team)
+    ? await resolveTeamId(ctx.gql, options.team)
     : undefined;
   const labelId = await resolveLabelId(
-    ctx.sdk,
+    ctx.gql,
     label,
     omitUndefined({
       teamId,
@@ -222,7 +222,7 @@ export function setupLabelsCommands(program: Command): void {
         }
 
         const teamId = options.team
-          ? await resolveTeamId(ctx.sdk, options.team)
+          ? await resolveTeamId(ctx.gql, options.team)
           : undefined;
 
         outputSuccess(await listLabels(ctx.gql, teamId, pagination));
@@ -248,7 +248,7 @@ export function setupLabelsCommands(program: Command): void {
         const color = parseLabelColor(options.color);
 
         if (options.team) {
-          input.teamId = await resolveTeamId(ctx.sdk, options.team);
+          input.teamId = await resolveTeamId(ctx.gql, options.team);
         }
 
         if (color) {

--- a/src/commands/milestones.ts
+++ b/src/commands/milestones.ts
@@ -76,7 +76,7 @@ export function setupMilestonesCommands(program: Command): void {
         const ctx = createContext(getRootOpts(command));
 
         // Resolve project ID
-        const projectId = await resolveProjectId(ctx.sdk, options.project);
+        const projectId = await resolveProjectId(ctx.gql, options.project);
 
         const milestones = await listMilestones(
           ctx.gql,
@@ -108,7 +108,6 @@ export function setupMilestonesCommands(program: Command): void {
 
         const milestoneId = await resolveMilestoneId(
           ctx.gql,
-          ctx.sdk,
           milestone,
           options.project,
         );
@@ -140,7 +139,7 @@ export function setupMilestonesCommands(program: Command): void {
         const ctx = createContext(getRootOpts(command));
 
         // Resolve project ID
-        const projectId = await resolveProjectId(ctx.sdk, options.project);
+        const projectId = await resolveProjectId(ctx.gql, options.project);
 
         const milestone = await createMilestone(ctx.gql, {
           projectId,
@@ -176,7 +175,6 @@ export function setupMilestonesCommands(program: Command): void {
 
         const milestoneId = await resolveMilestoneId(
           ctx.gql,
-          ctx.sdk,
           milestone,
           options.project,
         );

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -291,7 +291,7 @@ export function setupProjectsCommands(program: Command): void {
       commandAction<[string, ReadOptions, Command]>(
         async (project, options, command) => {
           const ctx = createContext(getRootOpts(command));
-          const projectId = await resolveProjectId(ctx.sdk, project);
+          const projectId = await resolveProjectId(ctx.gql, project);
           const result = await getProject(ctx.gql, projectId, {
             milestonesFirst: parseNonNegativeIntegerOption(
               "--milestones-first",
@@ -320,7 +320,7 @@ export function setupProjectsCommands(program: Command): void {
             throw invalidParameterError("--body", "is required");
           }
 
-          const projectId = await resolveProjectId(ctx.sdk, project);
+          const projectId = await resolveProjectId(ctx.gql, project);
           const result = await startProjectDiscussion(ctx.gql, {
             projectId,
             body: options.body,
@@ -342,7 +342,7 @@ export function setupProjectsCommands(program: Command): void {
         async (project, options, command) => {
           const ctx = createContext(getRootOpts(command));
 
-          const projectId = await resolveProjectId(ctx.sdk, project);
+          const projectId = await resolveProjectId(ctx.gql, project);
           const paginationOptions = buildPaginationOptions(
             parseLimit(options.limit || "25"),
             options.after,
@@ -588,7 +588,7 @@ export function setupProjectsCommands(program: Command): void {
 
           const teamNames = getCreateTeamNames(options);
           const teamIds = await Promise.all(
-            teamNames.map((t) => resolveTeamId(ctx.sdk, t)),
+            teamNames.map((t) => resolveTeamId(ctx.gql, t)),
           );
 
           const input: CreateProjectInput = {
@@ -613,7 +613,7 @@ export function setupProjectsCommands(program: Command): void {
           }
 
           if (options.lead) {
-            input.leadId = await resolveUserId(ctx.sdk, options.lead);
+            input.leadId = await resolveUserId(ctx.gql, options.lead);
           }
 
           if (options.members) {
@@ -622,7 +622,7 @@ export function setupProjectsCommands(program: Command): void {
               .map((m) => m.trim())
               .filter(Boolean);
             input.memberIds = await Promise.all(
-              memberNames.map((m) => resolveUserId(ctx.sdk, m)),
+              memberNames.map((m) => resolveUserId(ctx.gql, m)),
             );
           }
 
@@ -650,7 +650,7 @@ export function setupProjectsCommands(program: Command): void {
               .split(",")
               .map((l) => l.trim())
               .filter(Boolean);
-            input.labelIds = await resolveProjectLabelIds(ctx.sdk, labelNames);
+            input.labelIds = await resolveProjectLabelIds(ctx.gql, labelNames);
           }
 
           const result = await createProject(ctx.gql, input);
@@ -730,7 +730,7 @@ export function setupProjectsCommands(program: Command): void {
 
           const labelMode = parseLabelMode(options.labelMode);
 
-          const projectId = await resolveProjectId(ctx.sdk, project);
+          const projectId = await resolveProjectId(ctx.gql, project);
           const needsLabelContext =
             options.labels && (labelMode === "add" || labelMode === "remove");
           const projectContext = needsLabelContext
@@ -762,7 +762,7 @@ export function setupProjectsCommands(program: Command): void {
           if (options.clearLead) {
             input.leadId = null;
           } else if (options.lead) {
-            input.leadId = await resolveUserId(ctx.sdk, options.lead);
+            input.leadId = await resolveUserId(ctx.gql, options.lead);
           }
 
           if (options.members) {
@@ -771,7 +771,7 @@ export function setupProjectsCommands(program: Command): void {
               .map((m) => m.trim())
               .filter(Boolean);
             input.memberIds = await Promise.all(
-              memberNames.map((m) => resolveUserId(ctx.sdk, m)),
+              memberNames.map((m) => resolveUserId(ctx.gql, m)),
             );
           }
 
@@ -801,7 +801,7 @@ export function setupProjectsCommands(program: Command): void {
           const teamNames = getUpdateTeamNames(options);
           if (teamNames) {
             input.teamIds = await Promise.all(
-              teamNames.map((t) => resolveTeamId(ctx.sdk, t)),
+              teamNames.map((t) => resolveTeamId(ctx.gql, t)),
             );
           }
 
@@ -812,7 +812,7 @@ export function setupProjectsCommands(program: Command): void {
               .split(",")
               .map((l) => l.trim())
               .filter(Boolean);
-            const labelIds = await resolveProjectLabelIds(ctx.sdk, labelNames);
+            const labelIds = await resolveProjectLabelIds(ctx.gql, labelNames);
 
             if (labelMode === "add") {
               const currentLabels = projectContext?.labels?.nodes
@@ -851,7 +851,7 @@ export function setupProjectsCommands(program: Command): void {
       commandAction<[string, unknown, Command]>(
         async (project, _unused1, command) => {
           const ctx = createContext(getRootOpts(command));
-          const projectId = await resolveProjectId(ctx.sdk, project);
+          const projectId = await resolveProjectId(ctx.gql, project);
           const result = await archiveProject(ctx.gql, projectId);
           outputSuccess(result);
         },
@@ -865,7 +865,7 @@ export function setupProjectsCommands(program: Command): void {
       commandAction<[string, unknown, Command]>(
         async (project, _unused1, command) => {
           const ctx = createContext(getRootOpts(command));
-          const projectId = await resolveProjectId(ctx.sdk, project, {
+          const projectId = await resolveProjectId(ctx.gql, project, {
             includeArchived: true,
           });
           const result = await unarchiveProject(ctx.gql, projectId);
@@ -881,7 +881,7 @@ export function setupProjectsCommands(program: Command): void {
       commandAction<[string, unknown, Command]>(
         async (project, _unused1, command) => {
           const ctx = createContext(getRootOpts(command));
-          const projectId = await resolveProjectId(ctx.sdk, project, {
+          const projectId = await resolveProjectId(ctx.gql, project, {
             includeArchived: true,
           });
           const result = await deleteProject(ctx.gql, projectId);

--- a/src/commands/teams.ts
+++ b/src/commands/teams.ts
@@ -50,7 +50,7 @@ export function setupTeamsCommands(program: Command): void {
         const team = args[0] as string;
         const command = args.at(-1) as Command;
         const ctx = createContext(getRootOpts(command));
-        const teamId = await resolveTeamId(ctx.sdk, team);
+        const teamId = await resolveTeamId(ctx.gql, team);
         const result = await getTeam(ctx.gql, { id: teamId });
         outputSuccess(result);
       }),

--- a/src/common/context.ts
+++ b/src/common/context.ts
@@ -1,20 +1,17 @@
 import type { Command } from "commander";
 import { GraphQLClient } from "../client/graphql-client.js";
-import { LinearSdkClient } from "../client/linear-client.js";
 import { type CommandOptions, getApiToken } from "./auth.js";
 
 export type { CommandOptions };
 
 export interface CommandContext {
   gql: GraphQLClient;
-  sdk: LinearSdkClient;
 }
 
 export function createContext(options: CommandOptions): CommandContext {
   const token = getApiToken(options);
   return {
     gql: new GraphQLClient(token),
-    sdk: new LinearSdkClient(token),
   };
 }
 

--- a/src/common/resolve-filters.ts
+++ b/src/common/resolve-filters.ts
@@ -108,7 +108,7 @@ export async function resolveFilterOptions(
 
   const batchResolved = hasResolvableFilters
     ? await resolveSearchFilterIds(
-        ctx.sdk,
+        ctx.gql,
         omitUndefined({
           team: opts.team,
           assignee: opts.assignee,
@@ -123,7 +123,7 @@ export async function resolveFilterOptions(
     : {};
 
   const milestoneId = opts.milestone
-    ? await resolveMilestoneId(ctx.gql, ctx.sdk, opts.milestone, opts.project)
+    ? await resolveMilestoneId(ctx.gql, opts.milestone, opts.project)
     : undefined;
 
   const resolved: IssueFilterOptions = omitUndefined({

--- a/src/resolvers/cycle-resolver.ts
+++ b/src/resolvers/cycle-resolver.ts
@@ -1,7 +1,10 @@
-import type { LinearDocument } from "@linear/sdk";
-import type { LinearSdkClient } from "../client/linear-client.js";
+import type { GraphQLClient } from "../client/graphql-client.js";
 import { multipleMatchesError, notFoundError } from "../common/errors.js";
 import { asUuid, isUuid, type UUID } from "../common/identifier.js";
+import {
+  FindCycleGlobalDocument,
+  FindCycleScopedDocument,
+} from "../gql/graphql.js";
 import { resolveTeamId } from "./team-resolver.js";
 
 /**
@@ -10,61 +13,40 @@ import { resolveTeamId } from "./team-resolver.js";
  * Accepts UUID or cycle name. When multiple cycles match a name,
  * prefers active > next > previous. Use teamFilter to disambiguate.
  *
- * @param client - Linear SDK client
+ * @param client - GraphQL client
  * @param nameOrId - Cycle name or UUID
  * @param teamFilter - Optional team key/name/ID to scope search
  * @returns Cycle UUID
  * @throws Error if not found or multiple matches without clear preference
  */
 export async function resolveCycleId(
-  client: LinearSdkClient,
+  client: GraphQLClient,
   nameOrId: string,
   teamFilter?: string,
 ): Promise<UUID> {
   if (isUuid(nameOrId)) return asUuid(nameOrId);
 
-  const filter: LinearDocument.CycleFilter = {
-    name: { eq: nameOrId },
-  };
+  const matched = teamFilter
+    ? (
+        await client.request(FindCycleScopedDocument, {
+          name: nameOrId,
+          teamId: await resolveTeamId(client, teamFilter),
+        })
+      ).cycles.nodes
+    : (await client.request(FindCycleGlobalDocument, { name: nameOrId })).cycles
+        .nodes;
 
-  if (teamFilter) {
-    const teamId = await resolveTeamId(client, teamFilter);
-    filter.team = { id: { eq: teamId } };
-  }
-
-  const cyclesConnection = await client.sdk.cycles({
-    filter,
-    first: 10,
-  });
-
-  const nodes: Array<{
-    id: string;
-    name: string;
-    number: number;
-    startsAt?: string;
-    isActive: boolean;
-    isNext: boolean;
-    isPrevious: boolean;
-    team?: { id: string; key: string; name: string };
-  }> = [];
-
-  for (const cycle of cyclesConnection.nodes) {
-    const team = await cycle.team;
-    nodes.push({
-      id: cycle.id,
-      name: cycle.name ?? "",
-      number: cycle.number,
-      isActive: cycle.isActive,
-      isNext: cycle.isNext,
-      isPrevious: cycle.isPrevious,
-      ...(cycle.startsAt
-        ? { startsAt: new Date(cycle.startsAt).toISOString() }
-        : {}),
-      ...(team
-        ? { team: { id: team.id, key: team.key, name: team.name } }
-        : {}),
-    });
-  }
+  const nodes = matched.map((cycle) => ({
+    id: cycle.id,
+    number: cycle.number,
+    isActive: cycle.isActive,
+    isNext: cycle.isNext,
+    isPrevious: cycle.isPrevious,
+    ...(cycle.startsAt
+      ? { startsAt: new Date(cycle.startsAt).toISOString() }
+      : {}),
+    ...(cycle.team ? { team: { key: cycle.team.key } } : {}),
+  }));
 
   if (nodes.length === 0) {
     throw notFoundError(

--- a/src/resolvers/initiative-resolver.ts
+++ b/src/resolvers/initiative-resolver.ts
@@ -1,12 +1,12 @@
-import type { LinearDocument } from "@linear/sdk";
 import type { GraphQLClient } from "../client/graphql-client.js";
-import type { LinearSdkClient } from "../client/linear-client.js";
 import { firstOrThrow } from "../common/array.js";
 import { multipleMatchesError, notFoundError } from "../common/errors.js";
 import { asUuid, isUuid, type UUID } from "../common/identifier.js";
 import {
   FindInitiativeProjectLinkByPairDocument,
   FindInitiativeRelationByPairDocument,
+  FindInitiativesDocument,
+  type InitiativeFilter,
 } from "../gql/graphql.js";
 
 export interface InitiativeResolveScope {
@@ -15,7 +15,7 @@ export interface InitiativeResolveScope {
 }
 
 export async function resolveInitiativeId(
-  client: LinearSdkClient,
+  client: GraphQLClient,
   nameOrId: string,
   scope: InitiativeResolveScope = {},
 ): Promise<UUID> {
@@ -23,10 +23,10 @@ export async function resolveInitiativeId(
     return asUuid(nameOrId);
   }
 
-  const nameClause: LinearDocument.InitiativeFilter = {
+  const nameClause: InitiativeFilter = {
     name: { eqIgnoreCase: nameOrId },
   };
-  const scopeClauses: LinearDocument.InitiativeFilter[] = [];
+  const scopeClauses: InitiativeFilter[] = [];
 
   if (scope.teamId) {
     scopeClauses.push({ teams: { some: { id: { eq: scope.teamId } } } });
@@ -36,28 +36,31 @@ export async function resolveInitiativeId(
     scopeClauses.push({ owner: { id: { eq: scope.ownerId } } });
   }
 
-  const filter: LinearDocument.InitiativeFilter =
+  const filter: InitiativeFilter =
     scopeClauses.length === 0
       ? nameClause
       : { and: [nameClause, ...scopeClauses] };
 
-  const result = await client.sdk.initiatives({
+  const { initiatives } = await client.request(FindInitiativesDocument, {
     filter,
     first: 20,
   });
 
-  if (result.nodes.length === 0) {
+  if (initiatives.nodes.length === 0) {
     throw notFoundError("Initiative", nameOrId);
   }
 
-  if (result.nodes.length === 1) {
+  if (initiatives.nodes.length === 1) {
     return asUuid(
-      firstOrThrow(result.nodes, () => notFoundError("Initiative", nameOrId))
-        .id,
+      firstOrThrow(initiatives.nodes, () =>
+        notFoundError("Initiative", nameOrId),
+      ).id,
     );
   }
 
-  const candidates = result.nodes.map((node) => `${node.name} (${node.id})`);
+  const candidates = initiatives.nodes.map(
+    (node) => `${node.name} (${node.id})`,
+  );
 
   throw multipleMatchesError(
     "initiative",

--- a/src/resolvers/issue-filter-resolver.ts
+++ b/src/resolvers/issue-filter-resolver.ts
@@ -1,4 +1,4 @@
-import type { LinearSdkClient } from "../client/linear-client.js";
+import type { GraphQLClient } from "../client/graphql-client.js";
 import type { UUID } from "../common/identifier.js";
 import { resolveCycleId } from "./cycle-resolver.js";
 import { resolveIssueId } from "./issue-resolver.js";
@@ -31,49 +31,49 @@ export interface SearchFilterResolution {
 }
 
 export async function resolveSearchFilterIds(
-  sdkClient: LinearSdkClient,
+  gqlClient: GraphQLClient,
   input: SearchFilterResolutionInput,
 ): Promise<SearchFilterResolution> {
   const resolved: SearchFilterResolution = {};
 
   if (input.team) {
-    resolved.teamId = await resolveTeamId(sdkClient, input.team);
+    resolved.teamId = await resolveTeamId(gqlClient, input.team);
   }
 
   if (input.assignee) {
-    resolved.assigneeId = await resolveUserId(sdkClient, input.assignee);
+    resolved.assigneeId = await resolveUserId(gqlClient, input.assignee);
   }
 
   if (input.creator) {
-    resolved.creatorId = await resolveUserId(sdkClient, input.creator);
+    resolved.creatorId = await resolveUserId(gqlClient, input.creator);
   }
 
   if (input.project) {
-    resolved.projectId = await resolveProjectId(sdkClient, input.project);
+    resolved.projectId = await resolveProjectId(gqlClient, input.project);
   }
 
   if (input.statusNames && input.statusNames.length > 0) {
     resolved.stateIds = await Promise.all(
       input.statusNames.map((status) =>
-        resolveStatusId(sdkClient, status, resolved.teamId),
+        resolveStatusId(gqlClient, status, resolved.teamId),
       ),
     );
   }
 
   if (input.labelNames && input.labelNames.length > 0) {
-    resolved.labelIds = await resolveLabelIds(sdkClient, input.labelNames);
+    resolved.labelIds = await resolveLabelIds(gqlClient, input.labelNames);
   }
 
   if (input.cycle) {
     resolved.cycleId = await resolveCycleId(
-      sdkClient,
+      gqlClient,
       input.cycle,
       resolved.teamId ?? input.team,
     );
   }
 
   if (input.parent) {
-    resolved.parentId = await resolveIssueId(sdkClient, input.parent);
+    resolved.parentId = await resolveIssueId(gqlClient, input.parent);
   }
 
   return resolved;

--- a/src/resolvers/issue-resolver.ts
+++ b/src/resolvers/issue-resolver.ts
@@ -1,4 +1,4 @@
-import type { LinearSdkClient } from "../client/linear-client.js";
+import type { GraphQLClient } from "../client/graphql-client.js";
 import { firstOrThrow } from "../common/array.js";
 import { notFoundError } from "../common/errors.js";
 import {
@@ -7,78 +7,23 @@ import {
   parseIssueIdentifier,
   type UUID,
 } from "../common/identifier.js";
-import { omitUndefined } from "../common/object.js";
+import { FindIssuesDocument, type IssueFilter } from "../gql/graphql.js";
 import {
   resolveTeamEstimateContext,
   type TeamEstimateContext,
 } from "./team-resolver.js";
 
-function isRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function isPromiseLike(value: unknown): value is PromiseLike<unknown> {
-  if ((typeof value !== "object" && typeof value !== "function") || !value) {
-    return false;
+/** Builds the FindIssues filter for a UUID or "TEAM-123" identifier. */
+function issueLookupFilter(issueIdOrIdentifier: string): IssueFilter {
+  if (isUuid(issueIdOrIdentifier)) {
+    return { id: { eq: issueIdOrIdentifier } };
   }
 
-  return typeof (value as { then?: unknown }).then === "function";
-}
-
-async function resolveRelationValue(value: unknown): Promise<unknown> {
-  return isPromiseLike(value) ? await value : value;
-}
-
-/** Narrow projection of the SDK issue node fields the team lookup consumes. */
-interface IssueTeamProjection {
-  id: string;
-  teamId?: string;
-  team?: unknown; // relation; may be a value or PromiseLike (SDK quirk)
-}
-
-/** Narrow projection of a resolved team relation node. */
-interface TeamLookupProjection {
-  id?: string;
-  key?: string;
-}
-
-function toIssueTeamProjection(
-  node: unknown,
-  ref: string,
-): IssueTeamProjection {
-  if (!isRecord(node) || typeof node["id"] !== "string") {
-    throw new Error(`Issue "${ref}" is missing required team context`);
-  }
-
+  const { teamKey, issueNumber } = parseIssueIdentifier(issueIdOrIdentifier);
   return {
-    id: node["id"],
-    team: node["team"],
-    ...(typeof node["teamId"] === "string" ? { teamId: node["teamId"] } : {}),
+    number: { eq: issueNumber },
+    team: { key: { eq: teamKey } },
   };
-}
-
-function toTeamLookupProjection(
-  team: unknown,
-): TeamLookupProjection | undefined {
-  if (!isRecord(team)) return undefined;
-
-  return omitUndefined({
-    id: typeof team["id"] === "string" ? team["id"] : undefined,
-    key: typeof team["key"] === "string" ? team["key"] : undefined,
-  });
-}
-
-function getTeamLookupFromRelation(team: unknown): string | undefined {
-  const relation = toTeamLookupProjection(team);
-  return relation?.id ?? relation?.key;
-}
-
-async function getIssueTeamLookup(
-  projection: IssueTeamProjection,
-): Promise<string | undefined> {
-  if (projection.teamId) return projection.teamId;
-
-  return getTeamLookupFromRelation(await resolveRelationValue(projection.team));
 }
 
 export interface IssueEstimateContext {
@@ -91,24 +36,19 @@ export interface IssueEstimateContext {
  *
  * Accepts UUID or issue identifier (e.g., "ENG-123").
  *
- * @param client - Linear SDK client
+ * @param client - GraphQL client
  * @param issueIdOrIdentifier - Issue UUID or identifier
  * @returns Issue UUID
  * @throws Error if issue not found
  */
 export async function resolveIssueId(
-  client: LinearSdkClient,
+  client: GraphQLClient,
   issueIdOrIdentifier: string,
 ): Promise<UUID> {
   if (isUuid(issueIdOrIdentifier)) return asUuid(issueIdOrIdentifier);
 
-  const { teamKey, issueNumber } = parseIssueIdentifier(issueIdOrIdentifier);
-
-  const issues = await client.sdk.issues({
-    filter: {
-      number: { eq: issueNumber },
-      team: { key: { eq: teamKey } },
-    },
+  const { issues } = await client.request(FindIssuesDocument, {
+    filter: issueLookupFilter(issueIdOrIdentifier),
     first: 1,
   });
 
@@ -120,46 +60,20 @@ export async function resolveIssueId(
 }
 
 export async function resolveIssueEstimateContext(
-  client: LinearSdkClient,
+  client: GraphQLClient,
   issueIdOrIdentifier: string,
 ): Promise<IssueEstimateContext> {
-  const issueIsUuid = isUuid(issueIdOrIdentifier);
-  const issues = await (issueIsUuid
-    ? client.sdk.issues({
-        filter: { id: { eq: issueIdOrIdentifier } },
-        first: 1,
-      })
-    : (() => {
-        const { teamKey, issueNumber } =
-          parseIssueIdentifier(issueIdOrIdentifier);
+  const { issues } = await client.request(FindIssuesDocument, {
+    filter: issueLookupFilter(issueIdOrIdentifier),
+    first: 1,
+  });
 
-        return client.sdk.issues({
-          filter: {
-            number: { eq: issueNumber },
-            team: { key: { eq: teamKey } },
-          },
-          first: 1,
-        });
-      })());
-
-  if (issues.nodes.length === 0) {
-    throw notFoundError("Issue", issueIdOrIdentifier);
-  }
-
-  const projection = toIssueTeamProjection(
-    issues.nodes[0],
-    issueIdOrIdentifier,
+  const node = firstOrThrow(issues.nodes, () =>
+    notFoundError("Issue", issueIdOrIdentifier),
   );
 
-  const teamLookup = await getIssueTeamLookup(projection);
-  if (!teamLookup) {
-    throw new Error(
-      `Issue "${issueIdOrIdentifier}" is missing required team context`,
-    );
-  }
-
   return {
-    issueId: asUuid(projection.id),
-    team: await resolveTeamEstimateContext(client, teamLookup),
+    issueId: asUuid(node.id),
+    team: await resolveTeamEstimateContext(client, node.team.id),
   };
 }

--- a/src/resolvers/label-resolver.ts
+++ b/src/resolvers/label-resolver.ts
@@ -1,7 +1,11 @@
-import type { LinearSdkClient } from "../client/linear-client.js";
+import type { GraphQLClient } from "../client/graphql-client.js";
 import { firstOrThrow } from "../common/array.js";
 import { notFoundError } from "../common/errors.js";
 import { asUuid, isUuid, type UUID } from "../common/identifier.js";
+import {
+  FindIssueLabelsDocument,
+  type IssueLabelFilter,
+} from "../gql/graphql.js";
 
 export type LabelResolverScope = "workspace" | "team";
 
@@ -13,7 +17,7 @@ export interface ResolveLabelOptions {
 function buildLabelFilter(
   nameOrId: string,
   options: ResolveLabelOptions,
-): Record<string, unknown> {
+): IssueLabelFilter {
   if (options.scope === "workspace") {
     return {
       name: { eqIgnoreCase: nameOrId },
@@ -39,24 +43,24 @@ function buildLabelFilter(
 }
 
 export async function resolveLabelId(
-  client: LinearSdkClient,
+  client: GraphQLClient,
   nameOrId: string,
   options: ResolveLabelOptions = {},
 ): Promise<UUID> {
   if (isUuid(nameOrId)) return asUuid(nameOrId);
 
-  const result = await client.sdk.issueLabels({
+  const { issueLabels } = await client.request(FindIssueLabelsDocument, {
     filter: buildLabelFilter(nameOrId, options),
     first: 1,
   });
 
   return asUuid(
-    firstOrThrow(result.nodes, () => notFoundError("Label", nameOrId)).id,
+    firstOrThrow(issueLabels.nodes, () => notFoundError("Label", nameOrId)).id,
   );
 }
 
 export async function resolveLabelIds(
-  client: LinearSdkClient,
+  client: GraphQLClient,
   namesOrIds: string[],
 ): Promise<UUID[]> {
   return Promise.all(namesOrIds.map((id) => resolveLabelId(client, id)));

--- a/src/resolvers/milestone-resolver.ts
+++ b/src/resolvers/milestone-resolver.ts
@@ -1,5 +1,4 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
-import type { LinearSdkClient } from "../client/linear-client.js";
 import { firstOrThrow } from "../common/array.js";
 import { multipleMatchesError, notFoundError } from "../common/errors.js";
 import { asUuid, isUuid, type UUID } from "../common/identifier.js";
@@ -15,14 +14,12 @@ import { resolveProjectId } from "./project-resolver.js";
  * Accepts UUID or milestone name. When multiple milestones match a name,
  * use projectNameOrId to scope the search to a specific project.
  *
- * ARCHITECTURAL EXCEPTION: This resolver uses GraphQLClient in addition to
- * LinearSdkClient because the Linear SDK does not expose milestone lookup
- * by name. The GraphQL client is needed for the FindProjectMilestoneScoped
- * and FindProjectMilestoneGlobal queries. This is a documented deviation
- * from the standard resolver contract (resolvers normally use SDK only).
+ * ARCHITECTURAL EXCEPTION: This resolver queries milestones directly via
+ * GraphQL (FindProjectMilestoneScoped / FindProjectMilestoneGlobal) because
+ * the Linear API exposes no lean lookup fragment for milestones by name. All
+ * lookups go through the single GraphQL client.
  *
- * @param gqlClient - GraphQL client for querying milestones
- * @param sdkClient - SDK client for project resolution
+ * @param gqlClient - GraphQL client for querying milestones and projects
  * @param nameOrId - Milestone name or UUID
  * @param projectNameOrId - Optional project name/ID to scope search
  * @returns Milestone UUID
@@ -30,7 +27,6 @@ import { resolveProjectId } from "./project-resolver.js";
  */
 export async function resolveMilestoneId(
   gqlClient: GraphQLClient,
-  sdkClient: LinearSdkClient,
   nameOrId: string,
   projectNameOrId?: string,
 ): Promise<UUID> {
@@ -44,7 +40,7 @@ export async function resolveMilestoneId(
   let nodes: MilestoneNode[] = [];
 
   if (projectNameOrId) {
-    const projectId = await resolveProjectId(sdkClient, projectNameOrId);
+    const projectId = await resolveProjectId(gqlClient, projectNameOrId);
     const result = await gqlClient.request(FindProjectMilestoneScopedDocument, {
       name: nameOrId,
       projectId,

--- a/src/resolvers/project-resolver.ts
+++ b/src/resolvers/project-resolver.ts
@@ -1,65 +1,66 @@
-import type { LinearSdkClient } from "../client/linear-client.js";
+import type { GraphQLClient } from "../client/graphql-client.js";
 import { firstOrThrow } from "../common/array.js";
 import { multipleMatchesError, notFoundError } from "../common/errors.js";
 import { asUuid, isUuid, type UUID } from "../common/identifier.js";
-import { omitUndefined } from "../common/object.js";
+import {
+  FindProjectLabelByNameDocument,
+  FindProjectsByNameDocument,
+} from "../gql/graphql.js";
 
 export interface ResolveProjectIdOptions {
   includeArchived?: boolean;
 }
 
 export async function resolveProjectId(
-  client: LinearSdkClient,
+  client: GraphQLClient,
   nameOrId: string,
   options: ResolveProjectIdOptions = {},
 ): Promise<UUID> {
   if (isUuid(nameOrId)) return asUuid(nameOrId);
 
-  const result = await client.sdk.projects(
-    omitUndefined({
-      filter: { name: { eqIgnoreCase: nameOrId } },
-      first: 2,
-      includeArchived: options.includeArchived,
-    }),
-  );
+  const { projects } = await client.request(FindProjectsByNameDocument, {
+    name: nameOrId,
+    includeArchived: options.includeArchived,
+  });
 
-  if (result.nodes.length === 0) {
+  if (projects.nodes.length === 0) {
     throw notFoundError("Project", nameOrId);
   }
 
-  if (result.nodes.length > 1) {
+  if (projects.nodes.length > 1) {
     throw multipleMatchesError(
       "Project",
       nameOrId,
-      result.nodes.map((project) => project.id),
+      projects.nodes.map((project) => project.id),
       "provide project UUID",
     );
   }
 
   return asUuid(
-    firstOrThrow(result.nodes, () => notFoundError("Project", nameOrId)).id,
+    firstOrThrow(projects.nodes, () => notFoundError("Project", nameOrId)).id,
   );
 }
 
 export async function resolveProjectLabelId(
-  client: LinearSdkClient,
+  client: GraphQLClient,
   nameOrId: string,
 ): Promise<UUID> {
   if (isUuid(nameOrId)) return asUuid(nameOrId);
 
-  const result = await client.sdk.projectLabels({
-    filter: { name: { eqIgnoreCase: nameOrId } },
-    first: 1,
-  });
+  const { projectLabels } = await client.request(
+    FindProjectLabelByNameDocument,
+    { name: nameOrId },
+  );
 
   return asUuid(
-    firstOrThrow(result.nodes, () => notFoundError("Project label", nameOrId))
-      .id,
+    firstOrThrow(projectLabels.nodes, () =>
+      notFoundError("Project label", nameOrId),
+    ).id,
   );
 }
 
 export async function resolveProjectLabelIds(
-  client: LinearSdkClient,
+  client: GraphQLClient,
   namesOrIds: string[],
 ): Promise<UUID[]> {
   return Promise.all(

--- a/src/resolvers/project-status-resolver.ts
+++ b/src/resolvers/project-status-resolver.ts
@@ -8,12 +8,8 @@ import { GetProjectStatusesDocument } from "../gql/graphql.js";
  *
  * Accepts UUID (returned as-is) or a status name (case-insensitive match).
  *
- * ARCHITECTURAL EXCEPTION: This resolver uses GraphQLClient instead of
- * LinearSdkClient because the Linear SDK's projectStatuses() method does
- * not support server-side filtering. A GraphQL query fetches all statuses
- * (a small fixed set) and filters client-side. This is a documented
- * deviation from the standard resolver contract (resolvers normally use
- * SDK only).
+ * projectStatuses has no server-side name filter, so this fetches the full
+ * (small, fixed) set and matches client-side.
  *
  * @param client - GraphQL client for querying project statuses
  * @param nameOrId - Status name or UUID

--- a/src/resolvers/status-resolver.ts
+++ b/src/resolvers/status-resolver.ts
@@ -1,17 +1,20 @@
-import type { LinearDocument } from "@linear/sdk";
-import type { LinearSdkClient } from "../client/linear-client.js";
+import type { GraphQLClient } from "../client/graphql-client.js";
 import { firstOrThrow } from "../common/array.js";
 import { notFoundError } from "../common/errors.js";
 import { asUuid, isUuid, type UUID } from "../common/identifier.js";
+import {
+  FindWorkflowStatesDocument,
+  type WorkflowStateFilter,
+} from "../gql/graphql.js";
 
 export async function resolveStatusId(
-  client: LinearSdkClient,
+  client: GraphQLClient,
   nameOrId: string,
   teamId?: UUID,
 ): Promise<UUID> {
   if (isUuid(nameOrId)) return asUuid(nameOrId);
 
-  const filter: LinearDocument.WorkflowStateFilter = {
+  const filter: WorkflowStateFilter = {
     name: { eqIgnoreCase: nameOrId },
   };
 
@@ -19,13 +22,13 @@ export async function resolveStatusId(
     filter.team = { id: { eq: teamId } };
   }
 
-  const result = await client.sdk.workflowStates({
+  const { workflowStates } = await client.request(FindWorkflowStatesDocument, {
     filter,
     first: 1,
   });
 
   return asUuid(
-    firstOrThrow(result.nodes, () =>
+    firstOrThrow(workflowStates.nodes, () =>
       notFoundError(
         "Status",
         nameOrId,

--- a/src/resolvers/team-resolver.ts
+++ b/src/resolvers/team-resolver.ts
@@ -1,6 +1,7 @@
-import type { LinearSdkClient } from "../client/linear-client.js";
+import type { GraphQLClient } from "../client/graphql-client.js";
 import { notFoundError } from "../common/errors.js";
 import { asUuid, isUuid, type UUID } from "../common/identifier.js";
+import { FindTeamsDocument } from "../gql/graphql.js";
 
 type TeamEstimationType =
   | "notUsed"
@@ -95,39 +96,39 @@ function mapTeamNodeToEstimateContext(
 }
 
 export async function resolveTeamEstimateContext(
-  client: LinearSdkClient,
+  client: GraphQLClient,
   keyOrNameOrId: string,
 ): Promise<TeamEstimateContext> {
   if (isUuid(keyOrNameOrId)) {
-    const byId = await client.sdk.teams({
+    const { teams } = await client.request(FindTeamsDocument, {
       filter: { id: { eq: keyOrNameOrId } },
       first: 1,
     });
-    if (byId.nodes.length > 0) {
+    if (teams.nodes.length > 0) {
       return mapTeamNodeToEstimateContext(
-        toTeamEstimateNode(byId.nodes[0], keyOrNameOrId),
+        toTeamEstimateNode(teams.nodes[0], keyOrNameOrId),
       );
     }
     throw notFoundError("Team", keyOrNameOrId);
   }
 
-  const byKey = await client.sdk.teams({
+  const byKey = await client.request(FindTeamsDocument, {
     filter: { key: { eq: keyOrNameOrId } },
     first: 1,
   });
-  if (byKey.nodes.length > 0) {
+  if (byKey.teams.nodes.length > 0) {
     return mapTeamNodeToEstimateContext(
-      toTeamEstimateNode(byKey.nodes[0], keyOrNameOrId),
+      toTeamEstimateNode(byKey.teams.nodes[0], keyOrNameOrId),
     );
   }
 
-  const byName = await client.sdk.teams({
+  const byName = await client.request(FindTeamsDocument, {
     filter: { name: { eq: keyOrNameOrId } },
     first: 1,
   });
-  if (byName.nodes.length > 0) {
+  if (byName.teams.nodes.length > 0) {
     return mapTeamNodeToEstimateContext(
-      toTeamEstimateNode(byName.nodes[0], keyOrNameOrId),
+      toTeamEstimateNode(byName.teams.nodes[0], keyOrNameOrId),
     );
   }
 
@@ -135,25 +136,25 @@ export async function resolveTeamEstimateContext(
 }
 
 export async function resolveTeamId(
-  client: LinearSdkClient,
+  client: GraphQLClient,
   keyOrNameOrId: string,
 ): Promise<UUID> {
   if (isUuid(keyOrNameOrId)) return asUuid(keyOrNameOrId);
 
   // Try by key first
-  const byKey = await client.sdk.teams({
+  const byKey = await client.request(FindTeamsDocument, {
     filter: { key: { eq: keyOrNameOrId } },
     first: 1,
   });
-  const [byKeyMatch] = byKey.nodes;
+  const [byKeyMatch] = byKey.teams.nodes;
   if (byKeyMatch) return asUuid(byKeyMatch.id);
 
   // Fall back to name
-  const byName = await client.sdk.teams({
+  const byName = await client.request(FindTeamsDocument, {
     filter: { name: { eq: keyOrNameOrId } },
     first: 1,
   });
-  const [byNameMatch] = byName.nodes;
+  const [byNameMatch] = byName.teams.nodes;
   if (byNameMatch) return asUuid(byNameMatch.id);
 
   throw notFoundError("Team", keyOrNameOrId);

--- a/src/resolvers/user-resolver.ts
+++ b/src/resolvers/user-resolver.ts
@@ -1,15 +1,16 @@
-import type { LinearSdkClient } from "../client/linear-client.js";
+import type { GraphQLClient } from "../client/graphql-client.js";
 import { multipleMatchesError, notFoundError } from "../common/errors.js";
 import { asUuid, isUuid, type UUID } from "../common/identifier.js";
+import { FindUsersDocument } from "../gql/graphql.js";
 
 export async function resolveUserId(
-  client: LinearSdkClient,
+  client: GraphQLClient,
   nameOrEmailOrId: string,
 ): Promise<UUID> {
   if (isUuid(nameOrEmailOrId)) return asUuid(nameOrEmailOrId);
 
   // Try by display name first (case-insensitive)
-  const byName = await client.sdk.users({
+  const { users: byName } = await client.request(FindUsersDocument, {
     filter: { displayName: { eqIgnoreCase: nameOrEmailOrId } },
     first: 10,
   });
@@ -27,7 +28,7 @@ export async function resolveUserId(
   }
 
   // Fall back to email (case-insensitive)
-  const byEmail = await client.sdk.users({
+  const { users: byEmail } = await client.request(FindUsersDocument, {
     filter: { email: { eqIgnoreCase: nameOrEmailOrId } },
     first: 1,
   });

--- a/tests/unit/common/resolve-filters.test.ts
+++ b/tests/unit/common/resolve-filters.test.ts
@@ -1,6 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
-import type { LinearSdkClient } from "../../../src/client/linear-client.js";
 import type { CommandContext } from "../../../src/common/context.js";
 import { resolveFilterOptions } from "../../../src/common/resolve-filters.js";
 import { resolveSearchFilterIds } from "../../../src/resolvers/issue-filter-resolver.js";
@@ -26,7 +25,6 @@ vi.mock("../../../src/resolvers/milestone-resolver.js", () => ({
 function mockContext(): CommandContext {
   return {
     gql: {} as unknown as GraphQLClient,
-    sdk: {} as unknown as LinearSdkClient,
   };
 }
 
@@ -83,7 +81,6 @@ describe("resolveFilterOptions", () => {
       parent: "ENG-123",
     });
     expect(resolveMilestoneId).toHaveBeenCalledWith(
-      expect.anything(),
       expect.anything(),
       "v1.0",
       "Backend",
@@ -187,7 +184,6 @@ describe("resolveFilterOptions", () => {
 
     expect(resolveSearchFilterIds).not.toHaveBeenCalled();
     expect(resolveMilestoneId).toHaveBeenCalledWith(
-      expect.anything(),
       expect.anything(),
       "550e8400-e29b-41d4-a716-446655440002",
       undefined,

--- a/tests/unit/resolvers/cycle-resolver.test.ts
+++ b/tests/unit/resolvers/cycle-resolver.test.ts
@@ -1,53 +1,97 @@
 // tests/unit/resolvers/cycle-resolver.test.ts
 import { describe, expect, it, vi } from "vitest";
-import type { LinearSdkClient } from "../../../src/client/linear-client.js";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import { resolveCycleId } from "../../../src/resolvers/cycle-resolver.js";
 
-function mockSdkClient(
-  cycleNodes: Array<{
-    id: string;
-    name?: string;
-    isActive?: boolean;
-    isNext?: boolean;
-    isPrevious?: boolean;
-    number?: number;
-    startsAt?: string;
-  }>,
-) {
-  const teams = vi.fn().mockResolvedValue({ nodes: [{ id: "team-uuid" }] });
-  const cycles = vi.fn().mockResolvedValue({ nodes: cycleNodes });
-  // Mock cycle.team as a resolved property
-  cycleNodes.forEach((node) => {
-    Object.defineProperty(node, "team", {
-      value: Promise.resolve({
-        id: "team-uuid",
-        key: "ENG",
-        name: "Engineering",
-      }),
-      enumerable: false,
-    });
-  });
-  return { sdk: { teams, cycles } } as unknown as LinearSdkClient;
+type CycleNode = {
+  id: string;
+  name?: string;
+  number?: number;
+  startsAt?: string;
+  isActive?: boolean;
+  isNext?: boolean;
+  isPrevious?: boolean;
+  team?: { id: string; key: string };
+};
+
+function cycle(node: CycleNode): CycleNode {
+  return {
+    name: "Sprint",
+    number: 1,
+    isActive: false,
+    isNext: false,
+    isPrevious: false,
+    team: { id: "team-uuid", key: "ENG" },
+    ...node,
+  };
+}
+
+// Unscoped lookups issue a single FindCycleGlobal request.
+function mockGlobalClient(cycleNodes: CycleNode[]) {
+  return {
+    request: vi.fn().mockResolvedValue({ cycles: { nodes: cycleNodes } }),
+  } as unknown as GraphQLClient;
+}
+
+// Team-scoped lookups first resolve the team (FindTeams), then FindCycleScoped.
+function mockScopedClient(cycleNodes: CycleNode[]) {
+  const request = vi
+    .fn()
+    .mockResolvedValueOnce({ teams: { nodes: [{ id: "team-uuid" }] } })
+    .mockResolvedValueOnce({ cycles: { nodes: cycleNodes } });
+  return { request } as unknown as GraphQLClient;
 }
 
 describe("resolveCycleId", () => {
   it("returns UUID as-is", async () => {
-    const client = mockSdkClient([]);
+    const client = mockGlobalClient([]);
     const result = await resolveCycleId(
       client,
       "550e8400-e29b-41d4-a716-446655440000",
     );
     expect(result).toBe("550e8400-e29b-41d4-a716-446655440000");
+    expect(client.request).not.toHaveBeenCalled();
   });
 
   it("resolves single matching cycle by name", async () => {
-    const client = mockSdkClient([{ id: "cycle-uuid", name: "Sprint 1" }]);
+    const client = mockGlobalClient([cycle({ id: "cycle-uuid" })]);
     const result = await resolveCycleId(client, "Sprint 1");
     expect(result).toBe("cycle-uuid");
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      name: "Sprint 1",
+    });
+  });
+
+  it("prefers the active cycle when multiple match", async () => {
+    const client = mockGlobalClient([
+      cycle({ id: "prev", isPrevious: true }),
+      cycle({ id: "active", isActive: true }),
+      cycle({ id: "next", isNext: true }),
+    ]);
+    const result = await resolveCycleId(client, "Sprint");
+    expect(result).toBe("active");
+  });
+
+  it("scopes to a team by resolving the team first", async () => {
+    const client = mockScopedClient([cycle({ id: "cycle-uuid" })]);
+    const result = await resolveCycleId(client, "Sprint 1", "ENG");
+    expect(result).toBe("cycle-uuid");
+    expect(client.request).toHaveBeenNthCalledWith(2, expect.anything(), {
+      name: "Sprint 1",
+      teamId: "team-uuid",
+    });
   });
 
   it("throws when cycle not found", async () => {
-    const client = mockSdkClient([]);
+    const client = mockGlobalClient([]);
     await expect(resolveCycleId(client, "Nonexistent")).rejects.toThrow();
+  });
+
+  it("throws when multiple cycles match without a clear preference", async () => {
+    const client = mockGlobalClient([
+      cycle({ id: "a", team: { id: "t1", key: "ENG" } }),
+      cycle({ id: "b", team: { id: "t2", key: "OPS" } }),
+    ]);
+    await expect(resolveCycleId(client, "Sprint")).rejects.toThrow(/Multiple/i);
   });
 });

--- a/tests/unit/resolvers/initiative-resolver.test.ts
+++ b/tests/unit/resolvers/initiative-resolver.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
-import type { LinearSdkClient } from "../../../src/client/linear-client.js";
 import { asUuid } from "../../../src/common/identifier.js";
 import {
   resolveInitiativeId,
@@ -13,12 +12,10 @@ type InitiativeLookupNode = {
   name: string;
 };
 
-function mockSdkClient(nodes: InitiativeLookupNode[]) {
+function mockInitiativesClient(nodes: InitiativeLookupNode[]) {
   return {
-    sdk: {
-      initiatives: vi.fn().mockResolvedValue({ nodes }),
-    },
-  } as unknown as LinearSdkClient;
+    request: vi.fn().mockResolvedValue({ initiatives: { nodes } }),
+  } as unknown as GraphQLClient;
 }
 
 function mockGqlClient(response: Record<string, unknown>) {
@@ -41,59 +38,59 @@ function mockPagedGqlClient(responses: Array<Record<string, unknown>>) {
 
 describe("resolveInitiativeId", () => {
   it("returns UUID as-is", async () => {
-    const sdk = mockSdkClient([]);
+    const client = mockInitiativesClient([]);
     const result = await resolveInitiativeId(
-      sdk,
+      client,
       "550e8400-e29b-41d4-a716-446655440000",
     );
 
     expect(result).toBe("550e8400-e29b-41d4-a716-446655440000");
-    expect(sdk.sdk.initiatives).not.toHaveBeenCalled();
+    expect(client.request).not.toHaveBeenCalled();
   });
 
   it("resolves initiative name", async () => {
-    const sdk = mockSdkClient([{ id: "init-1", name: "Growth" }]);
+    const client = mockInitiativesClient([{ id: "init-1", name: "Growth" }]);
 
-    await expect(resolveInitiativeId(sdk, "growth")).resolves.toBe("init-1");
-    expect(sdk.sdk.initiatives).toHaveBeenCalledWith({
+    await expect(resolveInitiativeId(client, "growth")).resolves.toBe("init-1");
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       filter: { name: { eqIgnoreCase: "growth" } },
       first: 20,
     });
   });
 
   it("throws not found", async () => {
-    const sdk = mockSdkClient([]);
+    const client = mockInitiativesClient([]);
 
-    await expect(resolveInitiativeId(sdk, "Missing")).rejects.toThrow(
+    await expect(resolveInitiativeId(client, "Missing")).rejects.toThrow(
       'Initiative "Missing" not found',
     );
   });
 
   it("throws ambiguity without scope", async () => {
-    const sdk = mockSdkClient([
+    const client = mockInitiativesClient([
       { id: "init-1", name: "Growth" },
       { id: "init-2", name: "Growth" },
     ]);
 
-    await expect(resolveInitiativeId(sdk, "Growth")).rejects.toThrow(
+    await expect(resolveInitiativeId(client, "Growth")).rejects.toThrow(
       "Multiple initiatives found matching",
     );
-    await expect(resolveInitiativeId(sdk, "Growth")).rejects.toThrow(
+    await expect(resolveInitiativeId(client, "Growth")).rejects.toThrow(
       "provide --team or --owner, or use UUID",
     );
   });
 
   it("resolves scoped disambiguation", async () => {
-    const sdk = mockSdkClient([{ id: "init-2", name: "Growth" }]);
+    const client = mockInitiativesClient([{ id: "init-2", name: "Growth" }]);
 
     await expect(
-      resolveInitiativeId(sdk, "Growth", {
+      resolveInitiativeId(client, "Growth", {
         teamId: asUuid("team-1"),
         ownerId: asUuid("user-1"),
       }),
     ).resolves.toBe("init-2");
 
-    expect(sdk.sdk.initiatives).toHaveBeenCalledWith({
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       filter: {
         and: [
           { name: { eqIgnoreCase: "Growth" } },

--- a/tests/unit/resolvers/issue-filter-resolver.test.ts
+++ b/tests/unit/resolvers/issue-filter-resolver.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import type { LinearSdkClient } from "../../../src/client/linear-client.js";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import { resolveSearchFilterIds } from "../../../src/resolvers/issue-filter-resolver.js";
 
 const {
@@ -54,22 +54,22 @@ describe("resolveSearchFilterIds", () => {
   });
 
   it("passes resolved team UUID to status/cycle lookups", async () => {
-    const sdk = {} as unknown as LinearSdkClient;
+    const gql = {} as unknown as GraphQLClient;
 
     resolveTeamIdMock.mockResolvedValue("team-uuid");
     resolveStatusIdMock.mockResolvedValue("state-uuid");
     resolveCycleIdMock.mockResolvedValue("cycle-uuid");
 
-    const result = await resolveSearchFilterIds(sdk, {
+    const result = await resolveSearchFilterIds(gql, {
       team: "ENG",
       statusNames: ["Todo"],
       cycle: "Sprint 1",
     });
 
-    expect(resolveTeamIdMock).toHaveBeenCalledWith(sdk, "ENG");
-    expect(resolveStatusIdMock).toHaveBeenCalledWith(sdk, "Todo", "team-uuid");
+    expect(resolveTeamIdMock).toHaveBeenCalledWith(gql, "ENG");
+    expect(resolveStatusIdMock).toHaveBeenCalledWith(gql, "Todo", "team-uuid");
     expect(resolveCycleIdMock).toHaveBeenCalledWith(
-      sdk,
+      gql,
       "Sprint 1",
       "team-uuid",
     );
@@ -81,17 +81,17 @@ describe("resolveSearchFilterIds", () => {
   });
 
   it("falls back to raw team input for cycle lookup when team not pre-resolved", async () => {
-    const sdk = {} as unknown as LinearSdkClient;
+    const gql = {} as unknown as GraphQLClient;
 
     resolveCycleIdMock.mockResolvedValue("cycle-uuid");
 
-    const result = await resolveSearchFilterIds(sdk, {
+    const result = await resolveSearchFilterIds(gql, {
       cycle: "Sprint 2",
       team: "Engineering",
     });
 
     expect(resolveCycleIdMock).toHaveBeenCalledWith(
-      sdk,
+      gql,
       "Sprint 2",
       "Engineering",
     );

--- a/tests/unit/resolvers/issue-resolver.test.ts
+++ b/tests/unit/resolvers/issue-resolver.test.ts
@@ -1,6 +1,6 @@
 // tests/unit/resolvers/issue-resolver.test.ts
 import { describe, expect, it, vi } from "vitest";
-import type { LinearSdkClient } from "../../../src/client/linear-client.js";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import {
   resolveIssueEstimateContext,
   resolveIssueId,
@@ -8,16 +8,7 @@ import {
 
 type IssueNode = {
   id: string;
-  teamId?: string;
-  team?:
-    | {
-        id?: string;
-        key?: string;
-      }
-    | Promise<{
-        id?: string;
-        key?: string;
-      }>;
+  team: { id: string; key: string };
 };
 
 type TeamNode = {
@@ -34,13 +25,14 @@ type TeamNode = {
   issueEstimationAllowZero: boolean;
 };
 
-function mockSdkClient(issueNodes: IssueNode[], teamNodes: TeamNode[] = []) {
-  return {
-    sdk: {
-      issues: vi.fn().mockResolvedValue({ nodes: issueNodes }),
-      teams: vi.fn().mockResolvedValue({ nodes: teamNodes }),
-    },
-  } as unknown as LinearSdkClient;
+// The estimate-context resolver issues two requests: FindIssues, then FindTeams
+// (via resolveTeamEstimateContext). resolveIssueId only issues the first.
+function mockGqlClient(issueNodes: IssueNode[], teamNodes: TeamNode[] = []) {
+  const request = vi
+    .fn()
+    .mockResolvedValueOnce({ issues: { nodes: issueNodes } })
+    .mockResolvedValueOnce({ teams: { nodes: teamNodes } });
+  return { request } as unknown as GraphQLClient;
 }
 
 const teamId = "550e8400-e29b-41d4-a716-446655440001";
@@ -54,24 +46,34 @@ const exponentialTeam: TeamNode = {
   issueEstimationAllowZero: false,
 };
 
+const engIssue: IssueNode = {
+  id: "issue-uuid",
+  team: { id: teamId, key: "ENG" },
+};
+
 describe("resolveIssueId", () => {
   it("returns UUID as-is", async () => {
-    const client = mockSdkClient([]);
+    const client = mockGqlClient([]);
     const result = await resolveIssueId(
       client,
       "550e8400-e29b-41d4-a716-446655440000",
     );
     expect(result).toBe("550e8400-e29b-41d4-a716-446655440000");
+    expect(client.request).not.toHaveBeenCalled();
   });
 
   it("resolves ABC-123 identifier", async () => {
-    const client = mockSdkClient([{ id: "issue-uuid" }]);
+    const client = mockGqlClient([engIssue]);
     const result = await resolveIssueId(client, "ENG-42");
     expect(result).toBe("issue-uuid");
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      filter: { number: { eq: 42 }, team: { key: { eq: "ENG" } } },
+      first: 1,
+    });
   });
 
   it("throws when issue not found", async () => {
-    const client = mockSdkClient([]);
+    const client = mockGqlClient([]);
     await expect(resolveIssueId(client, "ENG-999")).rejects.toThrow(
       'Issue "ENG-999" not found',
     );
@@ -79,11 +81,8 @@ describe("resolveIssueId", () => {
 });
 
 describe("resolveIssueEstimateContext", () => {
-  it("resolves identifier, extracts teamId, delegates to team estimate resolver, and returns issueId plus team context", async () => {
-    const client = mockSdkClient(
-      [{ id: "issue-uuid", teamId }],
-      [exponentialTeam],
-    );
+  it("resolves identifier, derives team from the issue, and returns issueId plus team context", async () => {
+    const client = mockGqlClient([engIssue], [exponentialTeam]);
 
     await expect(
       resolveIssueEstimateContext(client, "ENG-42"),
@@ -99,137 +98,35 @@ describe("resolveIssueEstimateContext", () => {
       },
     });
 
-    expect(client.sdk.issues).toHaveBeenCalledWith({
-      filter: {
-        number: { eq: 42 },
-        team: { key: { eq: "ENG" } },
-      },
+    expect(client.request).toHaveBeenNthCalledWith(1, expect.anything(), {
+      filter: { number: { eq: 42 }, team: { key: { eq: "ENG" } } },
       first: 1,
     });
-    expect(client.sdk.teams).toHaveBeenCalledWith({
+    expect(client.request).toHaveBeenNthCalledWith(2, expect.anything(), {
       filter: { id: { eq: teamId } },
       first: 1,
     });
   });
 
-  it("resolves by UUID and uses sdk issues filter id eq", async () => {
-    const client = mockSdkClient(
-      [{ id: "issue-uuid", teamId }],
-      [exponentialTeam],
-    );
+  it("resolves by UUID using an id eq filter", async () => {
+    const client = mockGqlClient([engIssue], [exponentialTeam]);
 
     await resolveIssueEstimateContext(
       client,
       "550e8400-e29b-41d4-a716-446655440000",
     );
 
-    expect(client.sdk.issues).toHaveBeenCalledWith({
+    expect(client.request).toHaveBeenNthCalledWith(1, expect.anything(), {
       filter: { id: { eq: "550e8400-e29b-41d4-a716-446655440000" } },
       first: 1,
     });
   });
 
-  it("resolves identifier and uses sdk issues filter number plus team key", async () => {
-    const client = mockSdkClient(
-      [{ id: "issue-uuid", teamId }],
-      [exponentialTeam],
-    );
-
-    await resolveIssueEstimateContext(client, "ENG-42");
-
-    expect(client.sdk.issues).toHaveBeenCalledWith({
-      filter: {
-        number: { eq: 42 },
-        team: { key: { eq: "ENG" } },
-      },
-      first: 1,
-    });
-  });
-
-  it("succeeds when issue node has no nested team estimation fields", async () => {
-    const client = mockSdkClient(
-      [
-        {
-          id: "issue-uuid",
-          team: {
-            id: teamId,
-            key: "ENG",
-          },
-        },
-      ],
-      [exponentialTeam],
-    );
-
-    await expect(
-      resolveIssueEstimateContext(client, "ENG-42"),
-    ).resolves.toMatchObject({
-      issueId: "issue-uuid",
-      team: {
-        teamId,
-        teamKey: "ENG",
-      },
-    });
-  });
-
-  it("falls back to async team relation id when teamId is absent", async () => {
-    const client = mockSdkClient(
-      [
-        {
-          id: "issue-uuid",
-          team: Promise.resolve({ id: teamId, key: "ENG" }),
-        },
-      ],
-      [exponentialTeam],
-    );
-
-    await expect(
-      resolveIssueEstimateContext(client, "ENG-42"),
-    ).resolves.toMatchObject({
-      issueId: "issue-uuid",
-      team: {
-        teamId,
-        teamKey: "ENG",
-      },
-    });
-
-    expect(client.sdk.teams).toHaveBeenCalledWith({
-      filter: { id: { eq: teamId } },
-      first: 1,
-    });
-  });
-
-  it("falls back to async team relation key when relation id is absent", async () => {
-    const client = mockSdkClient(
-      [
-        {
-          id: "issue-uuid",
-          team: Promise.resolve({ key: "ENG" }),
-        },
-      ],
-      [exponentialTeam],
-    );
-
-    await resolveIssueEstimateContext(client, "ENG-42");
-
-    expect(client.sdk.teams).toHaveBeenCalledWith({
-      filter: { key: { eq: "ENG" } },
-      first: 1,
-    });
-  });
-
   it("throws Issue not found", async () => {
-    const client = mockSdkClient([]);
+    const client = mockGqlClient([]);
 
     await expect(
       resolveIssueEstimateContext(client, "ENG-999"),
     ).rejects.toThrow('Issue "ENG-999" not found');
-  });
-
-  it("throws when issue team context is missing", async () => {
-    const client = mockSdkClient([{ id: "issue-uuid" }]);
-
-    await expect(resolveIssueEstimateContext(client, "ENG-42")).rejects.toThrow(
-      'Issue "ENG-42" is missing required team context',
-    );
   });
 });

--- a/tests/unit/resolvers/label-resolver.test.ts
+++ b/tests/unit/resolvers/label-resolver.test.ts
@@ -1,22 +1,20 @@
 // tests/unit/resolvers/label-resolver.test.ts
 import { describe, expect, it, vi } from "vitest";
-import type { LinearSdkClient } from "../../../src/client/linear-client.js";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import {
   resolveLabelId,
   resolveLabelIds,
 } from "../../../src/resolvers/label-resolver.js";
 
-function mockSdkClient(nodes: Array<{ id: string; name?: string }>) {
+function mockGqlClient(nodes: Array<{ id: string; name?: string }>) {
   return {
-    sdk: {
-      issueLabels: vi.fn().mockResolvedValue({ nodes }),
-    },
-  } as unknown as LinearSdkClient;
+    request: vi.fn().mockResolvedValue({ issueLabels: { nodes } }),
+  } as unknown as GraphQLClient;
 }
 
 describe("resolveLabelId", () => {
   it("returns UUID as-is", async () => {
-    const client = mockSdkClient([]);
+    const client = mockGqlClient([]);
     const result = await resolveLabelId(
       client,
       "550e8400-e29b-41d4-a716-446655440000",
@@ -25,21 +23,21 @@ describe("resolveLabelId", () => {
   });
 
   it("resolves label by name", async () => {
-    const client = mockSdkClient([{ id: "label-uuid" }]);
+    const client = mockGqlClient([{ id: "label-uuid" }]);
     const result = await resolveLabelId(client, "Bug");
     expect(result).toBe("label-uuid");
-    expect(client.sdk.issueLabels).toHaveBeenCalledWith({
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       filter: { name: { eqIgnoreCase: "Bug" } },
       first: 1,
     });
   });
 
   it("resolves workspace label by name", async () => {
-    const client = mockSdkClient([{ id: "label-uuid" }]);
+    const client = mockGqlClient([{ id: "label-uuid" }]);
 
     await resolveLabelId(client, "Bug", { scope: "workspace" });
 
-    expect(client.sdk.issueLabels).toHaveBeenCalledWith({
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       filter: {
         name: { eqIgnoreCase: "Bug" },
         team: { null: true },
@@ -49,14 +47,14 @@ describe("resolveLabelId", () => {
   });
 
   it("resolves team-scoped label by name", async () => {
-    const client = mockSdkClient([{ id: "label-uuid" }]);
+    const client = mockGqlClient([{ id: "label-uuid" }]);
 
     await resolveLabelId(client, "Bug", {
       teamId: "team-uuid",
       scope: "team",
     });
 
-    expect(client.sdk.issueLabels).toHaveBeenCalledWith({
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       filter: {
         name: { eqIgnoreCase: "Bug" },
         team: { id: { eq: "team-uuid" }, null: false },
@@ -66,11 +64,11 @@ describe("resolveLabelId", () => {
   });
 
   it("filters by team when teamId is provided without explicit scope", async () => {
-    const client = mockSdkClient([{ id: "label-uuid" }]);
+    const client = mockGqlClient([{ id: "label-uuid" }]);
 
     await resolveLabelId(client, "Bug", { teamId: "team-uuid" });
 
-    expect(client.sdk.issueLabels).toHaveBeenCalledWith({
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       filter: {
         name: { eqIgnoreCase: "Bug" },
         team: { id: { eq: "team-uuid" } },
@@ -80,7 +78,7 @@ describe("resolveLabelId", () => {
   });
 
   it("throws when label not found", async () => {
-    const client = mockSdkClient([]);
+    const client = mockGqlClient([]);
     await expect(resolveLabelId(client, "Nonexistent")).rejects.toThrow(
       'Label "Nonexistent" not found',
     );
@@ -89,7 +87,7 @@ describe("resolveLabelId", () => {
 
 describe("resolveLabelIds", () => {
   it("resolves mixed UUIDs and names", async () => {
-    const client = mockSdkClient([{ id: "label-uuid" }]);
+    const client = mockGqlClient([{ id: "label-uuid" }]);
     const result = await resolveLabelIds(client, [
       "550e8400-e29b-41d4-a716-446655440000",
       "Bug",

--- a/tests/unit/resolvers/milestone-resolver.test.ts
+++ b/tests/unit/resolvers/milestone-resolver.test.ts
@@ -1,7 +1,6 @@
 // tests/unit/resolvers/milestone-resolver.test.ts
 import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
-import type { LinearSdkClient } from "../../../src/client/linear-client.js";
 import { resolveMilestoneId } from "../../../src/resolvers/milestone-resolver.js";
 
 function mockGqlClient(...responses: Array<Record<string, unknown>>) {
@@ -12,34 +11,38 @@ function mockGqlClient(...responses: Array<Record<string, unknown>>) {
   return { request } as unknown as GraphQLClient;
 }
 
-function mockSdkClient() {
-  return {
-    sdk: {
-      projects: vi.fn().mockResolvedValue({ nodes: [{ id: "proj-uuid" }] }),
-    },
-  } as unknown as LinearSdkClient;
-}
-
 describe("resolveMilestoneId", () => {
   it("returns UUID as-is", async () => {
     const gql = mockGqlClient();
-    const sdk = mockSdkClient();
     const result = await resolveMilestoneId(
       gql,
-      sdk,
       "550e8400-e29b-41d4-a716-446655440000",
     );
     expect(result).toBe("550e8400-e29b-41d4-a716-446655440000");
+    expect(gql.request).not.toHaveBeenCalled();
+  });
+
+  it("resolves a project-scoped milestone by name", async () => {
+    const gql = mockGqlClient(
+      { projects: { nodes: [{ id: "proj-uuid" }] } },
+      {
+        project: {
+          projectMilestones: { nodes: [{ id: "ms-uuid", name: "M1" }] },
+        },
+      },
+    );
+    const result = await resolveMilestoneId(gql, "M1", "My Project");
+    expect(result).toBe("ms-uuid");
   });
 
   it("throws when milestone not found", async () => {
     const gql = mockGqlClient(
+      { projects: { nodes: [{ id: "proj-uuid" }] } },
       { project: { projectMilestones: { nodes: [] } } },
       { projectMilestones: { nodes: [] } },
     );
-    const sdk = mockSdkClient();
     await expect(
-      resolveMilestoneId(gql, sdk, "Nonexistent", "My Project"),
+      resolveMilestoneId(gql, "Nonexistent", "My Project"),
     ).rejects.toThrow('Milestone "Nonexistent" not found');
   });
 });

--- a/tests/unit/resolvers/project-resolver.test.ts
+++ b/tests/unit/resolvers/project-resolver.test.ts
@@ -1,69 +1,64 @@
 // tests/unit/resolvers/project-resolver.test.ts
 import { describe, expect, it, vi } from "vitest";
-import type { LinearSdkClient } from "../../../src/client/linear-client.js";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import {
   resolveProjectId,
   resolveProjectLabelId,
   resolveProjectLabelIds,
 } from "../../../src/resolvers/project-resolver.js";
 
-function mockSdkClient(nodes: Array<{ id: string }>) {
+function mockGqlClient(nodes: Array<{ id: string }>) {
   return {
-    sdk: {
-      projects: vi.fn().mockResolvedValue({ nodes }),
-    },
-  } as unknown as LinearSdkClient;
+    request: vi.fn().mockResolvedValue({ projects: { nodes } }),
+  } as unknown as GraphQLClient;
 }
 
-function mockSdkClientWithLabels(nodes: Array<{ id: string }>) {
+function mockGqlClientWithLabels(nodes: Array<{ id: string }>) {
   return {
-    sdk: {
-      projectLabels: vi.fn().mockResolvedValue({ nodes }),
-    },
-  } as unknown as LinearSdkClient;
+    request: vi.fn().mockResolvedValue({ projectLabels: { nodes } }),
+  } as unknown as GraphQLClient;
 }
 
 describe("resolveProjectId", () => {
   it("returns UUID as-is", async () => {
-    const client = mockSdkClient([]);
+    const client = mockGqlClient([]);
     const result = await resolveProjectId(
       client,
       "550e8400-e29b-41d4-a716-446655440000",
     );
     expect(result).toBe("550e8400-e29b-41d4-a716-446655440000");
-    expect(client.sdk.projects).not.toHaveBeenCalled();
+    expect(client.request).not.toHaveBeenCalled();
   });
 
   it("resolves project by name", async () => {
-    const client = mockSdkClient([{ id: "proj-uuid" }]);
+    const client = mockGqlClient([{ id: "proj-uuid" }]);
     const result = await resolveProjectId(client, "Mobile App");
     expect(result).toBe("proj-uuid");
   });
 
   it("includes archived projects when requested", async () => {
-    const client = mockSdkClient([{ id: "archived-proj-uuid" }]);
+    const client = mockGqlClient([{ id: "archived-proj-uuid" }]);
 
     const result = await resolveProjectId(client, "Archived Project", {
       includeArchived: true,
     });
 
     expect(result).toBe("archived-proj-uuid");
-    expect(client.sdk.projects).toHaveBeenCalledWith({
-      filter: { name: { eqIgnoreCase: "Archived Project" } },
-      first: 2,
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      name: "Archived Project",
       includeArchived: true,
     });
   });
 
   it("throws when project not found", async () => {
-    const client = mockSdkClient([]);
+    const client = mockGqlClient([]);
     await expect(resolveProjectId(client, "Nonexistent")).rejects.toThrow(
       'Project "Nonexistent" not found',
     );
   });
 
   it("throws when multiple projects match same name", async () => {
-    const client = mockSdkClient([
+    const client = mockGqlClient([
       { id: "proj-uuid-1" },
       { id: "proj-uuid-2" },
     ]);
@@ -78,23 +73,23 @@ describe("resolveProjectId", () => {
 
 describe("resolveProjectLabelId", () => {
   it("returns UUID as-is", async () => {
-    const client = mockSdkClientWithLabels([]);
+    const client = mockGqlClientWithLabels([]);
     const result = await resolveProjectLabelId(
       client,
       "550e8400-e29b-41d4-a716-446655440000",
     );
     expect(result).toBe("550e8400-e29b-41d4-a716-446655440000");
-    expect(client.sdk.projectLabels).not.toHaveBeenCalled();
+    expect(client.request).not.toHaveBeenCalled();
   });
 
   it("resolves label by name", async () => {
-    const client = mockSdkClientWithLabels([{ id: "label-uuid" }]);
+    const client = mockGqlClientWithLabels([{ id: "label-uuid" }]);
     const result = await resolveProjectLabelId(client, "Q1-2025");
     expect(result).toBe("label-uuid");
   });
 
   it("throws when label not found", async () => {
-    const client = mockSdkClientWithLabels([]);
+    const client = mockGqlClientWithLabels([]);
     await expect(resolveProjectLabelId(client, "Nonexistent")).rejects.toThrow(
       'Project label "Nonexistent" not found',
     );
@@ -103,7 +98,7 @@ describe("resolveProjectLabelId", () => {
 
 describe("resolveProjectLabelIds", () => {
   it("resolves mixed UUIDs and names", async () => {
-    const client = mockSdkClientWithLabels([{ id: "label-uuid" }]);
+    const client = mockGqlClientWithLabels([{ id: "label-uuid" }]);
     const result = await resolveProjectLabelIds(client, [
       "550e8400-e29b-41d4-a716-446655440000",
       "Q1-2025",

--- a/tests/unit/resolvers/status-resolver.test.ts
+++ b/tests/unit/resolvers/status-resolver.test.ts
@@ -1,21 +1,19 @@
 // tests/unit/resolvers/status-resolver.test.ts
 
 import { describe, expect, it, vi } from "vitest";
-import type { LinearSdkClient } from "../../../src/client/linear-client.js";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import { asUuid } from "../../../src/common/identifier.js";
 import { resolveStatusId } from "../../../src/resolvers/status-resolver.js";
 
-function mockSdkClient(nodes: Array<{ id: string }>) {
+function mockGqlClient(nodes: Array<{ id: string }>) {
   return {
-    sdk: {
-      workflowStates: vi.fn().mockResolvedValue({ nodes }),
-    },
-  } as unknown as LinearSdkClient;
+    request: vi.fn().mockResolvedValue({ workflowStates: { nodes } }),
+  } as unknown as GraphQLClient;
 }
 
 describe("resolveStatusId", () => {
   it("returns UUID as-is", async () => {
-    const client = mockSdkClient([]);
+    const client = mockGqlClient([]);
     const result = await resolveStatusId(
       client,
       "550e8400-e29b-41d4-a716-446655440000",
@@ -24,15 +22,15 @@ describe("resolveStatusId", () => {
   });
 
   it("resolves status by name", async () => {
-    const client = mockSdkClient([{ id: "status-uuid" }]);
+    const client = mockGqlClient([{ id: "status-uuid" }]);
     const result = await resolveStatusId(client, "In Progress");
     expect(result).toBe("status-uuid");
   });
 
   it("resolves status by name with team context", async () => {
-    const client = mockSdkClient([{ id: "status-uuid" }]);
+    const client = mockGqlClient([{ id: "status-uuid" }]);
     await resolveStatusId(client, "In Progress", asUuid("team-uuid"));
-    expect(client.sdk.workflowStates).toHaveBeenCalledWith({
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       filter: {
         name: { eqIgnoreCase: "In Progress" },
         team: { id: { eq: "team-uuid" } },
@@ -42,7 +40,7 @@ describe("resolveStatusId", () => {
   });
 
   it("throws when status not found", async () => {
-    const client = mockSdkClient([]);
+    const client = mockGqlClient([]);
     await expect(resolveStatusId(client, "Nonexistent")).rejects.toThrow(
       'Status "Nonexistent" not found',
     );

--- a/tests/unit/resolvers/team-resolver.test.ts
+++ b/tests/unit/resolvers/team-resolver.test.ts
@@ -1,63 +1,69 @@
 // tests/unit/resolvers/team-resolver.test.ts
 import { describe, expect, it, vi } from "vitest";
-import type { LinearSdkClient } from "../../../src/client/linear-client.js";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import {
   resolveTeamEstimateContext,
   resolveTeamId,
 } from "../../../src/resolvers/team-resolver.js";
 
-function mockSdkClient(
-  ...callResults: Array<{
-    nodes: Array<{
-      id: string;
-      key?: string;
-      name?: string;
-      issueEstimationType?:
-        | "notUsed"
-        | "exponential"
-        | "fibonacci"
-        | "linear"
-        | "tShirt";
-      issueEstimationExtended?: boolean;
-      issueEstimationAllowZero?: boolean;
-    }>;
-  }>
-) {
-  const teams = vi.fn();
+type TeamLookupNode = {
+  id: string;
+  key?: string;
+  name?: string;
+  issueEstimationType?:
+    | "notUsed"
+    | "exponential"
+    | "fibonacci"
+    | "linear"
+    | "tShirt";
+  issueEstimationExtended?: boolean;
+  issueEstimationAllowZero?: boolean;
+};
+
+function mockGqlClient(...callResults: Array<{ nodes: TeamLookupNode[] }>) {
+  const request = vi.fn();
   for (const result of callResults) {
-    teams.mockResolvedValueOnce(result);
+    request.mockResolvedValueOnce({ teams: result });
   }
-  return { sdk: { teams } } as unknown as LinearSdkClient;
+  return { request } as unknown as GraphQLClient;
 }
 
 describe("resolveTeamId", () => {
-  it("returns UUID as-is without calling SDK", async () => {
-    const client = mockSdkClient();
+  it("returns UUID as-is without querying", async () => {
+    const client = mockGqlClient();
     const result = await resolveTeamId(
       client,
       "550e8400-e29b-41d4-a716-446655440000",
     );
     expect(result).toBe("550e8400-e29b-41d4-a716-446655440000");
-    expect(client.sdk.teams).not.toHaveBeenCalled();
+    expect(client.request).not.toHaveBeenCalled();
   });
 
   it("resolves team by key", async () => {
-    const client = mockSdkClient({ nodes: [{ id: "uuid-1", key: "ENG" }] });
+    const client = mockGqlClient({ nodes: [{ id: "uuid-1", key: "ENG" }] });
     const result = await resolveTeamId(client, "ENG");
     expect(result).toBe("uuid-1");
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      filter: { key: { eq: "ENG" } },
+      first: 1,
+    });
   });
 
   it("falls back to name when key not found", async () => {
-    const client = mockSdkClient(
+    const client = mockGqlClient(
       { nodes: [] },
       { nodes: [{ id: "uuid-2", name: "Engineering" }] },
     );
     const result = await resolveTeamId(client, "Engineering");
     expect(result).toBe("uuid-2");
+    expect(client.request).toHaveBeenNthCalledWith(2, expect.anything(), {
+      filter: { name: { eq: "Engineering" } },
+      first: 1,
+    });
   });
 
   it("throws when team not found by key or name", async () => {
-    const client = mockSdkClient({ nodes: [] }, { nodes: [] });
+    const client = mockGqlClient({ nodes: [] }, { nodes: [] });
     await expect(resolveTeamId(client, "NOPE")).rejects.toThrow(
       'Team "NOPE" not found',
     );
@@ -66,7 +72,7 @@ describe("resolveTeamId", () => {
 
 describe("resolveTeamEstimateContext", () => {
   it("resolves by key with full context fields", async () => {
-    const client = mockSdkClient({
+    const client = mockGqlClient({
       nodes: [
         {
           id: "uuid-1",
@@ -89,8 +95,8 @@ describe("resolveTeamEstimateContext", () => {
     });
   });
 
-  it("resolves by UUID and queries sdk with id eq filter", async () => {
-    const client = mockSdkClient({
+  it("resolves by UUID and queries with id eq filter", async () => {
+    const client = mockGqlClient({
       nodes: [
         {
           id: "team-uuid",
@@ -109,14 +115,14 @@ describe("resolveTeamEstimateContext", () => {
     );
 
     expect(result.teamId).toBe("team-uuid");
-    expect(client.sdk.teams).toHaveBeenCalledWith({
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       filter: { id: { eq: "550e8400-e29b-41d4-a716-446655440000" } },
       first: 1,
     });
   });
 
   it("falls back to name when key lookup misses", async () => {
-    const client = mockSdkClient(
+    const client = mockGqlClient(
       { nodes: [] },
       {
         nodes: [
@@ -143,11 +149,11 @@ describe("resolveTeamEstimateContext", () => {
       issueEstimationAllowZero: true,
     });
 
-    expect(client.sdk.teams).toHaveBeenNthCalledWith(1, {
+    expect(client.request).toHaveBeenNthCalledWith(1, expect.anything(), {
       filter: { key: { eq: "Engineering" } },
       first: 1,
     });
-    expect(client.sdk.teams).toHaveBeenNthCalledWith(2, {
+    expect(client.request).toHaveBeenNthCalledWith(2, expect.anything(), {
       filter: { name: { eq: "Engineering" } },
       first: 1,
     });
@@ -155,21 +161,21 @@ describe("resolveTeamEstimateContext", () => {
 
   it("throws not found for UUID when id lookup has no nodes and does not fallback", async () => {
     const teamId = "550e8400-e29b-41d4-a716-446655440000";
-    const client = mockSdkClient({ nodes: [] });
+    const client = mockGqlClient({ nodes: [] });
 
     await expect(resolveTeamEstimateContext(client, teamId)).rejects.toThrow(
       `Team "${teamId}" not found`,
     );
 
-    expect(client.sdk.teams).toHaveBeenCalledTimes(1);
-    expect(client.sdk.teams).toHaveBeenCalledWith({
+    expect(client.request).toHaveBeenCalledTimes(1);
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       filter: { id: { eq: teamId } },
       first: 1,
     });
   });
 
   it("throws not found when no nodes", async () => {
-    const client = mockSdkClient({ nodes: [] }, { nodes: [] });
+    const client = mockGqlClient({ nodes: [] }, { nodes: [] });
     await expect(resolveTeamEstimateContext(client, "NOPE")).rejects.toThrow(
       'Team "NOPE" not found',
     );

--- a/tests/unit/resolvers/user-resolver.test.ts
+++ b/tests/unit/resolvers/user-resolver.test.ts
@@ -1,6 +1,6 @@
 // tests/unit/resolvers/user-resolver.test.ts
 import { describe, expect, it, vi } from "vitest";
-import type { LinearSdkClient } from "../../../src/client/linear-client.js";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import { resolveUserId } from "../../../src/resolvers/user-resolver.js";
 
 interface MockUser {
@@ -9,41 +9,41 @@ interface MockUser {
   email?: string;
 }
 
-function mockSdkClient(...callResults: Array<{ nodes: MockUser[] }>) {
-  const users = vi.fn();
+function mockGqlClient(...callResults: Array<{ nodes: MockUser[] }>) {
+  const request = vi.fn();
   for (const result of callResults) {
-    users.mockResolvedValueOnce(result);
+    request.mockResolvedValueOnce({ users: result });
   }
-  return { sdk: { users } } as unknown as LinearSdkClient;
+  return { request } as unknown as GraphQLClient;
 }
 
 describe("resolveUserId", () => {
-  it("returns UUID as-is without calling SDK", async () => {
-    const client = mockSdkClient();
+  it("returns UUID as-is without querying", async () => {
+    const client = mockGqlClient();
     const result = await resolveUserId(
       client,
       "550e8400-e29b-41d4-a716-446655440000",
     );
     expect(result).toBe("550e8400-e29b-41d4-a716-446655440000");
-    expect(client.sdk.users).not.toHaveBeenCalled();
+    expect(client.request).not.toHaveBeenCalled();
   });
 
   it("resolves user by display name", async () => {
-    const client = mockSdkClient({
+    const client = mockGqlClient({
       nodes: [
         { id: "user-uuid-1", name: "John Doe", email: "john@example.com" },
       ],
     });
     const result = await resolveUserId(client, "John Doe");
     expect(result).toBe("user-uuid-1");
-    expect(client.sdk.users).toHaveBeenCalledWith({
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
       filter: { displayName: { eqIgnoreCase: "John Doe" } },
       first: 10,
     });
   });
 
   it("falls back to email when name not found", async () => {
-    const client = mockSdkClient(
+    const client = mockGqlClient(
       { nodes: [] },
       {
         nodes: [{ id: "user-uuid-2", name: "Jane", email: "jane@example.com" }],
@@ -51,22 +51,22 @@ describe("resolveUserId", () => {
     );
     const result = await resolveUserId(client, "jane@example.com");
     expect(result).toBe("user-uuid-2");
-    expect(client.sdk.users).toHaveBeenCalledTimes(2);
-    expect(client.sdk.users).toHaveBeenNthCalledWith(2, {
+    expect(client.request).toHaveBeenCalledTimes(2);
+    expect(client.request).toHaveBeenNthCalledWith(2, expect.anything(), {
       filter: { email: { eqIgnoreCase: "jane@example.com" } },
       first: 1,
     });
   });
 
   it("throws when user not found by name or email", async () => {
-    const client = mockSdkClient({ nodes: [] }, { nodes: [] });
+    const client = mockGqlClient({ nodes: [] }, { nodes: [] });
     await expect(resolveUserId(client, "Nobody")).rejects.toThrow(
       'User "Nobody" not found',
     );
   });
 
   it("throws when multiple users match by name", async () => {
-    const client = mockSdkClient({
+    const client = mockGqlClient({
       nodes: [
         { id: "user-1", name: "Alex Smith", email: "alex1@example.com" },
         { id: "user-2", name: "Alex Smith", email: "alex2@example.com" },


### PR DESCRIPTION
## What does this PR do?

Migrates every ID resolver off `LinearSdkClient` onto `GraphQLClient` + generated GraphQL operations/types, preserving all lookup order, disambiguation, and error behavior. Adds lean `FindUsers`/`FindIssues`/`FindIssueLabels` lookup queries (reusing the existing `Find*` queries for teams, projects, labels, statuses, cycles, and initiatives), rewires all command callers (`ctx.sdk` → `ctx.gql`), and removes the now-unused `LinearSdkClient` and `@linear/sdk` dependency. Resolver tests now mock `GraphQLClient.request` one layer deep.

Closes #209

## Type of change

- [ ] Bug fix
- [ ] New feature
- [x] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [x] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

`npm run generate`, `npm run check:ci`, `npx tsc --noEmit`, `npm test` (849 passing), `npm run build`, and `npm run knip` (clean — no dangling `@linear/sdk` dep or `LinearSdkClient`) all pass.

## Notes for reviewers

Behavior-preserving. The issue resolver is notably simpler because GraphQL returns `team` inline, removing the SDK's PromiseLike/relation-projection handling. `resolveMilestoneId` dropped its SDK client param (project now resolved via GraphQL). No changes to `src/gql/` (generated, git-ignored).