### PR TITLE
docs: reflect Linear SDK removal in docs and test mocks

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,16 +42,16 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full commit types table and examp
 ```
 CLI Input → Command → Resolver → Service → JSON Output
                │         │          │
-           createContext  SDK     GraphQL
+           createContext GraphQL  GraphQL
                         (UUID)   (data)
 ```
 
 | Layer | Directory | Client | Responsibility |
 |-----------|-----------------|---------------------|--------------------------------------|
 | Client | `src/client/` | — | Thin API wrappers, no logic |
-| Resolver | `src/resolvers/` | `LinearSdkClient` | Human ID → UUID conversion |
+| Resolver | `src/resolvers/` | `GraphQLClient` | Human ID → UUID conversion |
 | Service | `src/services/` | `GraphQLClient` | Business logic, CRUD via GraphQL |
-| Command | `src/commands/` | Both via `createContext()` | CLI orchestration only |
+| Command | `src/commands/` | `GraphQLClient` via `createContext()` | CLI orchestration only |
 | Common | `src/common/` | — | Shared types, errors, output, auth |
 
 ### Invariants (P0 — violations fail CI/review)
@@ -59,12 +59,12 @@ CLI Input → Command → Resolver → Service → JSON Output
 1. **No `any` types.** Use `unknown`, codegen types, or explicit interfaces.
 2. **Strict layer separation.** No cross-layer imports:
    - Resolvers must not import services (or vice versa).
-   - Commands must not import `GraphQLClient` directly.
+   - Commands must not construct `GraphQLClient` directly — use `createContext()`.
 3. **Client-layer contract:**
-   - Resolvers → `LinearSdkClient` by default.
-   - Services → `GraphQLClient` only.
-   - Commands → both, via `createContext()`.
-   - **Narrow exceptions allowed only when SDK lacks required capability**, with explicit `ARCHITECTURAL EXCEPTION` docstring in code (current examples: milestone/project-status lookups, initiative relation/link ID lookup helpers).
+   - Resolvers → `GraphQLClient` (via lean filter-based lookup queries).
+   - Services → `GraphQLClient`.
+   - Commands → `GraphQLClient` via `createContext()` (`ctx.gql`).
+   - Resolvers should prefer the lean lookup fragments; when the Linear API exposes no lean lookup for an entity, a resolver may query it directly with an explicit `ARCHITECTURAL EXCEPTION` docstring (current examples: milestone/project-status lookups, initiative relation/link ID lookup helpers).
 4. **ID resolution happens once**, in resolvers only. Services accept UUIDs.
 5. **All commands** use `handleCommand()` wrapper and `outputSuccess()` for output.
 6. **Explicit return types** on all exported functions.
@@ -84,9 +84,9 @@ Need a new GraphQL operation?
 
 Need to resolve a human-friendly ID?
   → Add/edit src/resolvers/*-resolver.ts
-  → Prefer LinearSdkClient, return UUID string
-  → Pattern: UUID passthrough → SDK lookup → notFoundError()
-  → If SDK cannot express lookup, use GraphQL as documented ARCHITECTURAL EXCEPTION (include rationale in resolver docstring)
+  → Use GraphQLClient with a lean lookup query, return UUID string
+  → Pattern: UUID passthrough → GraphQL filter lookup → notFoundError()
+  → If no lean lookup fragment exists, query directly as a documented ARCHITECTURAL EXCEPTION (include rationale in resolver docstring)
 
 Need business logic / CRUD?
   → Add/edit src/services/*-service.ts
@@ -110,7 +110,7 @@ Tests mirror `src/` structure under `tests/unit/`. Mock the dependency one layer
 
 | Test target | Mock | Example |
 |-------------|------|---------|
-| Resolver | `LinearSdkClient` (mock `sdk.*`) | `{ sdk: { teams: vi.fn() } } as unknown as LinearSdkClient` |
+| Resolver | `GraphQLClient` (mock `request`) | `{ request: vi.fn() } as unknown as GraphQLClient` |
 | Service | `GraphQLClient` (mock `request`) | `{ request: vi.fn() } as unknown as GraphQLClient` |
 | Common | No mocks (pure functions) | Direct import + assert |
 
@@ -136,12 +136,14 @@ async function createIssue(client: GraphQLClient, teamName: string) {
 async function createIssue(client: GraphQLClient, input: { teamId: string }) { ... }
 ```
 
-**Wrong client in layer:**
+**ID resolution in command:**
 ```typescript
-// WRONG: resolver uses GraphQLClient
-async function resolveTeamId(client: GraphQLClient) { ... }
-// RIGHT: resolver uses LinearSdkClient
-async function resolveTeamId(client: LinearSdkClient) { ... }
+// WRONG: command builds a raw mutation instead of delegating
+async function resolveTeamId(client: GraphQLClient, teamName: string) {
+  const teamId = /* inline lookup in the command */;
+}
+// RIGHT: resolvers own ID resolution, services own CRUD
+async function resolveTeamId(client: GraphQLClient, teamName: string): Promise<UUID> { ... }
 ```
 
 **Business logic in command:**
@@ -152,7 +154,7 @@ async function resolveTeamId(client: LinearSdkClient) { ... }
 }))
 // RIGHT: command delegates
 .action(handleCommand(async (title, opts) => {
-  const teamId = await resolveTeamId(ctx.sdk, opts.team);
+  const teamId = await resolveTeamId(ctx.gql, opts.team);
   const result = await createIssue(ctx.gql, { title, teamId });
   outputSuccess(result);
 }))
@@ -195,7 +197,7 @@ Registration checklist:
 ```
 src/
   main.ts              # entry point, command registration
