### PR TITLE
feat(issues): add activity command with threaded discussion timeline

### DIFF
--- a/graphql/queries/activity.graphql
+++ b/graphql/queries/activity.graphql
@@ -1,0 +1,74 @@
+fragment IssueHistoryFields on IssueHistory {
+  id
+  createdAt
+  actor {
+    id
+    displayName
+  }
+  botActor {
+    id
+    name
+  }
+  fromState {
+    id
+    name
+  }
+  toState {
+    id
+    name
+  }
+  fromAssignee {
+    id
+    displayName
+  }
+  toAssignee {
+    id
+    displayName
+  }
+  fromPriority
+  toPriority
+  fromProject {
+    id
+    name
+  }
+  toProject {
+    id
+    name
+  }
+  fromCycle {
+    id
+    number
+  }
+  toCycle {
+    id
+    number
+  }
+  fromTitle
+  toTitle
+  fromEstimate
+  toEstimate
+  addedLabelIds
+  removedLabelIds
+  archived
+}
+
+query GetIssueActivityRef($id: String!) {
+  issue(id: $id) {
+    id
+    identifier
+  }
+}
+
+query ListIssueActivityHistory($issueId: String!, $first: Int, $after: String) {
+  issue(id: $issueId) {
+    history(first: $first, after: $after) {
+      nodes {
+        ...IssueHistoryFields
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}

--- a/graphql/queries/labels.graphql
+++ b/graphql/queries/labels.graphql
@@ -44,8 +44,19 @@ query GetIssueLabel($id: String!) {
 # Variables:
 #   $first: Maximum number of labels to return (default: 50)
 #   $filter: Optional filter (e.g., { team: { id: { eq: "team-uuid" } } })
-query GetLabels($first: Int = 50, $after: String, $filter: IssueLabelFilter) {
-  issueLabels(first: $first, after: $after, filter: $filter) {
+#   $includeArchived: Include archived labels (default: false)
+query GetLabels(
+  $first: Int = 50
+  $after: String
+  $filter: IssueLabelFilter
+  $includeArchived: Boolean = false
+) {
+  issueLabels(
+    first: $first
+    after: $after
+    filter: $filter
+    includeArchived: $includeArchived
+  ) {
     nodes {
       ...LabelFields
     }

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -35,6 +35,7 @@ import {
   resolveIssueEstimateContext,
   resolveIssueId,
 } from "../resolvers/issue-resolver.js";
+import { getIssueActivity } from "../services/activity-service.js";
 import {
   createDiscussionCommentReaction,
   deleteDiscussionComment,
@@ -171,6 +172,13 @@ interface DiscussionsOptions {
   withReactions?: boolean;
 }
 
+interface ActivityOptions {
+  limit: string;
+  after?: string;
+  commentsOnly?: boolean;
+  withReactions?: boolean;
+}
+
 interface DiscussionBodyOptions {
   body?: string;
 }
@@ -265,6 +273,7 @@ export const ISSUES_META: DomainMeta = {
     query: "full-text search term",
   },
   seeAlso: [
+    "issues activity <issue>",
     "comments create <issue>",
     "documents list --issue <issue>",
     "attachments list <issue>",
@@ -842,6 +851,40 @@ export function setupIssuesCommands(program: Command): void {
           const result = await startIssueDiscussion(ctx.gql, {
             issueId,
             body: options.body,
+          });
+
+          outputSuccess(result);
+        },
+      ),
+    );
+
+  issues
+    .command("activity <issue>")
+    .description(
+      "chronological activity timeline: comment threads plus history events",
+    )
+    .addHelpText(
+      "after",
+      `\nWhen passing issue IDs, both UUID and identifiers like ABC-123 are supported.`,
+    )
+    .option("-l, --limit <n>", "max timeline items", "50")
+    .option("--after <cursor>", "cursor for next page")
+    .option("--comments-only", "exclude non-comment history events")
+    .option("--with-reactions", "include normalized comment reactions")
+    .action(
+      commandAction<[string, ActivityOptions, Command]>(
+        async (issue, options, command) => {
+          const ctx = createContext(getRootOpts(command));
+
+          const issueId = await resolveIssueId(ctx.gql, issue);
+          const paginationOptions = buildPaginationOptions(
+            parseLimit(options.limit),
+            options.after,
+          );
+          const result = await getIssueActivity(ctx.gql, issueId, {
+            ...paginationOptions,
+            commentsOnly: Boolean(options.commentsOnly),
+            withReactions: Boolean(options.withReactions),
           });
 
           outputSuccess(result);

--- a/src/common/types.ts
+++ b/src/common/types.ts
@@ -25,3 +25,37 @@ export function buildPaginationOptions(
 ): PaginationOptions {
   return after === undefined ? { limit } : { limit, after };
 }
+
+/** A Relay-style GraphQL connection page. */
+interface Connection<T> {
+  nodes: readonly T[];
+  pageInfo: { hasNextPage: boolean; endCursor?: string | null };
+}
+
+/**
+ * Exhaust a cursor-paginated GraphQL connection, returning every node. The
+ * caller's `fetchPage` requests a single page for the given `after` cursor (and
+ * performs any per-page guards, e.g. asserting the parent entity exists);
+ * iteration stops once the server reports no further pages. Centralizes the
+ * fetch-until-empty loop shared by services that must materialize a whole
+ * connection before processing it.
+ */
+export async function collectConnection<TNode>(
+  fetchPage: (after: string | undefined) => Promise<Connection<TNode>>,
+): Promise<TNode[]> {
+  const nodes: TNode[] = [];
+  let after: string | undefined;
+
+  while (true) {
+    const connection = await fetchPage(after);
+    nodes.push(...connection.nodes);
+
+    if (!connection.pageInfo.hasNextPage || !connection.pageInfo.endCursor) {
+      break;
+    }
+
+    after = connection.pageInfo.endCursor;
+  }
+
+  return nodes;
+}

--- a/src/services/activity-service.ts
+++ b/src/services/activity-service.ts
@@ -1,0 +1,427 @@
+import type { GraphQLClient } from "../client/graphql-client.js";
+import { asUuid, type UUID } from "../common/identifier.js";
+import { collectConnection } from "../common/types.js";
+import {
+  GetIssueActivityRefDocument,
+  GetLabelsDocument,
+  type IssueHistoryFieldsFragment,
+  ListIssueActivityHistoryDocument,
+  ListIssueDiscussionRootsDocument,
+  ListIssueDiscussionRootsWithReactionsDocument,
+} from "../gql/graphql.js";
+import {
+  buildThreadRepliesIndex,
+  collectThreadReplies,
+  type DiscussionThread,
+  type DiscussionThreadWithReactions,
+  fetchAllIssueDiscussionReplyCandidates,
+  fetchAllIssueDiscussionReplyCandidatesWithReactions,
+  normalizeDiscussionCommentsReactions,
+} from "./discussion-service.js";
+
+/** Page size used when exhausting a connection to build the merged timeline. */
+const TIMELINE_FETCH_LIMIT = 250;
+/** Default number of top-level timeline items returned per page. */
+const DEFAULT_ACTIVITY_LIMIT = 50;
+
+type NamedRef = { id: string; name: string };
+type UserRef = { id: string; displayName: string };
+type CycleRef = { id: string; number: number };
+/** A label reference; `name` is null when the label no longer exists. */
+type LabelRef = { id: string; name: string | null };
+
+/** A single normalized change captured by an issue history event. */
+type ActivityChange =
+  | { field: "state"; from: NamedRef | null; to: NamedRef | null }
+  | { field: "assignee"; from: UserRef | null; to: UserRef | null }
+  | { field: "priority"; from: number | null; to: number | null }
+  | { field: "project"; from: NamedRef | null; to: NamedRef | null }
+  | { field: "cycle"; from: CycleRef | null; to: CycleRef | null }
+  | { field: "title"; from: string | null; to: string | null }
+  | { field: "estimate"; from: number | null; to: number | null }
+  | { field: "labels"; added: LabelRef[]; removed: LabelRef[] }
+  | { field: "archived"; to: boolean };
+
+interface ActivityHistoryItem {
+  type: "history";
+  id: string;
+  createdAt: string;
+  actor: UserRef | null;
+  botActor: { id: string | null; name: string | null } | null;
+  changes: ActivityChange[];
+}
+
+interface ActivityCommentThreadItem<
+  TComment extends DiscussionThread | DiscussionThreadWithReactions,
+> {
+  type: "commentThread";
+  root: TComment;
+  replies: TComment[];
+}
+
+type ActivityItem =
+  | ActivityHistoryItem
+  | ActivityCommentThreadItem<DiscussionThread>
+  | ActivityCommentThreadItem<DiscussionThreadWithReactions>;
+
+export interface IssueActivityResult {
+  issue: { id: string; identifier: string };
+  activity: ActivityItem[];
+  pageInfo: { hasNextPage: boolean; endCursor: string | null };
+}
+
+export interface IssueActivityOptions {
+  limit?: number;
+  after?: string;
+  commentsOnly?: boolean;
+  withReactions?: boolean;
+}
+
+function refsDiffer(
+  from: { id: string } | null,
+  to: { id: string } | null,
+): boolean {
+  return (from?.id ?? null) !== (to?.id ?? null);
+}
+
+/** Translate a raw issue history node into its list of meaningful changes. */
+function buildHistoryChanges(
+  node: IssueHistoryFieldsFragment,
+  labelNames: ReadonlyMap<string, string>,
+): ActivityChange[] {
+  const changes: ActivityChange[] = [];
+
+  const toLabelRef = (id: string): LabelRef => ({
+    id,
+    name: labelNames.get(id) ?? null,
+  });
+
+  if (refsDiffer(node.fromState, node.toState)) {
+    changes.push({ field: "state", from: node.fromState, to: node.toState });
+  }
+
+  if (refsDiffer(node.fromAssignee, node.toAssignee)) {
+    changes.push({
+      field: "assignee",
+      from: node.fromAssignee,
+      to: node.toAssignee,
+    });
+  }
+
+  if (node.fromPriority !== node.toPriority) {
+    changes.push({
+      field: "priority",
+      from: node.fromPriority,
+      to: node.toPriority,
+    });
+  }
+
+  if (refsDiffer(node.fromProject, node.toProject)) {
+    changes.push({
+      field: "project",
+      from: node.fromProject,
+      to: node.toProject,
+    });
+  }
+
+  if (refsDiffer(node.fromCycle, node.toCycle)) {
+    changes.push({ field: "cycle", from: node.fromCycle, to: node.toCycle });
+  }
+
+  if (node.fromTitle !== node.toTitle) {
+    changes.push({ field: "title", from: node.fromTitle, to: node.toTitle });
+  }
+
+  if (node.fromEstimate !== node.toEstimate) {
+    changes.push({
+      field: "estimate",
+      from: node.fromEstimate,
+      to: node.toEstimate,
+    });
+  }
+
+  const added = node.addedLabelIds ?? [];
+  const removed = node.removedLabelIds ?? [];
+  if (added.length > 0 || removed.length > 0) {
+    changes.push({
+      field: "labels",
+      added: added.map(toLabelRef),
+      removed: removed.map(toLabelRef),
+    });
+  }
+
+  if (node.archived !== null) {
+    changes.push({ field: "archived", to: node.archived });
+  }
+
+  return changes;
+}
+
+async function fetchAllIssueDiscussionRoots(
+  client: GraphQLClient,
+  issueId: UUID,
+): Promise<DiscussionThread[]> {
+  return collectConnection(async (after) => {
+    const result = await client.request(ListIssueDiscussionRootsDocument, {
+      issueId,
+      first: TIMELINE_FETCH_LIMIT,
+      after,
+    });
+
+    if (!result.issue) {
+      throw new Error(`Issue with ID "${issueId}" not found`);
+    }
+
+    return result.issue.comments;
+  });
+}
+
+async function fetchAllIssueDiscussionRootsWithReactions(
+  client: GraphQLClient,
+  issueId: UUID,
+): Promise<DiscussionThreadWithReactions[]> {
+  const nodes = await collectConnection(async (after) => {
+    const result = await client.request(
+      ListIssueDiscussionRootsWithReactionsDocument,
+      { issueId, first: TIMELINE_FETCH_LIMIT, after },
+    );
+
+    if (!result.issue) {
+      throw new Error(`Issue with ID "${issueId}" not found`);
+    }
+
+    return result.issue.comments;
+  });
+
+  return normalizeDiscussionCommentsReactions(nodes);
+}
+
+async function fetchAllIssueHistory(
+  client: GraphQLClient,
+  issueId: UUID,
+): Promise<IssueHistoryFieldsFragment[]> {
+  return collectConnection(async (after) => {
+    const result = await client.request(ListIssueActivityHistoryDocument, {
+      issueId,
+      first: TIMELINE_FETCH_LIMIT,
+      after,
+    });
+
+    if (!result.issue) {
+      throw new Error(`Issue with ID "${issueId}" not found`);
+    }
+
+    return result.issue.history;
+  });
+}
+
+/** Collect the distinct label IDs referenced by any history node's label changes. */
+function collectLabelIds(
+  nodes: readonly IssueHistoryFieldsFragment[],
+): string[] {
+  const ids = new Set<string>();
+
+  for (const node of nodes) {
+    for (const id of node.addedLabelIds ?? []) {
+      ids.add(id);
+    }
+    for (const id of node.removedLabelIds ?? []) {
+      ids.add(id);
+    }
+  }
+
+  return [...ids];
+}
+
+/**
+ * Resolve label IDs referenced by history events to their names so the timeline
+ * exposes human-readable labels (matching state/assignee/project). Archived
+ * labels are included so historic label changes still resolve; labels that no
+ * longer exist are simply absent from the map, yielding a null name.
+ */
+async function resolveLabelNames(
+  client: GraphQLClient,
+  ids: readonly string[],
+): Promise<Map<string, string>> {
+  const names = new Map<string, string>();
+
+  if (ids.length === 0) {
+    return names;
+  }
+
+  const labels = await collectConnection(async (after) => {
+    const result = await client.request(GetLabelsDocument, {
+      first: TIMELINE_FETCH_LIMIT,
+      after,
+      filter: { id: { in: [...ids] } },
+      includeArchived: true,
+    });
+
+    return result.issueLabels;
+  });
+
+  for (const label of labels) {
+    names.set(label.id, label.name);
+  }
+
+  return names;
+}
+
+/** Assemble comment-thread timeline items from root threads and reply candidates. */
+function buildCommentThreadItems<
+  TComment extends DiscussionThread | DiscussionThreadWithReactions,
+>(
+  roots: readonly TComment[],
+  candidates: readonly TComment[],
+): ActivityCommentThreadItem<TComment>[] {
+  const childrenByParentId = buildThreadRepliesIndex(candidates);
+  return roots.map((root) => ({
+    type: "commentThread" as const,
+    root,
+    replies: collectThreadReplies(childrenByParentId, asUuid(root.id)),
+  }));
+}
+
+/**
+ * Fetch an issue's comment threads. Roots and reply candidates are independent
+ * connections, so they are exhausted concurrently before being assembled.
+ */
+async function fetchCommentThreadItems(
+  client: GraphQLClient,
+  issueId: UUID,
+  withReactions: boolean,
+): Promise<ActivityItem[]> {
+  if (withReactions) {
+    const [roots, candidates] = await Promise.all([
+      fetchAllIssueDiscussionRootsWithReactions(client, issueId),
+      fetchAllIssueDiscussionReplyCandidatesWithReactions(client, issueId),
+    ]);
+    return buildCommentThreadItems(roots, candidates);
+  }
+
+  const [roots, candidates] = await Promise.all([
+    fetchAllIssueDiscussionRoots(client, issueId),
+    fetchAllIssueDiscussionReplyCandidates(client, issueId),
+  ]);
+  return buildCommentThreadItems(roots, candidates);
+}
+
+interface TimelineEntry {
+  createdAt: string;
+  id: string;
+  item: ActivityItem;
+}
+
+function toTimelineEntry(item: ActivityItem): TimelineEntry {
+  return item.type === "history"
+    ? { createdAt: item.createdAt, id: item.id, item }
+    : { createdAt: item.root.createdAt, id: item.root.id, item };
+}
+
+function compareTimelineEntries(a: TimelineEntry, b: TimelineEntry): number {
+  const byCreatedAt = a.createdAt.localeCompare(b.createdAt);
+  return byCreatedAt !== 0 ? byCreatedAt : a.id.localeCompare(b.id);
+}
+
+interface TimelinePage {
+  nodes: ActivityItem[];
+  hasNextPage: boolean;
+  endCursor: string | null;
+}
+
+/** Slice a sorted timeline using an opaque id cursor (mirrors reply pagination). */
+function paginateTimeline(
+  entries: readonly TimelineEntry[],
+  limit: number,
+  after?: string,
+): TimelinePage {
+  const startIndex =
+    after === undefined
+      ? 0
+      : entries.findIndex((entry) => entry.id === after) + 1;
+
+  if (after !== undefined && startIndex === 0) {
+    throw new Error(`Activity cursor "${after}" not found`);
+  }
+
+  const page = entries.slice(startIndex, startIndex + limit);
+
+  return {
+    nodes: page.map((entry) => entry.item),
+    hasNextPage: startIndex + limit < entries.length,
+    endCursor: page.at(-1)?.id ?? null,
+  };
+}
+
+/**
+ * Build a chronological activity timeline for an issue: comment threads (root +
+ * nested replies) merged with issue history events, sorted ascending by
+ * creation time and paginated with an opaque id cursor.
+ *
+ * The timeline is materialized in full on every call before it is sliced: the
+ * comment and history connections are independent (Linear exposes no unified
+ * activity connection) and reply nesting needs all reply candidates regardless
+ * of the requested page. As a stateless CLI there is no cross-invocation cache,
+ * so each `--after` page re-fetches everything — the same materialize-then-slice
+ * tradeoff as {@link paginateTimeline}'s sibling in discussion reply pagination.
+ * This is cheap for typical issues; only pathologically large histories pay for it.
+ */
+export async function getIssueActivity(
+  client: GraphQLClient,
+  issueId: UUID,
+  options: IssueActivityOptions = {},
+): Promise<IssueActivityResult> {
+  const {
+    limit = DEFAULT_ACTIVITY_LIMIT,
+    after,
+    commentsOnly = false,
+    withReactions = false,
+  } = options;
+
+  const ref = await client.request(GetIssueActivityRefDocument, {
+    id: issueId,
+  });
+
+  if (!ref.issue) {
+    throw new Error(`Issue with ID "${issueId}" not found`);
+  }
+
+  // Comment threads and issue history are independent connections; fetch both
+  // concurrently. Label names depend on the history nodes, so they resolve after.
+  const [threadItems, historyNodes] = await Promise.all([
+    fetchCommentThreadItems(client, issueId, withReactions),
+    commentsOnly
+      ? Promise.resolve<IssueHistoryFieldsFragment[]>([])
+      : fetchAllIssueHistory(client, issueId),
+  ]);
+
+  const labelNames = await resolveLabelNames(
+    client,
+    collectLabelIds(historyNodes),
+  );
+
+  const historyItems: ActivityItem[] = historyNodes
+    .map((node) => ({
+      type: "history" as const,
+      id: node.id,
+      createdAt: node.createdAt,
+      actor: node.actor,
+      botActor: node.botActor,
+      changes: buildHistoryChanges(node, labelNames),
+    }))
+    // Drop events whose only changes fall outside the captured fragment fields;
+    // they carry no information and would otherwise consume pagination slots.
+    .filter((item) => item.changes.length > 0);
+
+  const entries = [...threadItems, ...historyItems]
+    .map(toTimelineEntry)
+    .sort(compareTimelineEntries);
+
+  const page = paginateTimeline(entries, limit, after);
+
+  return {
+    issue: { id: ref.issue.id, identifier: ref.issue.identifier },
+    activity: page.nodes,
+    pageInfo: { hasNextPage: page.hasNextPage, endCursor: page.endCursor },
+  };
+}

--- a/src/services/discussion-service.ts
+++ b/src/services/discussion-service.ts
@@ -4,7 +4,11 @@ import {
   requireMutationEntity,
   requireMutationSuccess,
 } from "../common/mutation-payload.js";
-import type { PaginatedResult, PaginationOptions } from "../common/types.js";
+import {
+  collectConnection,
+  type PaginatedResult,
+  type PaginationOptions,
+} from "../common/types.js";
 import {
   type CommentCreateInput,
   type CommentUpdateInput,
@@ -115,7 +119,7 @@ function normalizeDiscussionCommentReactions<
   };
 }
 
-function normalizeDiscussionCommentsReactions<
+export function normalizeDiscussionCommentsReactions<
   T extends { reactions: Parameters<typeof normalizeReactions>[0] },
 >(
   comments: readonly T[],
@@ -402,10 +406,53 @@ async function listDiscussionReplyCandidatesWithReactions(
   );
 }
 
-function filterThreadReplies<T extends DiscussionCommentFieldsFragment>(
-  comments: readonly T[],
-  threadId: UUID,
-): T[] {
+/**
+ * Fetch every reply candidate (comments with a parent) for an issue directly by
+ * issue UUID, looping until the connection is exhausted. Used by the activity
+ * timeline, which resolves the issue up front and does not have a thread context.
+ */
+export async function fetchAllIssueDiscussionReplyCandidates(
+  client: GraphQLClient,
+  issueId: UUID,
+): Promise<DiscussionCommentFieldsFragment[]> {
+  const nodes = await collectConnection(async (after) => {
+    const result = await client.request(
+      ListIssueDiscussionReplyCandidatesDocument,
+      { issueId, first: DISCUSSION_REPLY_FETCH_LIMIT, after },
+    );
+
+    return result.comments;
+  });
+
+  return nodes.sort(compareDiscussionCommentsChronologically);
+}
+
+export async function fetchAllIssueDiscussionReplyCandidatesWithReactions(
+  client: GraphQLClient,
+  issueId: UUID,
+): Promise<DiscussionThreadWithReactions[]> {
+  const nodes = await collectConnection(async (after) => {
+    const result = await client.request(
+      ListIssueDiscussionReplyCandidatesWithReactionsDocument,
+      { issueId, first: DISCUSSION_REPLY_FETCH_LIMIT, after },
+    );
+
+    return result.comments;
+  });
+
+  return normalizeDiscussionCommentsReactions(
+    nodes.sort(compareDiscussionCommentsChronologically),
+  );
+}
+
+/**
+ * Index reply candidates by their `parentId`, with each sibling list sorted
+ * chronologically. Building this once lets callers extract many threads'
+ * replies without rescanning the full candidate list per thread.
+ */
+export function buildThreadRepliesIndex<
+  T extends DiscussionCommentFieldsFragment,
+>(comments: readonly T[]): Map<string, T[]> {
   const childrenByParentId = new Map<string, T[]>();
 
   for (const comment of comments) {
@@ -419,6 +466,14 @@ function filterThreadReplies<T extends DiscussionCommentFieldsFragment>(
     childrenByParentId.set(comment.parentId, siblings);
   }
 
+  return childrenByParentId;
+}
+
+/** Walk a pre-built reply index depth-first to collect a thread's replies. */
+export function collectThreadReplies<T extends DiscussionCommentFieldsFragment>(
+  childrenByParentId: ReadonlyMap<string, T[]>,
+  threadId: UUID,
+): T[] {
   const replies: T[] = [];
   const stack = [...(childrenByParentId.get(threadId) ?? [])].reverse();
 
@@ -446,6 +501,13 @@ function filterThreadReplies<T extends DiscussionCommentFieldsFragment>(
   }
 
   return replies;
+}
+
+function filterThreadReplies<T extends DiscussionCommentFieldsFragment>(
+  comments: readonly T[],
+  threadId: UUID,
+): T[] {
+  return collectThreadReplies(buildThreadRepliesIndex(comments), threadId);
 }
 
 function paginateDiscussionReplies<T extends DiscussionCommentFieldsFragment>(

--- a/tests/unit/services/activity-service.test.ts
+++ b/tests/unit/services/activity-service.test.ts
@@ -1,0 +1,366 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { GraphQLClient } from "../../../src/client/graphql-client.js";
+import { asUuid } from "../../../src/common/identifier.js";
+import {
+  GetIssueActivityRefDocument,
+  GetLabelsDocument,
+  ListIssueActivityHistoryDocument,
+  ListIssueDiscussionReplyCandidatesDocument,
+  ListIssueDiscussionReplyCandidatesWithReactionsDocument,
+  ListIssueDiscussionRootsDocument,
+  ListIssueDiscussionRootsWithReactionsDocument,
+} from "../../../src/gql/graphql.js";
+import { getIssueActivity } from "../../../src/services/activity-service.js";
+import type { DiscussionThreadWithReactions } from "../../../src/services/discussion-service.js";
+
+const ISSUE_ID = asUuid("11111111-1111-1111-1111-111111111111");
+const USER = { id: "user-1", displayName: "Ada" };
+
+function createClientMock(): GraphQLClient {
+  return { request: vi.fn() } as unknown as GraphQLClient;
+}
+
+function comment(
+  id: string,
+  createdAt: string,
+  parentId: string | null = null,
+) {
+  return {
+    id,
+    body: `comment-${id}`,
+    createdAt,
+    editedAt: null,
+    parentId,
+    resolvedAt: null,
+    resolvingComment: null,
+    resolvingUser: null,
+    user: USER,
+  };
+}
+
+function commentWithReactions(
+  id: string,
+  createdAt: string,
+  parentId: string | null = null,
+) {
+  return {
+    ...comment(id, createdAt, parentId),
+    reactions: [{ id: "r-1", emoji: "👍", user: USER, externalUser: null }],
+  };
+}
+
+function historyNode(
+  id: string,
+  createdAt: string,
+  overrides: Record<string, unknown> = {},
+) {
+  return {
+    id,
+    createdAt,
+    fromPriority: null,
+    toPriority: null,
+    fromTitle: null,
+    toTitle: null,
+    fromEstimate: null,
+    toEstimate: null,
+    addedLabelIds: null,
+    removedLabelIds: null,
+    archived: null,
+    actor: USER,
+    botActor: null,
+    fromState: null,
+    toState: null,
+    fromAssignee: null,
+    toAssignee: null,
+    fromProject: null,
+    toProject: null,
+    fromCycle: null,
+    toCycle: null,
+    ...overrides,
+  };
+}
+
+const EMPTY_PAGE = { hasNextPage: false, endCursor: null };
+
+interface MockData {
+  ref?: { id: string; identifier: string } | null;
+  roots?: unknown[];
+  rootsWithReactions?: unknown[];
+  replyCandidates?: unknown[];
+  replyCandidatesWithReactions?: unknown[];
+  history?: unknown[];
+  labels?: { id: string; name: string }[];
+}
+
+function mockClient(client: GraphQLClient, data: MockData): void {
+  vi.mocked(client.request).mockImplementation(
+    async (document: unknown): Promise<unknown> => {
+      if (document === GetIssueActivityRefDocument) {
+        return {
+          issue:
+            data.ref === undefined
+              ? { id: ISSUE_ID, identifier: "ENG-1" }
+              : data.ref,
+        };
+      }
+      if (document === ListIssueDiscussionRootsDocument) {
+        return {
+          issue: {
+            comments: { nodes: data.roots ?? [], pageInfo: EMPTY_PAGE },
+          },
+        };
+      }
+      if (document === ListIssueDiscussionRootsWithReactionsDocument) {
+        return {
+          issue: {
+            comments: {
+              nodes: data.rootsWithReactions ?? [],
+              pageInfo: EMPTY_PAGE,
+            },
+          },
+        };
+      }
+      if (document === ListIssueDiscussionReplyCandidatesDocument) {
+        return {
+          comments: { nodes: data.replyCandidates ?? [], pageInfo: EMPTY_PAGE },
+        };
+      }
+      if (
+        document === ListIssueDiscussionReplyCandidatesWithReactionsDocument
+      ) {
+        return {
+          comments: {
+            nodes: data.replyCandidatesWithReactions ?? [],
+            pageInfo: EMPTY_PAGE,
+          },
+        };
+      }
+      if (document === ListIssueActivityHistoryDocument) {
+        return {
+          issue: {
+            history: { nodes: data.history ?? [], pageInfo: EMPTY_PAGE },
+          },
+        };
+      }
+      if (document === GetLabelsDocument) {
+        return {
+          issueLabels: { nodes: data.labels ?? [], pageInfo: EMPTY_PAGE },
+        };
+      }
+      throw new Error("Unexpected document in mock");
+    },
+  );
+}
+
+describe("getIssueActivity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("merges comment threads and history into one chronological timeline", async () => {
+    const client = createClientMock();
+    mockClient(client, {
+      roots: [
+        comment("root-1", "2026-04-21T10:00:00.000Z"),
+        comment("root-2", "2026-04-21T12:00:00.000Z"),
+      ],
+      replyCandidates: [
+        comment("reply-1", "2026-04-21T11:00:00.000Z", "root-1"),
+      ],
+      history: [
+        historyNode("hist-1", "2026-04-21T09:00:00.000Z", {
+          fromState: { id: "s1", name: "Todo" },
+          toState: { id: "s2", name: "In Progress" },
+        }),
+        historyNode("hist-2", "2026-04-21T13:00:00.000Z", {
+          toAssignee: { id: "user-2", displayName: "Alan" },
+        }),
+      ],
+    });
+
+    const result = await getIssueActivity(client, ISSUE_ID);
+
+    expect(result.issue).toEqual({ id: ISSUE_ID, identifier: "ENG-1" });
+    expect(result.activity.map((item) => item.type)).toEqual([
+      "history",
+      "commentThread",
+      "commentThread",
+      "history",
+    ]);
+
+    const [firstHistory, firstThread] = result.activity;
+    expect(firstHistory).toMatchObject({
+      type: "history",
+      id: "hist-1",
+      changes: [
+        {
+          field: "state",
+          from: { id: "s1", name: "Todo" },
+          to: { id: "s2", name: "In Progress" },
+        },
+      ],
+    });
+    expect(firstThread).toMatchObject({ type: "commentThread" });
+    if (firstThread?.type === "commentThread") {
+      expect(firstThread.root.id).toBe("root-1");
+      expect(firstThread.replies.map((reply) => reply.id)).toEqual(["reply-1"]);
+    }
+  });
+
+  it("drops history events whose changes are all outside the captured fields", async () => {
+    const client = createClientMock();
+    mockClient(client, {
+      history: [
+        // No from/to captured field differs -> empty changes, should be dropped.
+        historyNode("hist-empty", "2026-04-21T09:00:00.000Z"),
+        historyNode("hist-state", "2026-04-21T10:00:00.000Z", {
+          fromState: { id: "s1", name: "Todo" },
+          toState: { id: "s2", name: "Done" },
+        }),
+      ],
+    });
+
+    const result = await getIssueActivity(client, ISSUE_ID);
+
+    expect(
+      result.activity.map((item) =>
+        item.type === "history" ? item.id : item.root.id,
+      ),
+    ).toEqual(["hist-state"]);
+  });
+
+  it("resolves label ids on history events to names", async () => {
+    const client = createClientMock();
+    mockClient(client, {
+      history: [
+        historyNode("hist-labels", "2026-04-21T10:00:00.000Z", {
+          addedLabelIds: ["label-1"],
+          removedLabelIds: ["label-2"],
+        }),
+      ],
+      labels: [{ id: "label-1", name: "bug" }],
+    });
+
+    const result = await getIssueActivity(client, ISSUE_ID);
+
+    const [item] = result.activity;
+    expect(item).toMatchObject({
+      type: "history",
+      changes: [
+        {
+          field: "labels",
+          added: [{ id: "label-1", name: "bug" }],
+          // Unknown/deleted label resolves to a null name.
+          removed: [{ id: "label-2", name: null }],
+        },
+      ],
+    });
+    expect(client.request).toHaveBeenCalledWith(
+      GetLabelsDocument,
+      expect.objectContaining({
+        filter: { id: { in: ["label-1", "label-2"] } },
+      }),
+    );
+  });
+
+  it("excludes history events when commentsOnly is set", async () => {
+    const client = createClientMock();
+    mockClient(client, {
+      roots: [comment("root-1", "2026-04-21T10:00:00.000Z")],
+    });
+
+    const result = await getIssueActivity(client, ISSUE_ID, {
+      commentsOnly: true,
+    });
+
+    expect(result.activity.every((item) => item.type === "commentThread")).toBe(
+      true,
+    );
+    expect(client.request).not.toHaveBeenCalledWith(
+      ListIssueActivityHistoryDocument,
+      expect.anything(),
+    );
+  });
+
+  it("includes normalized reactions on root and replies with withReactions", async () => {
+    const client = createClientMock();
+    mockClient(client, {
+      rootsWithReactions: [
+        commentWithReactions("root-1", "2026-04-21T10:00:00.000Z"),
+      ],
+      replyCandidatesWithReactions: [
+        commentWithReactions("reply-1", "2026-04-21T11:00:00.000Z", "root-1"),
+      ],
+    });
+
+    const result = await getIssueActivity(client, ISSUE_ID, {
+      withReactions: true,
+      commentsOnly: true,
+    });
+
+    const [thread] = result.activity;
+    expect(thread?.type).toBe("commentThread");
+    if (thread?.type === "commentThread") {
+      const root = thread.root as DiscussionThreadWithReactions;
+      const replies = thread.replies as DiscussionThreadWithReactions[];
+      expect(Array.isArray(root.reactions)).toBe(true);
+      expect(root.reactions[0]).toMatchObject({ emoji: "👍" });
+      expect(replies[0]?.reactions[0]).toMatchObject({ emoji: "👍" });
+    }
+    expect(client.request).toHaveBeenCalledWith(
+      ListIssueDiscussionRootsWithReactionsDocument,
+      expect.anything(),
+    );
+  });
+
+  it("paginates the merged timeline with an id cursor", async () => {
+    const client = createClientMock();
+    mockClient(client, {
+      roots: [
+        comment("root-1", "2026-04-21T10:00:00.000Z"),
+        comment("root-2", "2026-04-21T11:00:00.000Z"),
+        comment("root-3", "2026-04-21T12:00:00.000Z"),
+      ],
+    });
+
+    const firstPage = await getIssueActivity(client, ISSUE_ID, {
+      limit: 2,
+      commentsOnly: true,
+    });
+    expect(firstPage.activity).toHaveLength(2);
+    expect(firstPage.pageInfo.hasNextPage).toBe(true);
+    expect(firstPage.pageInfo.endCursor).toBe("root-2");
+
+    const secondPage = await getIssueActivity(client, ISSUE_ID, {
+      limit: 2,
+      after: "root-2",
+      commentsOnly: true,
+    });
+    expect(secondPage.activity).toHaveLength(1);
+    expect(secondPage.pageInfo.hasNextPage).toBe(false);
+    expect(secondPage.pageInfo.endCursor).toBe("root-3");
+  });
+
+  it("throws when the after cursor is unknown", async () => {
+    const client = createClientMock();
+    mockClient(client, {
+      roots: [comment("root-1", "2026-04-21T10:00:00.000Z")],
+    });
+
+    await expect(
+      getIssueActivity(client, ISSUE_ID, {
+        after: "does-not-exist",
+        commentsOnly: true,
+      }),
+    ).rejects.toThrow(/cursor "does-not-exist" not found/);
+  });
+
+  it("throws when the issue does not exist", async () => {
+    const client = createClientMock();
+    mockClient(client, { ref: null });
+
+    await expect(getIssueActivity(client, ISSUE_ID)).rejects.toThrow(
+      /not found/,
+    );
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds an `issues activity <issue>` command that merges comment threads (root comments plus nested replies) with issue history events into a single chronological timeline, paginated via an opaque id cursor. Flags `--comments-only` and `--with-reactions` control inclusion of history events and normalized reactions; history events normalize state/assignee/priority/project/cycle/title/estimate/label/archived changes and resolve label IDs to names. Also refactors `discussion-service` to expose reusable reply-index helpers (`buildThreadRepliesIndex`/`collectThreadReplies`) and issue-scoped reply-candidate fetchers consumed by the new activity service.

Closes #144

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Ran `npm run build`, `npm run check:ci`, `npx tsc --noEmit`, and `npm test` (873 tests passing, including the new `activity-service` suite).