### PR TITLE
docs: add skills.sh badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@
 [![Node version](https://img.shields.io/node/v/linearis.svg)](https://nodejs.org)
 [![CI](https://github.com/linearis-oss/linearis/actions/workflows/ci.yml/badge.svg)](https://github.com/linearis-oss/linearis/actions/workflows/ci.yml)
 [![License: MIT](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE.md)
+[![skills.sh](https://skills.sh/b/linearis-oss/linearis)](https://skills.sh/linearis-oss/linearis)
 
 </div>
 


### PR DESCRIPTION
## What does this PR do?

Adds a skills.sh badge (pointing at the `linearis-oss/linearis` repo) to the badge row in the README.

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [ ] Tests
- [ ] Build / CI

## Checklist

- [ ] `npm run check:ci` passes (lint + format)
- [ ] `npx tsc --noEmit` passes (type check)
- [ ] `npm test` passes (unit tests)
- [ ] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Documentation-only change; no code affected.

## Notes for reviewers

Badge links to `https://skills.sh/linearis-oss/linearis`.