-  client/              # GraphQLClient, LinearSdkClient
+  client/              # GraphQLClient
   resolvers/           # ID resolution (human → UUID)
   services/            # business logic (GraphQL CRUD)
   commands/            # CLI definitions (Commander.js)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,24 +2,19 @@
 
 Linearis follows a modular, five-layer architecture with clear separation of concerns. The application uses a command-based structure with Commander.js, typed GraphQL operations, standalone resolver functions, and service functions that eliminate code duplication.
 
-The architecture emphasizes performance through GraphQL batch operations, single-query optimizations, and smart ID resolution for user convenience. All components are fully typed with TypeScript - no `any` types in the new architecture. The system uses both direct GraphQL queries (via typed client) and Linear SDK (for ID resolution).
+The architecture emphasizes performance through GraphQL batch operations, single-query optimizations, and smart ID resolution for user convenience. All components are fully typed with TypeScript - no `any` types in the new architecture. Every layer talks to the Linear API through a single typed GraphQL client — both ID resolution and data operations.
 
 ## Five-Layer Architecture
 
 ### 1. Client Layer (`src/client/`)
 
-Thin wrappers around GraphQL and Linear SDK with no business logic.
+Thin wrapper around the Linear GraphQL API with no business logic.
 
 - **graphql-client.ts** - Typed GraphQL client
   - Takes `DocumentNode` from codegen
   - Returns typed results via generics
   - Handles error transformation
   - No ID resolution or business logic
-
-- **linear-client.ts** - Linear SDK wrapper
-  - Simple wrapper exposing `sdk` property
-  - Used by resolvers for lookups
-  - No business logic
 
 ### 2. Resolver Layer (`src/resolvers/`)
 
@@ -34,10 +29,10 @@ Pure functions that convert human-friendly identifiers to UUIDs.
 - **issue-resolver.ts** - `resolveIssueId(client, issueIdOrIdentifier)` - Parses ABC-123 format
 - **status-resolver.ts** - `resolveStatusId(client, nameOrId, teamId?)`
 - **cycle-resolver.ts** - `resolveCycleId(client, nameOrId, teamFilter?)` - Complex disambiguation
-- **milestone-resolver.ts** - `resolveMilestoneId(gqlClient, sdkClient, nameOrId, projectNameOrId?)`
+- **milestone-resolver.ts** - `resolveMilestoneId(gqlClient, nameOrId, projectNameOrId?)`
 
 **Pattern:**
-- Accept SDK or GraphQL client
+- Accept the `GraphQLClient`
 - Check if input is UUID (early return)
 - Query Linear API for name/key match
 - Throw descriptive error if not found
@@ -60,7 +55,7 @@ Pure, typed functions for CRUD operations. Receive pre-resolved UUIDs.
 - **file-service.ts** - File upload/download operations
 
 **Pattern:**
-- Accept `GraphQLClient` or `LinearSdkClient`
+- Accept `GraphQLClient`
 - Take pre-resolved UUIDs in inputs
 - Use codegen `DocumentNode` types
 - Return typed results
@@ -91,8 +86,8 @@ Thin orchestration layer that composes resolvers and services.
       const ctx = await createContext(command.parent!.parent!.opts());
 
       // Resolve IDs
