### PR TITLE
feat(skill): add agent skill and Claude Code plugin for the CLI

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,22 @@
+{
+  "name": "linearis",
+  "owner": {
+    "name": "linearis-oss",
+    "url": "https://github.com/linearis-oss/linearis"
+  },
+  "metadata": {
+    "description": "Marketplace for the linearis Claude Code plugin.",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "linearis",
+      "source": "./",
+      "description": "Agent skill teaching agents to use the linearis Linear.app CLI.",
+      "version": "1.0.0",
+      "author": { "name": "linearis-oss" },
+      "homepage": "https://github.com/linearis-oss/linearis",
+      "license": "MIT"
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,11 @@
+{
+  "name": "linearis",
+  "description": "Agent skill for the linearis Linear.app CLI: preflight, discover-then-act usage protocol, JSON output, ID resolution, discussions, files.",
+  "version": "1.0.0",
+  "author": {
+    "name": "linearis-oss",
+    "url": "https://github.com/linearis-oss/linearis"
+  },
+  "homepage": "https://github.com/linearis-oss/linearis",
+  "license": "MIT"
+}

--- a/README.md
+++ b/README.md
@@ -145,36 +145,28 @@ The agent never loads the full API surface into context — it pays for what it 
 
 Use Linearis when token efficiency matters and you work primarily with issues and related data. Use the MCP when you need full API coverage or tight tool-call integration.
 
-### Example agent prompt
+### Agent skill
 
-Add this (or a version adapted to your workflow) to your `AGENTS.md` or `CLAUDE.md` so every session has it in context:
+Linearis ships an agent skill (following the [agentskills.io](https://agentskills.io) standard) so your agent knows how to use it — no prompt to paste. The skill preflights the install, advisory-checks for updates, then follows the discover-then-act protocol above.
 
-```markdown
-## Linear (project management)
+**Any harness (recommended)** — Vercel's skills CLI installs into the right place for 70+ agents and lists it on [skills.sh](https://skills.sh):
 
-Tool: `linearis` CLI, invoked via Bash. All output is JSON.
-
-Discovery (do this before acting): run `linearis usage` once for the list of
-domains, then `linearis <domain> usage` for a domain's full command reference.
-Never guess flags or subcommands — check usage first.
-
-Tickets: always reference by identifier, e.g. `ABC-123`.
-
-Workflow rules:
-- Ask which project a new ticket belongs to when it's unclear; subtasks inherit
-  the parent's project by default.
-- Keep the ticket description in sync when a task in it changes status.
-- Record progress that isn't a simple checkbox change in a discussion thread
-  (`issues discuss`), not in the description.
-
-Files: `files download <url>` only fetches Linear storage URLs
-(`uploads.linear.app`), such as images embedded in descriptions or comments.
-Upload new files with `files upload <file>`; it returns an `assetUrl` you can
-embed in descriptions or comments. `issues read --with-attachments` lists
-resources linked to an issue (PRs, docs, external URLs) under an
-`attachments.nodes` array whose entries carry a `url` — these are references,
-not necessarily downloadable files.
+```bash
+npx skills add linearis-oss/linearis
 ```
+
+**Claude Code** — native plugin:
+
+```
+/plugin marketplace add linearis-oss/linearis
+/plugin install linearis@linearis
+```
+
+**OpenAI Codex** — `npx skills add linearis-oss/linearis` installs to `~/.agents/skills/`; invoke with `/skills` or `$`.
+
+**pi** — `npx skills add linearis-oss/linearis` (or drop `skills/linearis/` into `.pi/skills/`); invoke `/skill:linearis`.
+
+**Google Antigravity** — `npx skills add linearis-oss/linearis` installs to `.agents/skills/`; auto-discovered from the skill list.
 
 ## Documentation
 

--- a/skills/linearis/SKILL.md
+++ b/skills/linearis/SKILL.md
@@ -1,0 +1,48 @@
+---
+name: linearis
+description: >-
+  Manage Linear.app work from the command line with the linearis CLI (bins
+  linearis / linear), which outputs JSON: issues/tickets, projects, cycles
+  (sprints), milestones, initiatives (roadmap), documents, labels, teams,
+  users, and issue discussions/comments. Use when the user mentions Linear, a
+  ticket identifier like ENG-42 or ABC-123, sprints, triage, or the roadmap, or
+  asks to create, read, search, update, assign, comment on, or otherwise manage
+  Linear issues and projects.
+license: MIT
+compatibility: Requires the linearis CLI (npm i -g linearis), Node >=22, and a Linear API token.
+allowed-tools: Bash(linearis:*) Bash(linear:*) Bash(jq:*)
+metadata:
+  author: linearis-oss
+  version: "1.0.0"
+---
+
+# linearis
+
+Drive [Linear.app](https://linear.app) from the shell via the `linearis` CLI (JSON-only output; `linear` is an alias). Do not guess the command surface — the CLI documents itself, and this skill teaches the protocol, not the flags.
+
+## Preflight (reactive — branch on the CLI's own output; don't pre-run checks every turn)
+
+- **Not installed** — if the shell reports command-not-found, tell the user linearis isn't installed and offer `npm install -g linearis`. As a no-install fallback, prefix commands with `npx linearis@latest` (adds cold-start latency and needs network per call — fallback, not default). Never silently `npm install -g`.
+- **Auth required** — any command may fail with this envelope on stderr and exit code 42:
+  `{ "error": "AUTHENTICATION_REQUIRED", "action": "USER_ACTION_REQUIRED", "instruction": "Run 'linearis auth' …", "exit_code": 42 }`.
+  Detect it by `exit_code === 42` / `error === "AUTHENTICATION_REQUIRED"` (not paraphrased text) and surface the CLI's own `instruction`. `linearis auth` is an interactive browser flow you cannot complete — hand it to the user.
+- **Updates (advisory, never blocking)** — optionally run `linearis version check` once → `{ current, latest, channel, updateAvailable }`. If `updateAvailable` is true, mention it and ask the user before `npm install -g linearis@latest`, honoring `channel` (don't move a `next` user to `latest`). npm can hang or rate-limit; on any timeout/error just proceed with the installed version. Read the plain installed version with `linearis version` (JSON), not `--version`.
+
+## Discover, then act
+
+1. Run `linearis usage` once for the list of domains (issues, projects, cycles, …).
+2. Run `linearis <domain> usage` for a domain's full command and flag reference **before** acting.
+3. Never invent flags or subcommands — `usage` is authoritative and always current.
+
+## Output
+
+Every command prints JSON on stdout. Shape it at the source with the global `--fields identifier,title,state.name` and `--compact` — no external binary, works on Windows and fresh containers. Reach for `jq` only for complex reshaping, and fall back to raw JSON if `jq` is absent.
+
+## Invariants worth knowing (everything else lives in `usage`)
+
+- IDs are forgiving: pass a UUID, team key (`ENG`), issue identifier (`ABC-123`), or name interchangeably. Reference tickets by identifier.
+- `issues create` requires `--team`; some filters need a scope flag — confirm in `usage` rather than memorizing.
+- Threaded discussion lives under `issues discuss` / `discussions` / `replies` / `reply`. The top-level `comments` domain is a deprecated facade (still works) — prefer the `issues` discussion commands. Record non-trivial progress in a discussion thread and keep the description in sync on status changes.
+- `files download <url>` only fetches Linear storage URLs (`uploads.linear.app`); `files upload` returns an `assetUrl` you can embed; `issues read --with-attachments` lists linked resources (PRs, docs, URLs) — references, not necessarily downloadable files.
+
+For anything not covered here, `linearis <domain> usage` is the reference.

--- a/skills/linearis/SKILL.md
+++ b/skills/linearis/SKILL.md
@@ -10,7 +10,7 @@ description: >-
   Linear issues and projects.
 license: MIT
 compatibility: Requires the linearis CLI (npm i -g linearis), Node >=22, and a Linear API token.
-allowed-tools: Bash(linearis:*) Bash(linear:*) Bash(jq:*)
+allowed-tools: Bash(linearis:*), Bash(linear:*), Bash(jq:*)
 metadata:
   author: linearis-oss
   version: "1.0.0"


### PR DESCRIPTION
## What does this PR do?

Adds an agent skill (following the [agentskills.io](https://agentskills.io) standard) and a Claude Code plugin so agents know how to drive the `linearis` CLI without a pasted prompt. The skill (`skills/linearis/SKILL.md`) teaches the preflight and discover-then-act protocol; `.claude-plugin/` adds the plugin and marketplace manifests; and the README's "Example agent prompt" section is replaced with per-harness install instructions.

Closes #

## Type of change

- [x] New feature
- [x] Documentation

## Checklist

- [ ] `npm run check:ci` passes (lint + format)
- [ ] `npx tsc --noEmit` passes (type check)
- [ ] `npm test` passes (unit tests)
- [ ] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Docs/markdown-only change — no code paths affected. Pre-commit biome and commitlint hooks passed.

## Notes for reviewers

The change is entirely additive (new skill + plugin manifests) plus a README rewrite of the agent-onboarding section; no source code under `src/` is touched.