### PR TITLE
perf(issues): batch-resolve assignee and IDs in create/update

### DIFF
--- a/graphql/queries/issues.graphql
+++ b/graphql/queries/issues.graphql
@@ -385,7 +385,7 @@ query BatchResolveForUpdate(
   $assigneeQuery: String
   $projectName: String
   $projectId: ID
-  $labelNames: [String!]
+  $labelFilter: IssueLabelFilter
   $statusName: String
   $cycleName: String
   $teamKey: String
@@ -420,10 +420,7 @@ query BatchResolveForUpdate(
     nodes {
       id
       name
-      projectMilestones(
-        filter: { name: { eqIgnoreCase: $milestoneName } }
-        first: 10
-      ) {
+      projectMilestones(filter: { name: { eq: $milestoneName } }, first: 10) {
         nodes {
           id
           name
@@ -432,7 +429,7 @@ query BatchResolveForUpdate(
     }
   }
 
-  labels: issueLabels(filter: { name: { in: $labelNames } }) {
+  labels: issueLabels(filter: $labelFilter) {
     nodes {
       id
       name
@@ -519,7 +516,7 @@ query BatchResolveForCreate(
   $assigneeQuery: String
   $projectName: String
   $projectId: ID
-  $labelNames: [String!]
+  $labelFilter: IssueLabelFilter
   $statusName: String
   $cycleName: String
   $milestoneName: String
@@ -527,13 +524,22 @@ query BatchResolveForCreate(
   $parentIssueNumber: Float
 ) {
   teams(
-    filter: { or: [{ key: { eq: $teamKey } }, { name: { eq: $teamName } }] }
+    filter: {
+      or: [
+        { key: { eq: $teamKey } }
+        { name: { eq: $teamName } }
+        { id: { eq: $teamId } }
+      ]
+    }
     first: 10
   ) {
     nodes {
       id
       key
       name
+      issueEstimationType
+      issueEstimationExtended
+      issueEstimationAllowZero
     }
   }
 
@@ -563,10 +569,7 @@ query BatchResolveForCreate(
     nodes {
       id
       name
-      projectMilestones(
-        filter: { name: { eqIgnoreCase: $milestoneName } }
-        first: 10
-      ) {
+      projectMilestones(filter: { name: { eq: $milestoneName } }, first: 10) {
         nodes {
           id
           name
@@ -575,7 +578,7 @@ query BatchResolveForCreate(
     }
   }
 
-  labels: issueLabels(filter: { name: { in: $labelNames } }) {
+  labels: issueLabels(filter: $labelFilter) {
     nodes {
       id
       name
@@ -661,7 +664,7 @@ query BatchResolveForSearch(
   $creatorQuery: String
   $projectName: String
   $projectId: ID
-  $labelNames: [String!]
+  $labelFilter: IssueLabelFilter
   $cycleName: String
   $parentTeamKey: String
   $parentIssueNumber: Float
@@ -733,7 +736,7 @@ query BatchResolveForSearch(
     }
   }
 
-  labels: issueLabels(filter: { name: { in: $labelNames } }) {
+  labels: issueLabels(filter: $labelFilter) {
     nodes {
       id
       name

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -23,20 +23,18 @@ import { resolveFilterOptions } from "../common/resolve-filters.js";
 import { buildPaginationOptions } from "../common/types.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import type { IssueRelationType } from "../gql/graphql.js";
-import { resolveCycleId } from "../resolvers/cycle-resolver.js";
+import {
+  type ResolveCreateIssueIdsInput,
+  type ResolvedUpdateIssueIds,
+  type ResolveUpdateIssueIdsInput,
+  resolveCreateIssueIds,
+  resolveUpdateIssueIds,
+  type UpdateIssueContext,
+} from "../resolvers/issue-mutation-resolver.js";
 import {
   resolveIssueEstimateContext,
   resolveIssueId,
 } from "../resolvers/issue-resolver.js";
-import { resolveLabelIds } from "../resolvers/label-resolver.js";
-import { resolveMilestoneId } from "../resolvers/milestone-resolver.js";
-import { resolveProjectId } from "../resolvers/project-resolver.js";
-import { resolveStatusId } from "../resolvers/status-resolver.js";
-import {
-  resolveTeamEstimateContext,
-  resolveTeamId,
-} from "../resolvers/team-resolver.js";
-import { resolveUserId } from "../resolvers/user-resolver.js";
 import {
   createDiscussionCommentReaction,
   deleteDiscussionComment,
@@ -1129,37 +1127,53 @@ export function setupIssuesCommands(program: Command): void {
             throw new Error("--team is required");
           }
 
-          const teamEstimateContext =
-            parsedEstimate !== undefined
-              ? await resolveTeamEstimateContext(ctx.gql, options.team)
-              : undefined;
+          if (options.projectMilestone && !options.project) {
+            throw new Error(
+              "--project-milestone requires --project to be specified",
+            );
+          }
 
-          const teamId = teamEstimateContext
-            ? teamEstimateContext.teamId
-            : await resolveTeamId(ctx.gql, options.team);
+          const idsInput: ResolveCreateIssueIdsInput = {
+            team: options.team,
+            withEstimateContext: parsedEstimate !== undefined,
+          };
+          if (options.assignee) idsInput.assignee = options.assignee;
+          if (options.project) idsInput.project = options.project;
+          if (options.labels) {
+            idsInput.labels = options.labels.split(",").map((l) => l.trim());
+          }
+          if (options.projectMilestone) {
+            idsInput.projectMilestone = options.projectMilestone;
+          }
+          if (options.cycle) idsInput.cycle = options.cycle;
+          if (options.status) idsInput.status = options.status;
+          if (options.parentTicket)
+            idsInput.parentTicket = options.parentTicket;
 
-          if (parsedEstimate !== undefined && teamEstimateContext) {
+          const ids = await resolveCreateIssueIds(ctx.gql, idsInput);
+
+          if (parsedEstimate !== undefined && ids.estimateContext) {
             validateEstimateAgainstTeamConfig(parsedEstimate, {
-              teamKey: teamEstimateContext.teamKey,
-              issueEstimationType: teamEstimateContext.issueEstimationType,
+              teamKey: ids.estimateContext.teamKey,
+              issueEstimationType: ids.estimateContext.issueEstimationType,
               issueEstimationExtended:
-                teamEstimateContext.issueEstimationExtended,
+                ids.estimateContext.issueEstimationExtended,
               issueEstimationAllowZero:
-                teamEstimateContext.issueEstimationAllowZero,
+                ids.estimateContext.issueEstimationAllowZero,
             });
           }
 
           const input: CreateIssueInput = {
             title,
-            teamId,
+            teamId: ids.teamId,
           };
 
           if (options.description) {
             input.description = options.description;
           }
 
-          if (options.assignee) {
-            input.assigneeId = await resolveUserId(ctx.gql, options.assignee);
+          if (ids.assigneeId) {
+            input.assigneeId = ids.assigneeId;
           }
 
           if (parsedPriority !== undefined) {
@@ -1170,49 +1184,28 @@ export function setupIssuesCommands(program: Command): void {
             input.estimate = parsedEstimate;
           }
 
-          if (options.project) {
-            input.projectId = await resolveProjectId(ctx.gql, options.project);
+          if (ids.projectId) {
+            input.projectId = ids.projectId;
           }
 
-          if (options.labels) {
-            const labelNames = options.labels.split(",").map((l) => l.trim());
-            input.labelIds = await resolveLabelIds(ctx.gql, labelNames);
+          if (ids.labelIds) {
+            input.labelIds = ids.labelIds;
           }
 
-          if (options.projectMilestone) {
-            if (!options.project) {
-              throw new Error(
-                "--project-milestone requires --project to be specified",
-              );
-            }
-            input.projectMilestoneId = await resolveMilestoneId(
-              ctx.gql,
-              options.projectMilestone,
-              options.project,
-            );
+          if (ids.projectMilestoneId) {
+            input.projectMilestoneId = ids.projectMilestoneId;
           }
 
-          if (options.cycle) {
-            input.cycleId = await resolveCycleId(
-              ctx.gql,
-              options.cycle,
-              options.team,
-            );
+          if (ids.cycleId) {
+            input.cycleId = ids.cycleId;
           }
 
-          if (options.status) {
-            input.stateId = await resolveStatusId(
-              ctx.gql,
-              options.status,
-              teamId,
-            );
+          if (ids.stateId) {
+            input.stateId = ids.stateId;
           }
 
-          if (options.parentTicket) {
-            input.parentId = await resolveIssueId(
-              ctx.gql,
-              options.parentTicket,
-            );
+          if (ids.parentId) {
+            input.parentId = ids.parentId;
           }
 
           if (options.dueDate) {
@@ -1354,6 +1347,51 @@ export function setupIssuesCommands(program: Command): void {
             ? await getIssue(ctx.gql, resolvedIssueId)
             : undefined;
 
+          const updContext: UpdateIssueContext = {};
+          if (issueContext && "team" in issueContext && issueContext.team) {
+            updContext.teamId = asUuid(issueContext.team.id);
+            if (issueContext.team.key) {
+              updContext.teamKey = issueContext.team.key;
+            }
+          }
+          if (
+            issueContext &&
+            "project" in issueContext &&
+            issueContext.project?.name
+          ) {
+            updContext.projectName = issueContext.project.name;
+          }
+
+          const updIdsInput: ResolveUpdateIssueIdsInput = {};
+          if (options.assignee) updIdsInput.assignee = options.assignee;
+          if (options.project) updIdsInput.project = options.project;
+          if (!options.clearLabels && options.labels) {
+            updIdsInput.labels = options.labels.split(",").map((l) => l.trim());
+          }
+          if (!options.clearProjectMilestone && options.projectMilestone) {
+            updIdsInput.projectMilestone = options.projectMilestone;
+          }
+          if (!options.clearCycle && options.cycle) {
+            updIdsInput.cycle = options.cycle;
+          }
+          if (options.status) updIdsInput.status = options.status;
+          if (!options.clearParentTicket && options.parentTicket) {
+            updIdsInput.parentTicket = options.parentTicket;
+          }
+
+          const needsResolution =
+            updIdsInput.assignee !== undefined ||
+            updIdsInput.project !== undefined ||
+            updIdsInput.labels !== undefined ||
+            updIdsInput.projectMilestone !== undefined ||
+            updIdsInput.cycle !== undefined ||
+            updIdsInput.status !== undefined ||
+            updIdsInput.parentTicket !== undefined;
+
+          const ids: ResolvedUpdateIssueIds = needsResolution
+            ? await resolveUpdateIssueIds(ctx.gql, updIdsInput, updContext)
+            : {};
+
           const input: UpdateIssueInput = {};
 
           if (options.title) {
@@ -1364,16 +1402,8 @@ export function setupIssuesCommands(program: Command): void {
             input.description = options.description;
           }
 
-          if (options.status) {
-            const teamId =
-              issueContext && "team" in issueContext && issueContext.team
-                ? asUuid(issueContext.team.id)
-                : undefined;
-            input.stateId = await resolveStatusId(
-              ctx.gql,
-              options.status,
-              teamId,
-            );
+          if (ids.stateId) {
+            input.stateId = ids.stateId;
           }
 
           if (parsedPriority !== undefined) {
@@ -1386,35 +1416,28 @@ export function setupIssuesCommands(program: Command): void {
             input.estimate = parsedEstimate;
           }
 
-          if (options.assignee) {
-            input.assigneeId = await resolveUserId(ctx.gql, options.assignee);
+          if (ids.assigneeId) {
+            input.assigneeId = ids.assigneeId;
           }
 
-          if (options.project) {
-            input.projectId = await resolveProjectId(ctx.gql, options.project);
+          if (ids.projectId) {
+            input.projectId = ids.projectId;
           }
 
           if (options.clearLabels) {
             input.labelIds = [];
-          } else if (options.labels) {
-            const labelNames = options.labels.split(",").map((l) => l.trim());
-            const labelIds = await resolveLabelIds(ctx.gql, labelNames);
+          } else if (options.labels && ids.labelIds) {
+            const labelIds = ids.labelIds;
+            const currentLabels =
+              issueContext &&
+              "labels" in issueContext &&
+              issueContext.labels?.nodes
+                ? issueContext.labels.nodes.map((l) => asUuid(l.id))
+                : [];
 
             if (labelMode === "add") {
-              const currentLabels =
-                issueContext &&
-                "labels" in issueContext &&
-                issueContext.labels?.nodes
-                  ? issueContext.labels.nodes.map((l) => asUuid(l.id))
-                  : [];
               input.labelIds = [...new Set([...currentLabels, ...labelIds])];
             } else if (labelMode === "remove") {
-              const currentLabels =
-                issueContext &&
-                "labels" in issueContext &&
-                issueContext.labels?.nodes
-                  ? issueContext.labels.nodes.map((l) => asUuid(l.id))
-                  : [];
               input.labelIds = currentLabels.filter(
                 (id) => !labelIds.includes(id),
               );
@@ -1425,41 +1448,20 @@ export function setupIssuesCommands(program: Command): void {
 
           if (options.clearParentTicket) {
             input.parentId = null;
-          } else if (options.parentTicket) {
-            input.parentId = await resolveIssueId(
-              ctx.gql,
-              options.parentTicket,
-            );
+          } else if (ids.parentId) {
+            input.parentId = ids.parentId;
           }
 
           if (options.clearProjectMilestone) {
             input.projectMilestoneId = null;
-          } else if (options.projectMilestone) {
-            const projectName =
-              issueContext &&
-              "project" in issueContext &&
-              issueContext.project?.name
-                ? issueContext.project.name
-                : undefined;
-            input.projectMilestoneId = await resolveMilestoneId(
-              ctx.gql,
-              options.projectMilestone,
-              projectName,
-            );
+          } else if (ids.projectMilestoneId) {
+            input.projectMilestoneId = ids.projectMilestoneId;
           }
 
           if (options.clearCycle) {
             input.cycleId = null;
-          } else if (options.cycle) {
-            const teamKey =
-              issueContext && "team" in issueContext && issueContext.team?.key
-                ? issueContext.team.key
-                : undefined;
-            input.cycleId = await resolveCycleId(
-              ctx.gql,
-              options.cycle,
-              teamKey,
-            );
+          } else if (ids.cycleId) {
+            input.cycleId = ids.cycleId;
           }
 
           if (options.clearDueDate) {

--- a/src/resolvers/batch-resolve-mappers.ts
+++ b/src/resolvers/batch-resolve-mappers.ts
@@ -1,0 +1,173 @@
+import { multipleMatchesError, notFoundError } from "../common/errors.js";
+import { asUuid, isUuid, type UUID } from "../common/identifier.js";
+import type {
+  BatchResolveForCreateQuery,
+  IssueLabelFilter,
+} from "../gql/graphql.js";
+
+/**
+ * Pure mappers shared by the batch resolvers (issue create/update and issue
+ * search). Each turns a `BatchResolve*` response collection into resolved
+ * UUIDs, reproducing the exact disambiguation / not-found / UUID-passthrough
+ * semantics of the corresponding single-entity resolver.
+ *
+ * The three batch queries select identical node shapes, so the aliases below
+ * (derived from `BatchResolveForCreate`) apply to all of them structurally.
+ */
+
+export type TeamNode = BatchResolveForCreateQuery["teams"]["nodes"][number];
+export type UserNode = BatchResolveForCreateQuery["assignees"]["nodes"][number];
+export type ProjectNode =
+  BatchResolveForCreateQuery["projects"]["nodes"][number];
+export type MilestoneNode = ProjectNode["projectMilestones"]["nodes"][number];
+export type LabelNode = BatchResolveForCreateQuery["labels"]["nodes"][number];
+export type StatusNode =
+  BatchResolveForCreateQuery["statuses"]["nodes"][number];
+export type CycleNode = BatchResolveForCreateQuery["cycles"]["nodes"][number];
+export type ParentNode =
+  BatchResolveForCreateQuery["parentIssues"]["nodes"][number];
+
+/**
+ * Builds an `IssueLabelFilter` matching each name case-insensitively (mirroring
+ * `resolveLabelId`'s `eqIgnoreCase`). An empty list yields a filter that matches
+ * nothing, so the batch query's `labels` field stays cheap when no labels are
+ * requested.
+ */
+export function buildLabelFilter(names: string[]): IssueLabelFilter {
+  if (names.length === 0) return { name: { in: [] } };
+  return { or: names.map((name) => ({ name: { eqIgnoreCase: name } })) };
+}
+
+/**
+ * Two-phase user precedence, replicated purely from the `or:[displayName,email]`
+ * result: an exact (case-insensitive) display-name match wins; multiple name
+ * matches are ambiguous; otherwise the first email match is used. Matches
+ * `resolveUserId`.
+ */
+export function mapUser(nodes: UserNode[], query: string): UUID {
+  const lower = query.toLowerCase();
+
+  const byName = nodes.filter((n) => n.displayName.toLowerCase() === lower);
+  if (byName.length === 1) return asUuid((byName[0] as UserNode).id);
+  if (byName.length > 1) {
+    throw multipleMatchesError(
+      "User",
+      query,
+      byName.map((u) => `${u.name} <${u.email}>`),
+      "Use email or UUID to disambiguate",
+    );
+  }
+
+  const byEmail = nodes.find((n) => n.email.toLowerCase() === lower);
+  if (byEmail) return asUuid(byEmail.id);
+
+  throw notFoundError("User", query);
+}
+
+/** Matches `resolveProjectId`: exactly one match, else not-found / ambiguous. */
+export function mapProjectNode(
+  nodes: ProjectNode[],
+  query: string,
+): ProjectNode {
+  if (nodes.length === 0) throw notFoundError("Project", query);
+  if (nodes.length > 1) {
+    throw multipleMatchesError(
+      "Project",
+      query,
+      nodes.map((project) => project.id),
+      "provide project UUID",
+    );
+  }
+  return nodes[0] as ProjectNode;
+}
+
+/** Convenience wrapper: {@link mapProjectNode} returning just the UUID. */
+export function mapProjectId(nodes: ProjectNode[], query: string): UUID {
+  return asUuid(mapProjectNode(nodes, query).id);
+}
+
+/** Matches `resolveLabelIds`: UUID passthrough, else case-insensitive name → id. */
+export function mapLabels(requested: string[], nodes: LabelNode[]): UUID[] {
+  return requested.map((label) => {
+    if (isUuid(label)) return asUuid(label);
+    const match = nodes.find(
+      (n) => n.name.toLowerCase() === label.toLowerCase(),
+    );
+    if (!match) throw notFoundError("Label", label);
+    return asUuid(match.id);
+  });
+}
+
+/** Matches `resolveStatusId`: first match, scoped not-found context. */
+export function mapStatus(
+  nodes: StatusNode[],
+  query: string,
+  teamContext: string | undefined,
+): UUID {
+  const first = nodes[0];
+  if (!first) throw notFoundError("Status", query, teamContext);
+  return asUuid(first.id);
+}
+
+/** Matches `resolveCycleId`: prefer active > next > previous, else ambiguous. */
+export function mapCycle(
+  nodes: CycleNode[],
+  query: string,
+  teamLabel: string | undefined,
+): UUID {
+  if (nodes.length === 0) {
+    throw notFoundError(
+      "Cycle",
+      query,
+      teamLabel ? `for team ${teamLabel}` : undefined,
+    );
+  }
+
+  let chosen =
+    nodes.find((n) => n.isActive) ??
+    nodes.find((n) => n.isNext) ??
+    nodes.find((n) => n.isPrevious);
+  if (!chosen && nodes.length === 1) chosen = nodes[0];
+
+  if (!chosen) {
+    const matches = nodes.map(
+      (n) =>
+        `${n.id} (${n.team?.key || "?"} / #${n.number} / ${
+          n.startsAt ? new Date(n.startsAt).toISOString() : undefined
+        })`,
+    );
+    throw multipleMatchesError(
+      "cycle",
+      query,
+      matches,
+      "use an ID or scope with --team",
+    );
+  }
+
+  return asUuid(chosen.id);
+}
+
+/** Matches `resolveMilestoneId` scoped to a single project's milestones. */
+export function mapMilestone(
+  nodes: MilestoneNode[],
+  query: string,
+  projectName: string | undefined,
+): UUID {
+  if (nodes.length === 0) throw notFoundError("Milestone", query);
+  if (nodes.length > 1) {
+    throw multipleMatchesError(
+      "milestone",
+      query,
+      nodes.map((m) => `"${m.name}" in project "${projectName ?? "?"}"`),
+      "specify --project or use the milestone ID",
+    );
+  }
+  return asUuid((nodes[0] as MilestoneNode).id);
+}
+
+/** Matches `resolveIssueId`: first match or not-found (UUID handled by caller). */
+export function mapParent(nodes: ParentNode[], query: string): UUID {
+  const first = nodes[0];
+  if (!first) throw notFoundError("Issue", query);
+  return asUuid(first.id);
+}

--- a/src/resolvers/issue-filter-resolver.ts
+++ b/src/resolvers/issue-filter-resolver.ts
@@ -1,12 +1,21 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
-import type { UUID } from "../common/identifier.js";
-import { resolveCycleId } from "./cycle-resolver.js";
-import { resolveIssueId } from "./issue-resolver.js";
-import { resolveLabelIds } from "./label-resolver.js";
-import { resolveProjectId } from "./project-resolver.js";
+import { notFoundError } from "../common/errors.js";
+import {
+  asUuid,
+  isUuid,
+  parseIssueIdentifier,
+  type UUID,
+} from "../common/identifier.js";
+import { BatchResolveForSearchDocument } from "../gql/graphql.js";
+import {
+  buildLabelFilter,
+  mapCycle,
+  mapLabels,
+  mapParent,
+  mapProjectId,
+  mapUser,
+} from "./batch-resolve-mappers.js";
 import { resolveStatusId } from "./status-resolver.js";
-import { resolveTeamId } from "./team-resolver.js";
-import { resolveUserId } from "./user-resolver.js";
 
 export interface SearchFilterResolutionInput {
   team?: string;
@@ -30,51 +39,125 @@ export interface SearchFilterResolution {
   parentId?: UUID;
 }
 
+/**
+ * Resolves every human identifier in a search filter in a single
+ * `BatchResolveForSearch` request, preserving the exact semantics of the
+ * individual resolvers via the shared batch mappers.
+ *
+ * Statuses are the one exception: the batch query returns the workflow states
+ * of the scoped team (matched client-side by name). When no team is given — or
+ * a name is not among the returned states — resolution falls back to
+ * `resolveStatusId`, which matches globally, so status filtering without a team
+ * keeps working.
+ */
 export async function resolveSearchFilterIds(
   gqlClient: GraphQLClient,
   input: SearchFilterResolutionInput,
 ): Promise<SearchFilterResolution> {
+  const team = input.team;
+  const teamIsUuid = team ? isUuid(team) : false;
+
+  const assigneeQuery =
+    input.assignee && !isUuid(input.assignee) ? input.assignee : null;
+  const creatorQuery =
+    input.creator && !isUuid(input.creator) ? input.creator : null;
+  const projectName =
+    input.project && !isUuid(input.project) ? input.project : null;
+  const projectIdVar =
+    input.project && isUuid(input.project) ? input.project : null;
+  const cycleName = input.cycle && !isUuid(input.cycle) ? input.cycle : null;
+  const labelNames = (input.labelNames ?? []).filter((l) => !isUuid(l));
+
+  const parent =
+    input.parent && !isUuid(input.parent)
+      ? parseIssueIdentifier(input.parent)
+      : null;
+
+  const response = await gqlClient.request(BatchResolveForSearchDocument, {
+    teamKey: team && !teamIsUuid ? team : null,
+    teamName: team && !teamIsUuid ? team : null,
+    teamId: team && teamIsUuid ? team : null,
+    assigneeQuery,
+    creatorQuery,
+    projectName,
+    projectId: projectIdVar,
+    labelFilter: buildLabelFilter(labelNames),
+    cycleName,
+    parentTeamKey: parent?.teamKey ?? null,
+    parentIssueNumber: parent?.issueNumber ?? null,
+    milestoneName: null,
+  });
+
   const resolved: SearchFilterResolution = {};
 
-  if (input.team) {
-    resolved.teamId = await resolveTeamId(gqlClient, input.team);
+  if (team) {
+    resolved.teamId = teamIsUuid
+      ? asUuid(team)
+      : mapSearchTeamId(response.teams.nodes, team);
   }
 
   if (input.assignee) {
-    resolved.assigneeId = await resolveUserId(gqlClient, input.assignee);
+    resolved.assigneeId = isUuid(input.assignee)
+      ? asUuid(input.assignee)
+      : mapUser(response.assignees.nodes, input.assignee);
   }
 
   if (input.creator) {
-    resolved.creatorId = await resolveUserId(gqlClient, input.creator);
+    resolved.creatorId = isUuid(input.creator)
+      ? asUuid(input.creator)
+      : mapUser(response.creators.nodes, input.creator);
   }
 
   if (input.project) {
-    resolved.projectId = await resolveProjectId(gqlClient, input.project);
+    resolved.projectId = isUuid(input.project)
+      ? asUuid(input.project)
+      : mapProjectId(response.projects.nodes, input.project);
   }
 
   if (input.statusNames && input.statusNames.length > 0) {
     resolved.stateIds = await Promise.all(
-      input.statusNames.map((status) =>
-        resolveStatusId(gqlClient, status, resolved.teamId),
-      ),
+      input.statusNames.map((name) => {
+        if (isUuid(name)) return asUuid(name);
+        const match = response.statuses.nodes.find(
+          (n) => n.name.toLowerCase() === name.toLowerCase(),
+        );
+        if (match) return asUuid(match.id);
+        // Not among the scoped team's states (or no team given) — resolve
+        // individually to match globally, as resolveStatusId did before.
+        return resolveStatusId(gqlClient, name, resolved.teamId);
+      }),
     );
   }
 
   if (input.labelNames && input.labelNames.length > 0) {
-    resolved.labelIds = await resolveLabelIds(gqlClient, input.labelNames);
+    resolved.labelIds = mapLabels(input.labelNames, response.labels.nodes);
   }
 
   if (input.cycle) {
-    resolved.cycleId = await resolveCycleId(
-      gqlClient,
-      input.cycle,
-      resolved.teamId ?? input.team,
-    );
+    resolved.cycleId = isUuid(input.cycle)
+      ? asUuid(input.cycle)
+      : mapCycle(
+          response.cycles.nodes,
+          input.cycle,
+          resolved.teamId ?? input.team,
+        );
   }
 
   if (input.parent) {
-    resolved.parentId = await resolveIssueId(gqlClient, input.parent);
+    resolved.parentId = isUuid(input.parent)
+      ? asUuid(input.parent)
+      : mapParent(response.parentIssues.nodes, input.parent);
   }
 
   return resolved;
+}
+
+type SearchTeamNode = { id: string; key: string; name: string };
+
+/** Mirrors resolveTeamId: prefer key match, then name; else not-found. */
+function mapSearchTeamId(nodes: SearchTeamNode[], raw: string): UUID {
+  const match =
+    nodes.find((n) => n.key === raw) ?? nodes.find((n) => n.name === raw);
+  if (!match) throw notFoundError("Team", raw);
+  return asUuid(match.id);
 }

--- a/src/resolvers/issue-filter-resolver.ts
+++ b/src/resolvers/issue-filter-resolver.ts
@@ -15,6 +15,7 @@ import {
   mapProjectId,
   mapUser,
 } from "./batch-resolve-mappers.js";
+import { resolveCycleId } from "./cycle-resolver.js";
 import { resolveStatusId } from "./status-resolver.js";
 
 export interface SearchFilterResolutionInput {
@@ -44,11 +45,11 @@ export interface SearchFilterResolution {
  * `BatchResolveForSearch` request, preserving the exact semantics of the
  * individual resolvers via the shared batch mappers.
  *
- * Statuses are the one exception: the batch query returns the workflow states
- * of the scoped team (matched client-side by name). When no team is given — or
- * a name is not among the returned states — resolution falls back to
- * `resolveStatusId`, which matches globally, so status filtering without a team
- * keeps working.
+ * Statuses and cycles are the exception: the batch query scopes both to the
+ * team (matched client-side by name). When no team is given — or the name is
+ * not among the returned nodes — resolution falls back to `resolveStatusId` /
+ * `resolveCycleId`, which match globally, so filtering by status or cycle name
+ * without a team keeps working.
  */
 export async function resolveSearchFilterIds(
   gqlClient: GraphQLClient,
@@ -134,13 +135,24 @@ export async function resolveSearchFilterIds(
   }
 
   if (input.cycle) {
-    resolved.cycleId = isUuid(input.cycle)
-      ? asUuid(input.cycle)
-      : mapCycle(
-          response.cycles.nodes,
-          input.cycle,
-          resolved.teamId ?? input.team,
-        );
+    if (isUuid(input.cycle)) {
+      resolved.cycleId = asUuid(input.cycle);
+    } else if (response.cycles.nodes.length > 0) {
+      resolved.cycleId = mapCycle(
+        response.cycles.nodes,
+        input.cycle,
+        resolved.teamId ?? input.team,
+      );
+    } else {
+      // No cycles in the batch response (the query scopes them to a team, so
+      // this is the no-team case) — resolve individually to match globally, as
+      // resolveCycleId did before.
+      resolved.cycleId = await resolveCycleId(
+        gqlClient,
+        input.cycle,
+        resolved.teamId ?? input.team,
+      );
+    }
   }
 
   if (input.parent) {

--- a/src/resolvers/issue-mutation-resolver.ts
+++ b/src/resolvers/issue-mutation-resolver.ts
@@ -1,0 +1,370 @@
+import type { GraphQLClient } from "../client/graphql-client.js";
+import { notFoundError } from "../common/errors.js";
+import {
+  asUuid,
+  isUuid,
+  parseIssueIdentifier,
+  type UUID,
+} from "../common/identifier.js";
+import {
+  BatchResolveForCreateDocument,
+  BatchResolveForUpdateDocument,
+} from "../gql/graphql.js";
+import {
+  buildLabelFilter,
+  mapCycle,
+  mapLabels,
+  mapMilestone,
+  mapParent,
+  mapProjectNode,
+  mapStatus,
+  mapUser,
+  type ProjectNode,
+  type TeamNode,
+} from "./batch-resolve-mappers.js";
+import type { TeamEstimateContext } from "./team-resolver.js";
+
+/**
+ * Batch resolver for issue create / update.
+ *
+ * Replaces the per-field sequential resolver calls (`resolveTeamId`,
+ * `resolveUserId`, `resolveProjectId`, …) with a single `BatchResolve*`
+ * GraphQL request, then maps the response back to UUIDs while preserving the
+ * exact disambiguation, not-found and UUID-passthrough semantics of each
+ * individual resolver.
+ *
+ * Create resolves everything in one request. Update inherently needs two
+ * sequential requests — the target issue must be fetched first (its team /
+ * project scope the status / cycle / milestone lookups) — the caller supplies
+ * that context via {@link UpdateIssueContext}.
+ */
+
+const TEAM_ESTIMATION_TYPES = [
+  "notUsed",
+  "exponential",
+  "fibonacci",
+  "linear",
+  "tShirt",
+] as const;
+
+type TeamEstimationType = (typeof TEAM_ESTIMATION_TYPES)[number];
+
+function narrowEstimationType(
+  value: string,
+  teamLabel: string,
+): TeamEstimationType {
+  if ((TEAM_ESTIMATION_TYPES as readonly string[]).includes(value)) {
+    return value as TeamEstimationType;
+  }
+  throw new Error(`Team "${teamLabel}" is missing required estimation context`);
+}
+
+// --- Create -----------------------------------------------------------------
+
+export interface ResolveCreateIssueIdsInput {
+  /** Team key, name or UUID. Required for create. */
+  team: string;
+  assignee?: string;
+  project?: string;
+  labels?: string[];
+  /** Milestone name or UUID; requires {@link ResolveCreateIssueIdsInput.project}. */
+  projectMilestone?: string;
+  cycle?: string;
+  status?: string;
+  parentTicket?: string;
+  /** When true, resolve the team's estimation config for `--estimate` validation. */
+  withEstimateContext?: boolean;
+}
+
+export interface ResolvedCreateIssueIds {
+  teamId: UUID;
+  estimateContext?: TeamEstimateContext;
+  assigneeId?: UUID;
+  projectId?: UUID;
+  labelIds?: UUID[];
+  projectMilestoneId?: UUID;
+  cycleId?: UUID;
+  stateId?: UUID;
+  parentId?: UUID;
+}
+
+/**
+ * Resolves every human identifier needed to create an issue in a single
+ * `BatchResolveForCreate` request.
+ */
+export async function resolveCreateIssueIds(
+  client: GraphQLClient,
+  input: ResolveCreateIssueIdsInput,
+): Promise<ResolvedCreateIssueIds> {
+  const teamIsUuid = isUuid(input.team);
+  const assigneeQuery =
+    input.assignee && !isUuid(input.assignee) ? input.assignee : null;
+  const projectName =
+    input.project && !isUuid(input.project) ? input.project : null;
+  const projectIdVar =
+    input.project && isUuid(input.project) ? input.project : null;
+  const milestoneName =
+    input.projectMilestone && !isUuid(input.projectMilestone)
+      ? input.projectMilestone
+      : null;
+  const statusName =
+    input.status && !isUuid(input.status) ? input.status : null;
+  const cycleName = input.cycle && !isUuid(input.cycle) ? input.cycle : null;
+  const labelNames = (input.labels ?? []).filter((l) => !isUuid(l));
+
+  const parent =
+    input.parentTicket && !isUuid(input.parentTicket)
+      ? parseIssueIdentifier(input.parentTicket)
+      : null;
+
+  const response = await client.request(BatchResolveForCreateDocument, {
+    teamKey: teamIsUuid ? null : input.team,
+    teamName: teamIsUuid ? null : input.team,
+    teamId: teamIsUuid ? input.team : null,
+    assigneeQuery,
+    projectName,
+    projectId: projectIdVar,
+    labelFilter: buildLabelFilter(labelNames),
+    statusName,
+    cycleName,
+    milestoneName,
+    parentTeamKey: parent?.teamKey ?? null,
+    parentIssueNumber: parent?.issueNumber ?? null,
+  });
+
+  // Team (required). Prefer key match, then name, then id — mirrors resolveTeamId.
+  const teamNode = teamIsUuid
+    ? response.teams.nodes.find((n) => n.id === input.team)
+    : findTeamNode(response.teams.nodes, input.team);
+  const teamId: UUID =
+    teamIsUuid && !teamNode
+      ? asUuid(input.team)
+      : asUuid(requireTeam(teamNode, input.team).id);
+
+  const resolved: ResolvedCreateIssueIds = { teamId };
+
+  if (input.withEstimateContext) {
+    const node = requireTeam(teamNode, input.team);
+    resolved.estimateContext = {
+      teamId: asUuid(node.id),
+      teamKey: node.key,
+      teamName: node.name,
+      issueEstimationType: narrowEstimationType(
+        node.issueEstimationType,
+        input.team,
+      ),
+      issueEstimationExtended: node.issueEstimationExtended,
+      issueEstimationAllowZero: node.issueEstimationAllowZero,
+    };
+  }
+
+  if (input.assignee) {
+    resolved.assigneeId = isUuid(input.assignee)
+      ? asUuid(input.assignee)
+      : mapUser(response.assignees.nodes, input.assignee);
+  }
+
+  let matchedProject: ProjectNode | undefined;
+  if (input.project) {
+    if (isUuid(input.project)) {
+      resolved.projectId = asUuid(input.project);
+      matchedProject = response.projects.nodes.find(
+        (n) => n.id === input.project,
+      );
+    } else {
+      matchedProject = mapProjectNode(response.projects.nodes, input.project);
+      resolved.projectId = asUuid(matchedProject.id);
+    }
+  }
+
+  if (input.labels && input.labels.length > 0) {
+    resolved.labelIds = mapLabels(input.labels, response.labels.nodes);
+  }
+
+  if (input.projectMilestone) {
+    resolved.projectMilestoneId = isUuid(input.projectMilestone)
+      ? asUuid(input.projectMilestone)
+      : mapMilestone(
+          matchedProject?.projectMilestones.nodes ?? [],
+          input.projectMilestone,
+          matchedProject?.name,
+        );
+  }
+
+  if (input.cycle) {
+    resolved.cycleId = isUuid(input.cycle)
+      ? asUuid(input.cycle)
+      : mapCycle(response.cycles.nodes, input.cycle, input.team);
+  }
+
+  if (input.status) {
+    resolved.stateId = isUuid(input.status)
+      ? asUuid(input.status)
+      : mapStatus(response.statuses.nodes, input.status, `for team ${teamId}`);
+  }
+
+  if (input.parentTicket) {
+    resolved.parentId = isUuid(input.parentTicket)
+      ? asUuid(input.parentTicket)
+      : mapParent(response.parentIssues.nodes, input.parentTicket);
+  }
+
+  return resolved;
+}
+
+function findTeamNode(nodes: TeamNode[], raw: string): TeamNode | undefined {
+  return nodes.find((n) => n.key === raw) ?? nodes.find((n) => n.name === raw);
+}
+
+function requireTeam(node: TeamNode | undefined, raw: string): TeamNode {
+  if (!node) throw notFoundError("Team", raw);
+  return node;
+}
+
+// --- Update -----------------------------------------------------------------
+
+/** Context derived from the target issue (already fetched) that scopes lookups. */
+export interface UpdateIssueContext {
+  /** The issue's team UUID — scopes status / cycle resolution. */
+  teamId?: UUID;
+  /** The issue's team key — used in cycle not-found messages. */
+  teamKey?: string;
+  /** The issue's current project name — scopes milestone resolution. */
+  projectName?: string;
+}
+
+export interface ResolveUpdateIssueIdsInput {
+  assignee?: string;
+  project?: string;
+  labels?: string[];
+  projectMilestone?: string;
+  cycle?: string;
+  status?: string;
+  parentTicket?: string;
+}
+
+export interface ResolvedUpdateIssueIds {
+  assigneeId?: UUID;
+  projectId?: UUID;
+  /** Resolved label UUIDs (add/remove/overwrite set math stays in the command). */
+  labelIds?: UUID[];
+  projectMilestoneId?: UUID;
+  cycleId?: UUID;
+  stateId?: UUID;
+  parentId?: UUID;
+}
+
+/**
+ * Resolves the new values for an issue update in a single
+ * `BatchResolveForUpdate` request. Status / cycle / milestone are scoped by the
+ * target issue's own team / project supplied in {@link UpdateIssueContext}.
+ *
+ * When both `--project` and `--project-milestone` are given, the milestone is
+ * resolved within the *new* project (an intentional improvement over the prior
+ * behavior, which scoped it to the issue's old project).
+ */
+export async function resolveUpdateIssueIds(
+  client: GraphQLClient,
+  input: ResolveUpdateIssueIdsInput,
+  context: UpdateIssueContext,
+): Promise<ResolvedUpdateIssueIds> {
+  const assigneeQuery =
+    input.assignee && !isUuid(input.assignee) ? input.assignee : null;
+
+  // projectName scopes both --project resolution and milestone lookup: the new
+  // project when --project is a name, else the issue's current project.
+  const projectNameVar =
+    input.project && !isUuid(input.project)
+      ? input.project
+      : (context.projectName ?? null);
+  const projectIdVar =
+    input.project && isUuid(input.project) ? input.project : null;
+
+  const milestoneName =
+    input.projectMilestone && !isUuid(input.projectMilestone)
+      ? input.projectMilestone
+      : null;
+  const statusName =
+    input.status && !isUuid(input.status) ? input.status : null;
+  const cycleName = input.cycle && !isUuid(input.cycle) ? input.cycle : null;
+  const labelNames = (input.labels ?? []).filter((l) => !isUuid(l));
+
+  const parent =
+    input.parentTicket && !isUuid(input.parentTicket)
+      ? parseIssueIdentifier(input.parentTicket)
+      : null;
+
+  const response = await client.request(BatchResolveForUpdateDocument, {
+    assigneeQuery,
+    projectName: projectNameVar,
+    projectId: projectIdVar,
+    labelFilter: buildLabelFilter(labelNames),
+    statusName,
+    cycleName,
+    teamKey: context.teamKey ?? null,
+    teamId: context.teamId ?? null,
+    milestoneName,
+    parentTeamKey: parent?.teamKey ?? null,
+    parentIssueNumber: parent?.issueNumber ?? null,
+  });
+
+  const resolved: ResolvedUpdateIssueIds = {};
+
+  if (input.assignee) {
+    resolved.assigneeId = isUuid(input.assignee)
+      ? asUuid(input.assignee)
+      : mapUser(response.assignees.nodes, input.assignee);
+  }
+
+  // The projects field matches by projectNameVar/projectIdVar; the matched node
+  // is reused for milestone scoping.
+  const matchedProject: ProjectNode | undefined = isUuid(input.project ?? "")
+    ? response.projects.nodes.find((n) => n.id === input.project)
+    : response.projects.nodes.find(
+        (n) => n.name.toLowerCase() === (projectNameVar ?? "").toLowerCase(),
+      );
+
+  if (input.project) {
+    resolved.projectId = isUuid(input.project)
+      ? asUuid(input.project)
+      : asUuid(mapProjectNode(response.projects.nodes, input.project).id);
+  }
+
+  if (input.labels && input.labels.length > 0) {
+    resolved.labelIds = mapLabels(input.labels, response.labels.nodes);
+  }
+
+  if (input.projectMilestone) {
+    resolved.projectMilestoneId = isUuid(input.projectMilestone)
+      ? asUuid(input.projectMilestone)
+      : mapMilestone(
+          matchedProject?.projectMilestones.nodes ?? [],
+          input.projectMilestone,
+          matchedProject?.name ?? projectNameVar ?? undefined,
+        );
+  }
+
+  if (input.cycle) {
+    resolved.cycleId = isUuid(input.cycle)
+      ? asUuid(input.cycle)
+      : mapCycle(response.cycles.nodes, input.cycle, context.teamKey);
+  }
+
+  if (input.status) {
+    resolved.stateId = isUuid(input.status)
+      ? asUuid(input.status)
+      : mapStatus(
+          response.statuses.nodes,
+          input.status,
+          context.teamId ? `for team ${context.teamId}` : undefined,
+        );
+  }
+
+  if (input.parentTicket) {
+    resolved.parentId = isUuid(input.parentTicket)
+      ? asUuid(input.parentTicket)
+      : mapParent(response.parentIssues.nodes, input.parentTicket);
+  }
+
+  return resolved;
+}

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -21,20 +21,13 @@ vi.mock("../../../src/common/output.js", async (importOriginal) => {
   };
 });
 
-vi.mock("../../../src/resolvers/user-resolver.js", () => ({
-  resolveUserId: vi.fn().mockResolvedValue("resolved-user-uuid"),
+vi.mock("../../../src/resolvers/issue-mutation-resolver.js", () => ({
+  resolveCreateIssueIds: vi.fn(),
+  resolveUpdateIssueIds: vi.fn(),
 }));
 
-vi.mock("../../../src/resolvers/team-resolver.js", () => ({
-  resolveTeamId: vi.fn().mockResolvedValue("resolved-team-uuid"),
-  resolveTeamEstimateContext: vi.fn().mockResolvedValue({
-    teamId: "resolved-team-uuid",
-    teamKey: "ENG",
-    teamName: "Engineering",
-    issueEstimationType: "fibonacci",
-    issueEstimationExtended: false,
-    issueEstimationAllowZero: false,
-  }),
+vi.mock("../../../src/resolvers/issue-filter-resolver.js", () => ({
+  resolveSearchFilterIds: vi.fn(),
 }));
 
 vi.mock("../../../src/resolvers/issue-resolver.js", () => ({
@@ -50,26 +43,6 @@ vi.mock("../../../src/resolvers/issue-resolver.js", () => ({
       issueEstimationAllowZero: false,
     },
   }),
-}));
-
-vi.mock("../../../src/resolvers/project-resolver.js", () => ({
-  resolveProjectId: vi.fn().mockResolvedValue("resolved-project-uuid"),
-}));
-
-vi.mock("../../../src/resolvers/label-resolver.js", () => ({
-  resolveLabelIds: vi.fn().mockResolvedValue(["resolved-label-uuid"]),
-}));
-
-vi.mock("../../../src/resolvers/milestone-resolver.js", () => ({
-  resolveMilestoneId: vi.fn().mockResolvedValue("resolved-milestone-uuid"),
-}));
-
-vi.mock("../../../src/resolvers/cycle-resolver.js", () => ({
-  resolveCycleId: vi.fn().mockResolvedValue("resolved-cycle-uuid"),
-}));
-
-vi.mock("../../../src/resolvers/status-resolver.js", () => ({
-  resolveStatusId: vi.fn().mockResolvedValue("resolved-status-uuid"),
 }));
 
 vi.mock("../../../src/services/issue-service.js", () => ({
@@ -206,16 +179,15 @@ vi.mock("../../../src/services/discussion-service.js", () => ({
 }));
 
 import { setupIssuesCommands } from "../../../src/commands/issues.js";
+import { resolveSearchFilterIds } from "../../../src/resolvers/issue-filter-resolver.js";
+import {
+  resolveCreateIssueIds,
+  resolveUpdateIssueIds,
+} from "../../../src/resolvers/issue-mutation-resolver.js";
 import {
   resolveIssueEstimateContext,
   resolveIssueId,
 } from "../../../src/resolvers/issue-resolver.js";
-import { resolveLabelIds } from "../../../src/resolvers/label-resolver.js";
-import {
-  resolveTeamEstimateContext,
-  resolveTeamId,
-} from "../../../src/resolvers/team-resolver.js";
-import { resolveUserId } from "../../../src/resolvers/user-resolver.js";
 import {
   createDiscussionCommentReaction,
   deleteDiscussionComment,
@@ -257,6 +229,69 @@ import {
   deleteOwnReactionById,
 } from "../../../src/services/reaction-service.js";
 
+// Default echo implementations for the batch resolvers: each provided human
+// input is "resolved" to a deterministic UUID. Set once at module scope;
+// beforeEach uses clearAllMocks (call history only), so implementations persist.
+// Individual tests override with mock*Once for estimate-context / error cases.
+vi.mocked(resolveCreateIssueIds).mockImplementation(async (_gql, input) => {
+  const out: Awaited<ReturnType<typeof resolveCreateIssueIds>> = {
+    teamId: asUuid("resolved-team-uuid"),
+  };
+  if (input.assignee) out.assigneeId = asUuid("resolved-user-uuid");
+  if (input.project) out.projectId = asUuid("resolved-project-uuid");
+  if (input.labels) out.labelIds = [asUuid("resolved-label-uuid")];
+  if (input.projectMilestone) {
+    out.projectMilestoneId = asUuid("resolved-milestone-uuid");
+  }
+  if (input.cycle) out.cycleId = asUuid("resolved-cycle-uuid");
+  if (input.status) out.stateId = asUuid("resolved-status-uuid");
+  if (input.parentTicket) out.parentId = asUuid("resolved-parent-uuid");
+  if (input.withEstimateContext) {
+    out.estimateContext = {
+      teamId: asUuid("resolved-team-uuid"),
+      teamKey: "ENG",
+      teamName: "Engineering",
+      issueEstimationType: "fibonacci",
+      issueEstimationExtended: false,
+      issueEstimationAllowZero: false,
+    };
+  }
+  return out;
+});
+
+vi.mocked(resolveUpdateIssueIds).mockImplementation(async (_gql, input) => {
+  const out: Awaited<ReturnType<typeof resolveUpdateIssueIds>> = {};
+  if (input.assignee) out.assigneeId = asUuid("resolved-user-uuid");
+  if (input.project) out.projectId = asUuid("resolved-project-uuid");
+  if (input.labels) {
+    out.labelIds = input.labels.map(() => asUuid("resolved-label-uuid"));
+  }
+  if (input.projectMilestone) {
+    out.projectMilestoneId = asUuid("resolved-milestone-uuid");
+  }
+  if (input.cycle) out.cycleId = asUuid("resolved-cycle-uuid");
+  if (input.status) out.stateId = asUuid("resolved-status-uuid");
+  if (input.parentTicket) out.parentId = asUuid("resolved-parent-uuid");
+  return out;
+});
+
+vi.mocked(resolveSearchFilterIds).mockImplementation(async (_gql, input) => {
+  const out: Awaited<ReturnType<typeof resolveSearchFilterIds>> = {};
+  if (input.team) out.teamId = asUuid("resolved-team-uuid");
+  if (input.assignee) out.assigneeId = asUuid("resolved-user-uuid");
+  if (input.creator) out.creatorId = asUuid("resolved-creator-uuid");
+  if (input.project) out.projectId = asUuid("resolved-project-uuid");
+  if (input.statusNames && input.statusNames.length > 0) {
+    out.stateIds = [asUuid("resolved-status-uuid")];
+  }
+  if (input.labelNames && input.labelNames.length > 0) {
+    out.labelIds = [asUuid("resolved-label-uuid")];
+  }
+  if (input.cycle) out.cycleId = asUuid("resolved-cycle-uuid");
+  if (input.parent) out.parentId = asUuid("resolved-parent-uuid");
+  return out;
+});
+
 function createProgram(): Command {
   const program = new Command();
   program.option("--api-token <token>");
@@ -286,7 +321,10 @@ describe("issues create --assignee", () => {
       "John Doe",
     ]);
 
-    expect(resolveUserId).toHaveBeenCalledWith(expect.anything(), "John Doe");
+    expect(resolveCreateIssueIds).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ assignee: "John Doe" }),
+    );
     expect(createIssue).toHaveBeenCalledWith(
       expect.anything(),
       expect.objectContaining({ assigneeId: "resolved-user-uuid" }),
@@ -307,9 +345,9 @@ describe("issues create --assignee", () => {
       "john@example.com",
     ]);
 
-    expect(resolveUserId).toHaveBeenCalledWith(
+    expect(resolveCreateIssueIds).toHaveBeenCalledWith(
       expect.anything(),
-      "john@example.com",
+      expect.objectContaining({ assignee: "john@example.com" }),
     );
     expect(createIssue).toHaveBeenCalledWith(
       expect.anything(),
@@ -317,7 +355,7 @@ describe("issues create --assignee", () => {
     );
   });
 
-  it("does not call resolveUserId when --assignee is omitted", async () => {
+  it("does not resolve an assignee when --assignee is omitted", async () => {
     const program = createProgram();
     await program.parseAsync([
       "node",
@@ -329,7 +367,10 @@ describe("issues create --assignee", () => {
       "ENG",
     ]);
 
-    expect(resolveUserId).not.toHaveBeenCalled();
+    expect(resolveCreateIssueIds).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.not.objectContaining({ assignee: expect.anything() }),
+    );
     expect(createIssue).toHaveBeenCalledWith(
       expect.anything(),
       expect.not.objectContaining({ assigneeId: expect.anything() }),
@@ -366,13 +407,16 @@ describe("issues create --estimate", () => {
   });
 
   it("passes estimate 0 through to createIssue when team allows zero", async () => {
-    vi.mocked(resolveTeamEstimateContext).mockResolvedValueOnce({
+    vi.mocked(resolveCreateIssueIds).mockResolvedValueOnce({
       teamId: asUuid("resolved-team-uuid"),
-      teamKey: "ENG",
-      teamName: "Engineering",
-      issueEstimationType: "fibonacci",
-      issueEstimationExtended: false,
-      issueEstimationAllowZero: true,
+      estimateContext: {
+        teamId: asUuid("resolved-team-uuid"),
+        teamKey: "ENG",
+        teamName: "Engineering",
+        issueEstimationType: "fibonacci",
+        issueEstimationExtended: false,
+        issueEstimationAllowZero: true,
+      },
     });
 
     const program = createProgram();
@@ -437,13 +481,16 @@ describe("issues create --estimate", () => {
   });
 
   it("rejects create estimate when team estimation disabled", async () => {
-    vi.mocked(resolveTeamEstimateContext).mockResolvedValueOnce({
+    vi.mocked(resolveCreateIssueIds).mockResolvedValueOnce({
       teamId: asUuid("resolved-team-uuid"),
-      teamKey: "ENG",
-      teamName: "Engineering",
-      issueEstimationType: "notUsed",
-      issueEstimationExtended: false,
-      issueEstimationAllowZero: false,
+      estimateContext: {
+        teamId: asUuid("resolved-team-uuid"),
+        teamKey: "ENG",
+        teamName: "Engineering",
+        issueEstimationType: "notUsed",
+        issueEstimationExtended: false,
+        issueEstimationAllowZero: false,
+      },
     });
 
     const program = createProgram();
@@ -496,7 +543,7 @@ describe("issues create numeric option validation", () => {
         "Invalid --priority: must be an integer between 1 and 4",
       ),
     );
-    expect(resolveTeamId).not.toHaveBeenCalled();
+    expect(resolveCreateIssueIds).not.toHaveBeenCalled();
     expect(createIssue).not.toHaveBeenCalled();
   });
 
@@ -519,7 +566,7 @@ describe("issues create numeric option validation", () => {
         "Invalid --estimate: must be a non-negative integer",
       ),
     );
-    expect(resolveTeamId).not.toHaveBeenCalled();
+    expect(resolveCreateIssueIds).not.toHaveBeenCalled();
     expect(createIssue).not.toHaveBeenCalled();
   });
 
@@ -1023,7 +1070,11 @@ describe("issues update --assignee", () => {
       "Jane Smith",
     ]);
 
-    expect(resolveUserId).toHaveBeenCalledWith(expect.anything(), "Jane Smith");
+    expect(resolveUpdateIssueIds).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ assignee: "Jane Smith" }),
+      expect.anything(),
+    );
     expect(updateIssue).toHaveBeenCalledWith(
       expect.anything(),
       "resolved-issue-uuid",
@@ -1031,7 +1082,7 @@ describe("issues update --assignee", () => {
     );
   });
 
-  it("does not call resolveUserId when --assignee is omitted", async () => {
+  it("does not resolve IDs when only non-reference fields change", async () => {
     const program = createProgram();
     await program.parseAsync([
       "node",
@@ -1043,7 +1094,7 @@ describe("issues update --assignee", () => {
       "New title",
     ]);
 
-    expect(resolveUserId).not.toHaveBeenCalled();
+    expect(resolveUpdateIssueIds).not.toHaveBeenCalled();
   });
 });
 
@@ -1979,7 +2030,11 @@ describe("issues update --labels", () => {
       "remove",
     ]);
 
-    expect(resolveLabelIds).toHaveBeenCalledWith(expect.anything(), ["bug"]);
+    expect(resolveUpdateIssueIds).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ labels: ["bug"] }),
+      expect.anything(),
+    );
     expect(updateIssue).toHaveBeenCalledWith(
       expect.anything(),
       "resolved-issue-uuid",

--- a/tests/unit/resolvers/issue-filter-resolver.test.ts
+++ b/tests/unit/resolvers/issue-filter-resolver.test.ts
@@ -2,99 +2,170 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import { resolveSearchFilterIds } from "../../../src/resolvers/issue-filter-resolver.js";
 
-const {
-  resolveTeamIdMock,
-  resolveUserIdMock,
-  resolveProjectIdMock,
-  resolveStatusIdMock,
-  resolveLabelIdsMock,
-  resolveCycleIdMock,
-  resolveIssueIdMock,
-} = vi.hoisted(() => ({
-  resolveTeamIdMock: vi.fn(),
-  resolveUserIdMock: vi.fn(),
-  resolveProjectIdMock: vi.fn(),
+const { resolveStatusIdMock } = vi.hoisted(() => ({
   resolveStatusIdMock: vi.fn(),
-  resolveLabelIdsMock: vi.fn(),
-  resolveCycleIdMock: vi.fn(),
-  resolveIssueIdMock: vi.fn(),
-}));
-
-vi.mock("../../../src/resolvers/team-resolver.js", () => ({
-  resolveTeamId: resolveTeamIdMock,
-}));
-
-vi.mock("../../../src/resolvers/user-resolver.js", () => ({
-  resolveUserId: resolveUserIdMock,
-}));
-
-vi.mock("../../../src/resolvers/project-resolver.js", () => ({
-  resolveProjectId: resolveProjectIdMock,
 }));
 
 vi.mock("../../../src/resolvers/status-resolver.js", () => ({
   resolveStatusId: resolveStatusIdMock,
 }));
 
-vi.mock("../../../src/resolvers/label-resolver.js", () => ({
-  resolveLabelIds: resolveLabelIdsMock,
-}));
+type BatchNodes = {
+  teams?: Array<{ id: string; key: string; name: string }>;
+  assignees?: Array<{
+    id: string;
+    name: string;
+    email: string;
+    displayName: string;
+  }>;
+  creators?: Array<{
+    id: string;
+    name: string;
+    email: string;
+    displayName: string;
+  }>;
+  projects?: Array<{
+    id: string;
+    name: string;
+    projectMilestones?: Array<{ id: string; name: string }>;
+  }>;
+  labels?: Array<{ id: string; name: string }>;
+  statuses?: Array<{
+    id: string;
+    name: string;
+    team: { id: string; key: string };
+  }>;
+  cycles?: Array<{
+    id: string;
+    name: string | null;
+    isActive: boolean;
+    isNext: boolean;
+    isPrevious: boolean;
+    number: number;
+    startsAt: string;
+    team: { id: string; key: string };
+  }>;
+  parentIssues?: Array<{ id: string; identifier: string }>;
+};
 
-vi.mock("../../../src/resolvers/cycle-resolver.js", () => ({
-  resolveCycleId: resolveCycleIdMock,
-}));
-
-vi.mock("../../../src/resolvers/issue-resolver.js", () => ({
-  resolveIssueId: resolveIssueIdMock,
-}));
+function mockGql(nodes: BatchNodes) {
+  const request = vi.fn().mockResolvedValue({
+    teams: { nodes: nodes.teams ?? [] },
+    assignees: { nodes: nodes.assignees ?? [] },
+    creators: { nodes: nodes.creators ?? [] },
+    projects: {
+      nodes: (nodes.projects ?? []).map((p) => ({
+        ...p,
+        projectMilestones: { nodes: p.projectMilestones ?? [] },
+      })),
+    },
+    labels: { nodes: nodes.labels ?? [] },
+    statuses: { nodes: nodes.statuses ?? [] },
+    cycles: { nodes: nodes.cycles ?? [] },
+    parentIssues: { nodes: nodes.parentIssues ?? [] },
+  });
+  return { client: { request } as unknown as GraphQLClient, request };
+}
 
 describe("resolveSearchFilterIds", () => {
   beforeEach(() => {
     vi.resetAllMocks();
   });
 
-  it("passes resolved team UUID to status/cycle lookups", async () => {
-    const gql = {} as unknown as GraphQLClient;
+  it("resolves all filters in a single batch request", async () => {
+    const { client, request } = mockGql({
+      teams: [{ id: "team-uuid", key: "ENG", name: "Engineering" }],
+      assignees: [
+        {
+          id: "user-uuid",
+          name: "John",
+          email: "john@example.com",
+          displayName: "John Doe",
+        },
+      ],
+      projects: [{ id: "project-uuid", name: "Q1" }],
+      labels: [{ id: "label-uuid", name: "Bug" }],
+      statuses: [
+        {
+          id: "state-uuid",
+          name: "Todo",
+          team: { id: "team-uuid", key: "ENG" },
+        },
+      ],
+      cycles: [
+        {
+          id: "cycle-uuid",
+          name: "Sprint 1",
+          isActive: true,
+          isNext: false,
+          isPrevious: false,
+          number: 1,
+          startsAt: "2026-01-01T00:00:00.000Z",
+          team: { id: "team-uuid", key: "ENG" },
+        },
+      ],
+      parentIssues: [{ id: "parent-uuid", identifier: "ENG-1" }],
+    });
 
-    resolveTeamIdMock.mockResolvedValue("team-uuid");
-    resolveStatusIdMock.mockResolvedValue("state-uuid");
-    resolveCycleIdMock.mockResolvedValue("cycle-uuid");
-
-    const result = await resolveSearchFilterIds(gql, {
+    const result = await resolveSearchFilterIds(client, {
       team: "ENG",
+      assignee: "John Doe",
+      project: "Q1",
+      // "bug" lower-case must still match "Bug" (case-insensitive).
+      labelNames: ["bug"],
       statusNames: ["Todo"],
       cycle: "Sprint 1",
+      parent: "ENG-1",
     });
 
-    expect(resolveTeamIdMock).toHaveBeenCalledWith(gql, "ENG");
-    expect(resolveStatusIdMock).toHaveBeenCalledWith(gql, "Todo", "team-uuid");
-    expect(resolveCycleIdMock).toHaveBeenCalledWith(
-      gql,
-      "Sprint 1",
-      "team-uuid",
-    );
+    expect(request).toHaveBeenCalledTimes(1);
     expect(result).toEqual({
       teamId: "team-uuid",
+      assigneeId: "user-uuid",
+      projectId: "project-uuid",
+      labelIds: ["label-uuid"],
       stateIds: ["state-uuid"],
       cycleId: "cycle-uuid",
+      parentId: "parent-uuid",
     });
+    // Status matched from the batch response — no per-status fallback call.
+    expect(resolveStatusIdMock).not.toHaveBeenCalled();
   });
 
-  it("falls back to raw team input for cycle lookup when team not pre-resolved", async () => {
-    const gql = {} as unknown as GraphQLClient;
+  it("falls back to global status resolution when a name is not team-scoped", async () => {
+    const { client } = mockGql({}); // no statuses returned (e.g. no team)
+    resolveStatusIdMock.mockResolvedValue("global-state-uuid");
 
-    resolveCycleIdMock.mockResolvedValue("cycle-uuid");
-
-    const result = await resolveSearchFilterIds(gql, {
-      cycle: "Sprint 2",
-      team: "Engineering",
+    const result = await resolveSearchFilterIds(client, {
+      statusNames: ["In Progress"],
     });
 
-    expect(resolveCycleIdMock).toHaveBeenCalledWith(
-      gql,
-      "Sprint 2",
-      "Engineering",
+    expect(resolveStatusIdMock).toHaveBeenCalledWith(
+      client,
+      "In Progress",
+      undefined,
     );
-    expect(result).toEqual({ cycleId: "cycle-uuid" });
+    expect(result).toEqual({ stateIds: ["global-state-uuid"] });
+  });
+
+  it("throws when the team cannot be resolved", async () => {
+    const { client } = mockGql({ teams: [] });
+
+    await expect(
+      resolveSearchFilterIds(client, { team: "Nope" }),
+    ).rejects.toThrow('Team "Nope" not found');
+  });
+
+  it("passes UUID inputs through without matching against the response", async () => {
+    const { client, request } = mockGql({});
+
+    const result = await resolveSearchFilterIds(client, {
+      assignee: "550e8400-e29b-41d4-a716-446655440000",
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      assigneeId: "550e8400-e29b-41d4-a716-446655440000",
+    });
   });
 });

--- a/tests/unit/resolvers/issue-filter-resolver.test.ts
+++ b/tests/unit/resolvers/issue-filter-resolver.test.ts
@@ -2,12 +2,17 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import { resolveSearchFilterIds } from "../../../src/resolvers/issue-filter-resolver.js";
 
-const { resolveStatusIdMock } = vi.hoisted(() => ({
+const { resolveStatusIdMock, resolveCycleIdMock } = vi.hoisted(() => ({
   resolveStatusIdMock: vi.fn(),
+  resolveCycleIdMock: vi.fn(),
 }));
 
 vi.mock("../../../src/resolvers/status-resolver.js", () => ({
   resolveStatusId: resolveStatusIdMock,
+}));
+
+vi.mock("../../../src/resolvers/cycle-resolver.js", () => ({
+  resolveCycleId: resolveCycleIdMock,
 }));
 
 type BatchNodes = {
@@ -146,6 +151,22 @@ describe("resolveSearchFilterIds", () => {
       undefined,
     );
     expect(result).toEqual({ stateIds: ["global-state-uuid"] });
+  });
+
+  it("falls back to global cycle resolution when no cycles are team-scoped", async () => {
+    const { client } = mockGql({}); // no cycles returned (e.g. no team)
+    resolveCycleIdMock.mockResolvedValue("global-cycle-uuid");
+
+    const result = await resolveSearchFilterIds(client, {
+      cycle: "Sprint 1",
+    });
+
+    expect(resolveCycleIdMock).toHaveBeenCalledWith(
+      client,
+      "Sprint 1",
+      undefined,
+    );
+    expect(result).toEqual({ cycleId: "global-cycle-uuid" });
   });
 
   it("throws when the team cannot be resolved", async () => {

--- a/tests/unit/resolvers/issue-mutation-resolver.test.ts
+++ b/tests/unit/resolvers/issue-mutation-resolver.test.ts
@@ -1,0 +1,414 @@
+import { describe, expect, it, vi } from "vitest";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import {
+  resolveCreateIssueIds,
+  resolveUpdateIssueIds,
+} from "../../../src/resolvers/issue-mutation-resolver.js";
+
+const UUID = "550e8400-e29b-41d4-a716-446655440000";
+
+type Nodes = {
+  teams?: Array<{
+    id: string;
+    key: string;
+    name: string;
+    issueEstimationType?: string;
+    issueEstimationExtended?: boolean;
+    issueEstimationAllowZero?: boolean;
+  }>;
+  assignees?: Array<{
+    id: string;
+    name: string;
+    email: string;
+    displayName: string;
+  }>;
+  projects?: Array<{
+    id: string;
+    name: string;
+    projectMilestones?: Array<{ id: string; name: string }>;
+  }>;
+  labels?: Array<{ id: string; name: string }>;
+  statuses?: Array<{
+    id: string;
+    name: string;
+    team: { id: string; key: string };
+  }>;
+  cycles?: Array<{
+    id: string;
+    name: string | null;
+    isActive: boolean;
+    isNext: boolean;
+    isPrevious: boolean;
+    number: number;
+    startsAt: string;
+    team: { id: string; key: string };
+  }>;
+  parentIssues?: Array<{ id: string; identifier: string }>;
+};
+
+function buildResponse(nodes: Nodes) {
+  return {
+    teams: {
+      nodes: (nodes.teams ?? []).map((t) => ({
+        issueEstimationType: "fibonacci",
+        issueEstimationExtended: false,
+        issueEstimationAllowZero: false,
+        ...t,
+      })),
+    },
+    assignees: { nodes: nodes.assignees ?? [] },
+    projects: {
+      nodes: (nodes.projects ?? []).map((p) => ({
+        id: p.id,
+        name: p.name,
+        projectMilestones: { nodes: p.projectMilestones ?? [] },
+      })),
+    },
+    labels: { nodes: nodes.labels ?? [] },
+    statuses: { nodes: nodes.statuses ?? [] },
+    cycles: { nodes: nodes.cycles ?? [] },
+    parentIssues: { nodes: nodes.parentIssues ?? [] },
+  };
+}
+
+function mockGql(nodes: Nodes) {
+  const request = vi.fn().mockResolvedValue(buildResponse(nodes));
+  return { client: { request } as unknown as GraphQLClient, request };
+}
+
+describe("resolveCreateIssueIds", () => {
+  it("resolves every reference in a single batch request", async () => {
+    const { client, request } = mockGql({
+      teams: [{ id: "team-uuid", key: "ENG", name: "Engineering" }],
+      assignees: [
+        {
+          id: "user-uuid",
+          name: "John",
+          email: "john@example.com",
+          displayName: "John Doe",
+        },
+      ],
+      projects: [
+        {
+          id: "project-uuid",
+          name: "Q1",
+          projectMilestones: [{ id: "ms-uuid", name: "M1" }],
+        },
+      ],
+      labels: [{ id: "label-uuid", name: "Bug" }],
+      statuses: [
+        {
+          id: "state-uuid",
+          name: "Todo",
+          team: { id: "team-uuid", key: "ENG" },
+        },
+      ],
+      cycles: [
+        {
+          id: "cycle-uuid",
+          name: "Sprint 1",
+          isActive: true,
+          isNext: false,
+          isPrevious: false,
+          number: 1,
+          startsAt: "2026-01-01T00:00:00.000Z",
+          team: { id: "team-uuid", key: "ENG" },
+        },
+      ],
+      parentIssues: [{ id: "parent-uuid", identifier: "ENG-1" }],
+    });
+
+    const result = await resolveCreateIssueIds(client, {
+      team: "ENG",
+      assignee: "John Doe",
+      project: "Q1",
+      labels: ["bug"], // lower-case must match "Bug"
+      projectMilestone: "M1",
+      cycle: "Sprint 1",
+      status: "Todo",
+      parentTicket: "ENG-1",
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        teamKey: "ENG",
+        teamName: "ENG",
+        assigneeQuery: "John Doe",
+        labelFilter: { or: [{ name: { eqIgnoreCase: "bug" } }] },
+        statusName: "Todo",
+        cycleName: "Sprint 1",
+        milestoneName: "M1",
+        parentTeamKey: "ENG",
+        parentIssueNumber: 1,
+      }),
+    );
+    expect(result).toEqual({
+      teamId: "team-uuid",
+      assigneeId: "user-uuid",
+      projectId: "project-uuid",
+      labelIds: ["label-uuid"],
+      projectMilestoneId: "ms-uuid",
+      cycleId: "cycle-uuid",
+      stateId: "state-uuid",
+      parentId: "parent-uuid",
+    });
+  });
+
+  it("passes UUID inputs through without name lookups", async () => {
+    const { client, request } = mockGql({});
+
+    const result = await resolveCreateIssueIds(client, {
+      team: UUID,
+      assignee: UUID,
+      project: UUID,
+      status: UUID,
+      parentTicket: UUID,
+    });
+
+    expect(request).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        teamKey: null,
+        teamName: null,
+        teamId: UUID,
+        assigneeQuery: null,
+        projectName: null,
+        projectId: UUID,
+        statusName: null,
+        parentTeamKey: null,
+        parentIssueNumber: null,
+      }),
+    );
+    expect(result).toEqual({
+      teamId: UUID,
+      assigneeId: UUID,
+      projectId: UUID,
+      stateId: UUID,
+      parentId: UUID,
+    });
+  });
+
+  it("prefers a display-name match over an email match", async () => {
+    const { client } = mockGql({
+      teams: [{ id: "team-uuid", key: "ENG", name: "Engineering" }],
+      assignees: [
+        {
+          id: "by-name",
+          name: "John",
+          email: "someone@else.com",
+          displayName: "John Doe",
+        },
+        {
+          id: "by-email",
+          name: "Other",
+          email: "john doe",
+          displayName: "Other Person",
+        },
+      ],
+    });
+
+    const result = await resolveCreateIssueIds(client, {
+      team: "ENG",
+      assignee: "John Doe",
+    });
+
+    expect(result.assigneeId).toBe("by-name");
+  });
+
+  it("throws when multiple users match by display name", async () => {
+    const { client } = mockGql({
+      teams: [{ id: "team-uuid", key: "ENG", name: "Engineering" }],
+      assignees: [
+        {
+          id: "u1",
+          name: "Alex A",
+          email: "a1@example.com",
+          displayName: "Alex",
+        },
+        {
+          id: "u2",
+          name: "Alex B",
+          email: "a2@example.com",
+          displayName: "Alex",
+        },
+      ],
+    });
+
+    await expect(
+      resolveCreateIssueIds(client, { team: "ENG", assignee: "Alex" }),
+    ).rejects.toThrow('Multiple Users found matching "Alex"');
+  });
+
+  it("falls back to email when no display name matches", async () => {
+    const { client } = mockGql({
+      teams: [{ id: "team-uuid", key: "ENG", name: "Engineering" }],
+      assignees: [
+        {
+          id: "u2",
+          name: "Jane",
+          email: "jane@example.com",
+          displayName: "Jane Roe",
+        },
+      ],
+    });
+
+    const result = await resolveCreateIssueIds(client, {
+      team: "ENG",
+      assignee: "jane@example.com",
+    });
+
+    expect(result.assigneeId).toBe("u2");
+  });
+
+  it("throws when an assignee cannot be found", async () => {
+    const { client } = mockGql({
+      teams: [{ id: "team-uuid", key: "ENG", name: "Engineering" }],
+    });
+
+    await expect(
+      resolveCreateIssueIds(client, { team: "ENG", assignee: "ghost" }),
+    ).rejects.toThrow('User "ghost" not found');
+  });
+
+  it("throws when the team cannot be resolved", async () => {
+    const { client } = mockGql({ teams: [] });
+
+    await expect(
+      resolveCreateIssueIds(client, { team: "NOPE" }),
+    ).rejects.toThrow('Team "NOPE" not found');
+  });
+
+  it("returns estimate context from the same request when requested", async () => {
+    const { client, request } = mockGql({
+      teams: [
+        {
+          id: "team-uuid",
+          key: "ENG",
+          name: "Engineering",
+          issueEstimationType: "fibonacci",
+          issueEstimationExtended: true,
+          issueEstimationAllowZero: true,
+        },
+      ],
+    });
+
+    const result = await resolveCreateIssueIds(client, {
+      team: "ENG",
+      withEstimateContext: true,
+    });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(result.estimateContext).toEqual({
+      teamId: "team-uuid",
+      teamKey: "ENG",
+      teamName: "Engineering",
+      issueEstimationType: "fibonacci",
+      issueEstimationExtended: true,
+      issueEstimationAllowZero: true,
+    });
+  });
+
+  it("throws when a project is not found", async () => {
+    const { client } = mockGql({
+      teams: [{ id: "team-uuid", key: "ENG", name: "Engineering" }],
+      projects: [],
+    });
+
+    await expect(
+      resolveCreateIssueIds(client, { team: "ENG", project: "Ghost" }),
+    ).rejects.toThrow('Project "Ghost" not found');
+  });
+
+  it("scopes milestone resolution to the matched project", async () => {
+    const { client } = mockGql({
+      teams: [{ id: "team-uuid", key: "ENG", name: "Engineering" }],
+      projects: [{ id: "project-uuid", name: "Q1", projectMilestones: [] }],
+    });
+
+    await expect(
+      resolveCreateIssueIds(client, {
+        team: "ENG",
+        project: "Q1",
+        projectMilestone: "Ghost",
+      }),
+    ).rejects.toThrow('Milestone "Ghost" not found');
+  });
+});
+
+describe("resolveUpdateIssueIds", () => {
+  it("resolves references in a single request scoped by issue context", async () => {
+    const { client, request } = mockGql({
+      assignees: [
+        {
+          id: "user-uuid",
+          name: "Jane",
+          email: "jane@example.com",
+          displayName: "Jane Roe",
+        },
+      ],
+      statuses: [
+        {
+          id: "state-uuid",
+          name: "Done",
+          team: { id: "team-uuid", key: "ENG" },
+        },
+      ],
+    });
+
+    const result = await resolveUpdateIssueIds(
+      client,
+      { assignee: "Jane Roe", status: "Done" },
+      { teamId: "team-uuid" as never, teamKey: "ENG" },
+    );
+
+    expect(request).toHaveBeenCalledTimes(1);
+    expect(request).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        assigneeQuery: "Jane Roe",
+        statusName: "Done",
+        teamKey: "ENG",
+        teamId: "team-uuid",
+      }),
+    );
+    expect(result).toEqual({
+      assigneeId: "user-uuid",
+      stateId: "state-uuid",
+    });
+  });
+
+  it("parses a parent identifier into filter variables", async () => {
+    const { client, request } = mockGql({
+      parentIssues: [{ id: "parent-uuid", identifier: "ENG-7" }],
+    });
+
+    const result = await resolveUpdateIssueIds(
+      client,
+      { parentTicket: "ENG-7" },
+      {},
+    );
+
+    expect(request).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        parentTeamKey: "ENG",
+        parentIssueNumber: 7,
+      }),
+    );
+    expect(result.parentId).toBe("parent-uuid");
+  });
+
+  it("passes UUID inputs through", async () => {
+    const { client } = mockGql({});
+
+    const result = await resolveUpdateIssueIds(
+      client,
+      { assignee: UUID, project: UUID },
+      {},
+    );
+
+    expect(result).toEqual({ assigneeId: UUID, projectId: UUID });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Replaces the per-field sequential resolver calls in `issues create`/`issues update` with a single `BatchResolveForCreate`/`BatchResolveForUpdate` request via a new `issue-mutation-resolver`, and extracts the disambiguation/not-found/UUID-passthrough logic into shared pure mappers (`batch-resolve-mappers`). The search filter resolver is migrated onto `BatchResolveForSearch` too. This removes the standalone `--assignee` user lookup and the remaining N+1 ID lookups while preserving the exact resolver semantics.

Closes #126

## Type of change

- [x] Bug fix
- [ ] New feature
- [x] Refactor (no behavior change)
- [x] Tests

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

`npm run check:ci`, `npx tsc --noEmit`, `npm test` (865 passing), `npm run build`, and `npm run knip` all pass locally.

## Notes for reviewers

Batching scopes cycles/statuses to a team, which would have broken `issue list --cycle <name>` (and status) without `--team`; both now fall back to the global single-entity resolver when the batch response is empty, with regression tests covering it. Otherwise the mappers reproduce the exact semantics of the original single-entity resolvers.