-      const teamId = await resolveTeamId(ctx.sdk, options.team);
-      const labelIds = await resolveLabelIds(ctx.sdk, options.labels.split(','));
+      const teamId = await resolveTeamId(ctx.gql, options.team);
+      const labelIds = await resolveLabelIds(ctx.gql, options.labels.split(','));
 
       // Call service
       const result = await createIssue(ctx.gql, {
@@ -111,7 +106,7 @@ Thin orchestration layer that composes resolvers and services.
 
 Shared utilities used across layers.
 
-- **context.ts** - `createContext(options)` - Creates `{ gql, sdk }` from auth
+- **context.ts** - `createContext(options)` - Creates `{ gql }` from auth
 - **auth.ts** - `resolveApiToken(options)` - Multi-source authentication (flag, env, encrypted storage, legacy file)
 - **output.ts** - `outputSuccess(data)`, `outputError(error)`, `handleCommand(fn)`
 - **errors.ts** - `notFoundError()`, `multipleMatchesError()`, `invalidParameterError()`
@@ -140,7 +135,6 @@ Shared utilities used across layers.
 ### Client Layer - API Wrappers
 
 - **src/client/graphql-client.ts** - Typed GraphQL client with error handling
-- **src/client/linear-client.ts** - Linear SDK wrapper
 
 ### Resolver Layer - ID Resolution
 
@@ -170,7 +164,6 @@ Shared utilities used across layers.
 **Client Layer**
 
 - src/client/graphql-client.ts - GraphQLClient class with typed request method
-- src/client/linear-client.ts - LinearSdkClient wrapper
 
 **Resolver Layer**
 
@@ -202,9 +195,9 @@ Shared utilities used across layers.
 ### Command Execution Flow
 
 1. **Command Parsing** - src/main.ts parses CLI arguments via Commander.js
-2. **Context Creation** - src/common/context.ts creates `{ gql, sdk }` from auth options
+2. **Context Creation** - src/common/context.ts creates `{ gql }` from auth options
 3. **Authentication** - src/common/auth.ts resolves API token from multiple sources
-4. **ID Resolution** - src/resolvers/* convert human inputs to UUIDs via SDK
+4. **ID Resolution** - src/resolvers/* convert human inputs to UUIDs via GraphQL
 5. **Service Operations** - src/services/* execute typed GraphQL operations
 6. **Response Formatting** - src/common/output.ts outputs structured JSON
 

--- a/docs/build-system.md
+++ b/docs/build-system.md
@@ -135,8 +135,9 @@ npm run test:commands   # Run command coverage analysis
 
 | Package | Version | Purpose |
 |---|---|---|
-| `@linear/sdk` | ^58.1.0 | Linear API SDK for ID resolution |
-| `commander` | ^14.0.0 | CLI argument parsing |
+| `commander` | 14.0.3 | CLI argument parsing |
+| `graphql` | 16.12.0 | GraphQL document parsing/types for the typed client |
+| `node-emoji` | 2.2.0 | Emoji shortcode handling |
 
 ### Development
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -33,19 +33,19 @@ The codebase is organized into five layers, each with a single responsibility:
 ```
 CLI Input --> Command --> Resolver --> Service --> JSON Output
                            |             |
-                        SDK client    GraphQL client
+                        GraphQL client GraphQL client
                         (ID lookup)   (data operations)
 ```
 
 | Layer | Directory | Client | Responsibility |
 |-------|-----------|--------|----------------|
-| Client | `src/client/` | -- | API client wrappers |
-| Resolver | `src/resolvers/` | `LinearSdkClient` | Convert human IDs to UUIDs |
+| Client | `src/client/` | -- | API client wrapper |
+| Resolver | `src/resolvers/` | `GraphQLClient` | Convert human IDs to UUIDs |
 | Service | `src/services/` | `GraphQLClient` | Business logic and CRUD |
-| Command | `src/commands/` | Both (via `createContext()`) | CLI orchestration |
+| Command | `src/commands/` | `GraphQLClient` (via `createContext()`) | CLI orchestration |
 | Common | `src/common/` | -- | Shared utilities and types |
 
-Two separate clients exist because the Linear SDK is convenient for ID lookups (resolvers), while direct GraphQL queries are more efficient for data operations (services). Commands get both clients through `createContext()`.
+A single typed GraphQL client backs every layer: resolvers use lean filter-based lookup queries for ID resolution, while services use richer queries for data operations. Commands get the client through `createContext()` as `ctx.gql`.
 
 ## Code Style
 
@@ -90,7 +90,7 @@ export function setupIssuesCommands(program: Command): void {
     .action(handleCommand(async (title, options, command) => {
       const ctx = await createContext(command.parent!.parent!.opts());
       const teamId = options.team
-        ? await resolveTeamId(ctx.sdk, options.team)
+        ? await resolveTeamId(ctx.gql, options.team)
         : undefined;
       const result = await createIssue(ctx.gql, { title, teamId });
       outputSuccess(result);
@@ -109,38 +109,44 @@ setupEntityCommands(program);
 
 ### Resolver Pattern
 
-Resolvers convert human-friendly identifiers (team keys, names, issue identifiers like `ENG-123`) into UUIDs. They use the `LinearSdkClient` and live in `src/resolvers/`.
+Resolvers convert human-friendly identifiers (team keys, names, issue identifiers like `ENG-123`) into UUIDs. They use the `GraphQLClient` with lean filter-based lookup queries and live in `src/resolvers/`.
 
 ```typescript
-import type { LinearSdkClient } from "../client/linear-client.js";
-import { isUuid } from "../common/identifier.js";
+import type { GraphQLClient } from "../client/graphql-client.js";
+import { notFoundError } from "../common/errors.js";
+import { asUuid, isUuid, type UUID } from "../common/identifier.js";
+import { FindTeamsDocument } from "../gql/graphql.js";
 
 export async function resolveTeamId(
-  client: LinearSdkClient,
+  client: GraphQLClient,
   keyOrNameOrId: string,
-): Promise<string> {
-  if (isUuid(keyOrNameOrId)) return keyOrNameOrId;
+): Promise<UUID> {
+  if (isUuid(keyOrNameOrId)) return asUuid(keyOrNameOrId);
 
-  const byKey = await client.sdk.teams({
+  // Try by key first
+  const byKey = await client.request(FindTeamsDocument, {
     filter: { key: { eq: keyOrNameOrId } },
     first: 1,
   });
-  if (byKey.nodes.length > 0) return byKey.nodes[0].id;
+  const [byKeyMatch] = byKey.teams.nodes;
+  if (byKeyMatch) return asUuid(byKeyMatch.id);
 
-  const byName = await client.sdk.teams({
+  // Fall back to name
+  const byName = await client.request(FindTeamsDocument, {
     filter: { name: { eq: keyOrNameOrId } },
     first: 1,
   });
-  if (byName.nodes.length > 0) return byName.nodes[0].id;
+  const [byNameMatch] = byName.teams.nodes;
+  if (byNameMatch) return asUuid(byNameMatch.id);
 
-  throw new Error(`Team "${keyOrNameOrId}" not found`);
+  throw notFoundError("Team", keyOrNameOrId);
 }
 ```
 
 Rules for resolvers:
 - Always accept a UUID passthrough as the first check.
 - Return a UUID string, never an object.
-- Use `LinearSdkClient` only (not `GraphQLClient`).
+- Use `GraphQLClient` with a lean lookup query; do not import services.
 - No CRUD operations or data transformations.
 
 ### Service Pattern
@@ -180,7 +186,7 @@ export async function createIssue(
 ```
 
 Rules for services:
-- Use `GraphQLClient` only (not `LinearSdkClient`).
+- Use `GraphQLClient` (the only client).
 - Accept UUIDs, not human-friendly identifiers.
 - Import `DocumentNode` constants and types from `src/gql/graphql.js`.
 - Always type the `client.request<T>()` call.
@@ -299,7 +305,7 @@ A typical feature addition touches four layers. Here is the sequence:
 
 1. **GraphQL operations** -- Define queries and mutations in `graphql/queries/` or `graphql/mutations/`, then run `npm run generate`.
 
-2. **Resolver** (if new entity types need ID resolution) -- Add a `resolve*Id()` function in `src/resolvers/`. Use `LinearSdkClient`, return a UUID string.
+2. **Resolver** (if new entity types need ID resolution) -- Add a `resolve*Id()` function in `src/resolvers/`. Use `GraphQLClient` with a lean lookup query, return a UUID string.
 
 3. **Service** -- Add functions in `src/services/`. Use `GraphQLClient`, accept UUIDs, import codegen types.
 
@@ -353,7 +359,6 @@ src/
   main.ts                    # Entry point, registers all command groups
   client/
     graphql-client.ts        # GraphQLClient - direct GraphQL execution
-    linear-client.ts         # LinearSdkClient - SDK wrapper for resolvers
   resolvers/                 # Human ID to UUID resolution
     team-resolver.ts
     project-resolver.ts
@@ -403,7 +408,7 @@ graphql/
   mutations/                 # GraphQL mutation definitions
 tests/
   unit/
-    resolvers/               # Resolver tests (mock SDK)
+    resolvers/               # Resolver tests (mock GraphQLClient)
     services/                # Service tests (mock GraphQL)
     common/                  # Pure function tests
 ```
@@ -411,8 +416,9 @@ tests/
 ## Dependencies
 
 **Runtime:**
-- `@linear/sdk` -- Linear SDK, used by resolvers for ID lookups
 - `commander` -- CLI framework
+- `graphql` -- GraphQL document parsing/types for the typed client
+- `node-emoji` -- emoji shortcode handling
 
 **Development:**
 - `typescript` -- Compiler

--- a/docs/files.md
+++ b/docs/files.md
@@ -8,14 +8,13 @@ A reference of every file in the Linearis codebase, organized by architectural l
 
 ## Client Layer (`src/client/`)
 
-Thin wrappers around the Linear API. No business logic.
+Thin wrapper around the Linear API. No business logic.
 
 - **graphql-client.ts** -- `GraphQLClient` class with a typed `request<TResult>(document: DocumentNode, variables?: Record<string, unknown>)` method for direct GraphQL execution.
-- **linear-client.ts** -- `LinearSdkClient` wrapper exposing a readonly `sdk: LinearClient` property for SDK-based lookups.
 
 ## Resolver Layer (`src/resolvers/`)
 
-Each resolver converts a human-friendly identifier (name, key, or slug) into a UUID. Resolvers use `LinearSdkClient` exclusively.
+Each resolver converts a human-friendly identifier (name, key, or slug) into a UUID. Resolvers use `GraphQLClient` with lean filter-based lookup queries.
 
 - **team-resolver.ts** -- `resolveTeamId(client, keyOrNameOrId)`
 - **project-resolver.ts** -- `resolveProjectId(client, nameOrId)`
@@ -61,7 +60,7 @@ CLI orchestration. Each file registers a command group via a `setup*Commands(pro
 
 Shared utilities used across all layers.
 
-- **context.ts** -- `CommandContext` interface and `createContext()` factory that produces both `GraphQLClient` and `LinearSdkClient`.
+- **context.ts** -- `CommandContext` interface and `createContext()` factory that produces the `GraphQLClient` (`ctx.gql`).
 - **auth.ts** -- `resolveApiToken()` with multi-source lookup: `--api-token` flag, `LINEAR_API_TOKEN` env var, `~/.linearis/token` (encrypted), `~/.linear_api_token` (deprecated).
 - **token-storage.ts** -- `saveToken()`, `getStoredToken()`, `clearToken()` for encrypted token storage in `~/.linearis/token`.
 - **encryption.ts** -- AES-256-CBC encryption for token storage.
@@ -103,7 +102,7 @@ Source `.graphql` files that feed into code generation.
 
 ## Tests (`tests/`)
 
-Unit tests mirror the source structure. Resolver tests mock the SDK client; service tests mock the GraphQL client; common tests require no mocks.
+Unit tests mirror the source structure. Resolver and service tests both mock the `GraphQLClient` (`request`); common tests require no mocks.
 
 ```
 tests/unit/
@@ -138,7 +137,7 @@ tests/unit/
 ```
 CLI Input --> Command --> Resolver --> Service --> JSON Output
                 |            |            |
-           createContext()   SDK       GraphQL
+           createContext() GraphQL     GraphQL
                           (name->UUID)  (CRUD)
 ```
 

--- a/docs/project-overview.md
+++ b/docs/project-overview.md
@@ -10,10 +10,10 @@ The codebase follows a five-layer architecture. Each layer has a specific respon
 
 | Layer | Directory | Responsibility | Client |
 |-------|-----------|---------------|--------|
-| Client | `src/client/` | Low-level API wrappers | -- |
-| Resolver | `src/resolvers/` | Human ID to UUID conversion | LinearSdkClient |
+| Client | `src/client/` | Low-level API wrapper | -- |
+| Resolver | `src/resolvers/` | Human ID to UUID conversion | GraphQLClient |
 | Service | `src/services/` | Business logic and CRUD operations | GraphQLClient |
-| Command | `src/commands/` | CLI orchestration via Commander.js | Both (via `createContext()`) |
+| Command | `src/commands/` | CLI orchestration via Commander.js | GraphQLClient (via `createContext()`) |
 | Common | `src/common/` | Shared utilities, types, error handling | -- |
 
 Data flows in one direction:
@@ -29,7 +29,7 @@ Commands receive user input, resolve any identifiers to UUIDs through the resolv
 - **TypeScript** with strict mode enabled and no `any` types
 - **Node.js** >= 22.0.0, ES modules throughout
 - **Commander.js** v14.0.0 for CLI structure
-- **Linear SDK** v58.1.0 for the SDK client used in resolvers
+- **GraphQL** for the typed client backing every layer (resolvers and services)
 - **GraphQL Codegen** for type-safe query and mutation documents
 - **Vitest** for unit testing
 - **tsx** for development execution

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -61,17 +61,16 @@ Each architectural layer uses a different mock target. The rule is simple: mock 
 
 ### Resolver Tests
 
-Resolvers depend on `LinearSdkClient`. Mock the SDK methods it calls:
+Resolvers depend on `GraphQLClient`. Mock the `request` method it calls:
 
 ```typescript
-import type { LinearSdkClient } from "../../src/client/linear-client.js";
+import type { GraphQLClient } from "../../src/client/graphql-client.js";
 
-const mockSdk = {
-  teams: vi.fn().mockResolvedValue({
-    nodes: [{ id: "uuid-123", key: "ABC" }],
+const client = {
+  request: vi.fn().mockResolvedValue({
+    teams: { nodes: [{ id: "uuid-123", key: "ABC" }] },
   }),
-};
-const client = { sdk: mockSdk } as unknown as LinearSdkClient;
+} as unknown as GraphQLClient;
 ```
 
 ### Service Tests
@@ -100,10 +99,11 @@ expect(isUuid("ABC-123")).toBe(false);
 
 ### Client Tests
 
-Client tests mock the underlying network layer:
+Client tests mock the underlying network layer by stubbing global `fetch`:
 
 ```typescript
-const mockClient = { rawRequest: vi.fn() };
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
 ```
 
 ## Writing a New Test
@@ -116,34 +116,32 @@ Example resolver test:
 
 ```typescript
 import { describe, expect, it, vi } from "vitest";
-import type { LinearSdkClient } from "../../../src/client/linear-client.js";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import { resolveTeamId } from "../../../src/resolvers/team-resolver.js";
 
+// Queue one `{ teams: { nodes } }` response per expected request.
+function mockGqlClient(...results: Array<{ nodes: Array<{ id: string; key?: string; name?: string }> }>) {
+  const request = vi.fn();
+  for (const teams of results) request.mockResolvedValueOnce({ teams });
+  return { request } as unknown as GraphQLClient;
+}
+
 describe("resolveTeamId", () => {
-  it("should return UUID as-is", async () => {
-    const client = { sdk: {} } as unknown as LinearSdkClient;
+  it("should return UUID as-is without querying", async () => {
+    const client = mockGqlClient();
     const result = await resolveTeamId(client, "550e8400-e29b-41d4-a716-446655440000");
     expect(result).toBe("550e8400-e29b-41d4-a716-446655440000");
+    expect(client.request).not.toHaveBeenCalled();
   });
 
   it("should resolve team by key", async () => {
-    const mockSdk = {
-      teams: vi.fn().mockResolvedValue({
-        nodes: [{ id: "uuid-456", key: "ENG" }],
-      }),
-    };
-    const client = { sdk: mockSdk } as unknown as LinearSdkClient;
-
+    const client = mockGqlClient({ nodes: [{ id: "uuid-456", key: "ENG" }] });
     const result = await resolveTeamId(client, "ENG");
     expect(result).toBe("uuid-456");
   });
 
   it("should throw when team is not found", async () => {
-    const mockSdk = {
-      teams: vi.fn().mockResolvedValue({ nodes: [] }),
-    };
-    const client = { sdk: mockSdk } as unknown as LinearSdkClient;
-
+    const client = mockGqlClient({ nodes: [] }, { nodes: [] });
     await expect(resolveTeamId(client, "NOPE")).rejects.toThrow();
   });
 });

--- a/src/common/resolve-filters.ts
+++ b/src/common/resolve-filters.ts
@@ -20,7 +20,7 @@ import { omitUndefined } from "./object.js";
  * Validation order: format → dependency → date ranges → ID resolution.
  * Fails fast before making any API calls when input is invalid.
  *
- * @param ctx - Command context with SDK and GraphQL clients
+ * @param ctx - Command context with the GraphQL client
  * @param opts - Raw filter flags from CLI options
  * @returns Resolved filter options with UUIDs ready for buildIssueFilter()
  */

--- a/tests/unit/commands/attachments.test.ts
+++ b/tests/unit/commands/attachments.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../../src/common/context.js", () => ({
   createContext: vi.fn(() => ({
     gql: { request: vi.fn() },
-    sdk: {},
   })),
   getRootOpts: vi.fn(() => ({ apiToken: "test-token" })),
 }));

--- a/tests/unit/commands/comments.test.ts
+++ b/tests/unit/commands/comments.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../../src/common/context.js", () => ({
   createContext: vi.fn(() => ({
     gql: { request: vi.fn() },
-    sdk: { sdk: {} },
   })),
   getRootOpts: vi.fn(() => ({ apiToken: "test-token" })),
 }));

--- a/tests/unit/commands/documents.test.ts
+++ b/tests/unit/commands/documents.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../../src/common/context.js", () => ({
   createContext: vi.fn(() => ({
     gql: { request: vi.fn() },
-    sdk: { sdk: {} },
   })),
   getRootOpts: vi.fn(() => ({ apiToken: "test-token" })),
 }));

--- a/tests/unit/commands/initiatives.test.ts
+++ b/tests/unit/commands/initiatives.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../../src/common/context.js", () => ({
   createContext: vi.fn(() => ({
     gql: { request: vi.fn() },
-    sdk: { sdk: {} },
   })),
   getRootOpts: vi.fn(() => ({ apiToken: "test-token" })),
 }));

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -8,7 +8,6 @@ import { asUuid } from "../../../src/common/identifier.js";
 vi.mock("../../../src/common/context.js", () => ({
   createContext: vi.fn(() => ({
     gql: { request: vi.fn() },
-    sdk: { sdk: {} },
   })),
   getRootOpts: vi.fn(() => ({ apiToken: "test-token" })),
 }));

--- a/tests/unit/commands/labels.test.ts
+++ b/tests/unit/commands/labels.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../../src/common/context.js", () => ({
   createContext: vi.fn(() => ({
     gql: { request: vi.fn() },
-    sdk: { sdk: {} },
   })),
   getRootOpts: vi.fn(() => ({ apiToken: "test-token" })),
 }));

--- a/tests/unit/commands/projects.test.ts
+++ b/tests/unit/commands/projects.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../../src/common/context.js", () => ({
   createContext: vi.fn(() => ({
     gql: { request: vi.fn() },
-    sdk: { sdk: {} },
   })),
   getRootOpts: vi.fn(() => ({ apiToken: "test-token" })),
 }));

--- a/tests/unit/commands/teams.test.ts
+++ b/tests/unit/commands/teams.test.ts
@@ -4,7 +4,6 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 vi.mock("../../../src/common/context.js", () => ({
   createContext: vi.fn(() => ({
     gql: { request: vi.fn() },
-    sdk: { sdk: {} },
   })),
   getRootOpts: vi.fn(() => ({ apiToken: "test-token" })),
 }));


### PR DESCRIPTION
## What does this PR do?

Updates the architecture docs, dependency tables, and command-test context mocks to describe the current GraphQLClient-only design after the Linear SDK was dropped from the resolver layer. Docs now show resolvers using `GraphQLClient` with lean filter-based lookup queries, the dependency lists match `package.json` (`@linear/sdk` removed; `graphql` and `node-emoji` added), and the `createContext()`/test mocks reflect a `{ gql }`-only context.

Closes #210

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [x] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [ ] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Documentation and test-mock cleanup only; verified against source: dependency lists match `package.json`, the `resolveMilestoneId`/`createContext` signatures match the docs, and `linear-client.ts` no longer exists. Command tests still pass with the `sdk` mock property removed.

## Notes for reviewers

Pure docs + test-mock cleanup with no runtime behavior change. The `client.sdk.*` reference remaining in `docs/performance.md` is intentional — it illustrates the old "before" SDK pattern being contrasted against the new GraphQL approach.