### PR TITLE
feat(teams): add team create, update, and membership management

### DIFF
--- a/graphql/mutations/teams.graphql
+++ b/graphql/mutations/teams.graphql
@@ -1,0 +1,59 @@
+# ------------------------------------------------------------
+# GraphQL mutations for Linear team operations
+#
+# Creates and updates teams, and manages team membership. Team
+# mutations return the same TeamDetailFields fragment that `teams read`
+# queries, so the entity shape matches (the read command additionally
+# derives valid estimate options on top of these fields). Membership
+# mutations use Linear's TeamMembership entity: a membership joins a
+# user to a team and is deleted by its own id.
+# ------------------------------------------------------------
+
+# Create a new team
+#
+# Requires at minimum a name. The key is auto-derived from the name
+# when omitted. Returns complete detail fields.
+mutation CreateTeam($input: TeamCreateInput!) {
+  teamCreate(input: $input) {
+    success
+    team {
+      ...TeamDetailFields
+    }
+  }
+}
+
+# Update an existing team
+#
+# Updates mutable team metadata and settings, returning detail fields.
+mutation UpdateTeam($id: String!, $input: TeamUpdateInput!) {
+  teamUpdate(id: $id, input: $input) {
+    success
+    team {
+      ...TeamDetailFields
+    }
+  }
+}
+
+# Add a user to a team
+#
+# Creates a TeamMembership joining the user to the team. Set owner to
+# grant team-admin rights.
+mutation AddTeamMember($input: TeamMembershipCreateInput!) {
+  teamMembershipCreate(input: $input) {
+    success
+    teamMembership {
+      ...TeamMembershipFields
+    }
+  }
+}
+
+# Remove a user from a team
+#
+# Deletes a TeamMembership by its id (resolved from team + user by the
+# service layer).
+mutation RemoveTeamMember($id: String!) {
+  teamMembershipDelete(id: $id) {
+    success
+    entityId
+  }
+}

--- a/graphql/queries/teams.graphql
+++ b/graphql/queries/teams.graphql
@@ -105,3 +105,38 @@ query FindTeams($filter: TeamFilter, $first: Int = 1) {
     }
   }
 }
+
+# Team membership fields fragment
+#
+# A membership joins a user to a team. The membership id is required to
+# delete the membership; owner marks a team admin.
+fragment TeamMembershipFields on TeamMembership {
+  id
+  owner
+  user {
+    id
+    name
+    email
+    displayName
+  }
+}
+
+# List a team's memberships
+#
+# Used by `teams members` and to resolve a membership id from a
+# team + user pair for `teams remove-member`. Paginated by the service
+# layer so all members are fetched regardless of team size.
+query GetTeamMemberships($id: String!, $first: Int = 250, $after: String) {
+  team(id: $id) {
+    id
+    memberships(first: $first, after: $after) {
+      nodes {
+        ...TeamMembershipFields
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}

--- a/src/commands/teams.ts
+++ b/src/commands/teams.ts
@@ -1,10 +1,26 @@
 import type { Command } from "commander";
-import { createContext, getRootOpts } from "../common/context.js";
+import {
+  type CommandContext,
+  createContext,
+  getRootOpts,
+} from "../common/context.js";
+import { invalidParameterError } from "../common/errors.js";
 import { handleCommand, outputSuccess, parseLimit } from "../common/output.js";
 import { buildPaginationOptions } from "../common/types.js";
 import { type DomainMeta, formatDomainUsage } from "../common/usage.js";
 import { resolveTeamId } from "../resolvers/team-resolver.js";
-import { getTeam, listTeams } from "../services/team-service.js";
+import { resolveUserId } from "../resolvers/user-resolver.js";
+import {
+  addTeamMember,
+  type CreateTeamInput,
+  createTeam,
+  getTeam,
+  listTeamMembers,
+  listTeams,
+  removeTeamMember,
+  type UpdateTeamInput,
+  updateTeam,
+} from "../services/team-service.js";
 
 export const TEAMS_META: DomainMeta = {
   name: "teams",
@@ -12,10 +28,232 @@ export const TEAMS_META: DomainMeta = {
   context: [
     "a team is a group of users that owns issues, cycles, statuses, and",
     "labels. teams are identified by a short key (e.g. ENG), name, or UUID.",
+    "teams can be created and updated, and their membership managed with",
+    "add-member/remove-member. boolean settings take an explicit true|false",
+    "value so scripts can set or unset them unambiguously.",
   ].join("\n"),
-  arguments: {},
-  seeAlso: [],
+  arguments: {
+    team: "team identifier (key, name, or UUID)",
+    name: "team display name",
+    user: "user identifier (display name, email, or UUID)",
+  },
+  seeAlso: ["users list", "issues create --team", "cycles list --team"],
 };
+
+const ESTIMATION_TYPES = [
+  "notUsed",
+  "exponential",
+  "fibonacci",
+  "linear",
+  "tShirt",
+] as const;
+
+function parseBooleanOption(flag: string, value: string): boolean {
+  const normalized = value.trim().toLowerCase();
+  if (normalized === "true") return true;
+  if (normalized === "false") return false;
+  throw invalidParameterError(flag, `expected true or false, got "${value}"`);
+}
+
+function parseIntegerOption(flag: string, value: string): number {
+  // Number("") and Number("   ") coerce to 0, so reject blank input first.
+  const parsed = value.trim() === "" ? Number.NaN : Number(value);
+  if (!Number.isInteger(parsed)) {
+    throw invalidParameterError(flag, `expected an integer, got "${value}"`);
+  }
+  return parsed;
+}
+
+// Linear types cycle/auto-close durations and cycleStartDay as Float, so
+// fractional values are valid (e.g. a cycleStartDay with a time-of-day
+// component). Only finite numbers are accepted.
+function parseNumberOption(flag: string, value: string): number {
+  // Number("") and Number("   ") coerce to 0, so reject blank input first.
+  const parsed = value.trim() === "" ? Number.NaN : Number(value);
+  if (!Number.isFinite(parsed)) {
+    throw invalidParameterError(flag, `expected a number, got "${value}"`);
+  }
+  return parsed;
+}
+
+function parseEstimationType(value: string): string {
+  if (!(ESTIMATION_TYPES as readonly string[]).includes(value)) {
+    throw invalidParameterError(
+      "--estimation-type",
+      `expected one of ${ESTIMATION_TYPES.join(", ")}, got "${value}"`,
+    );
+  }
+  return value;
+}
+
+// Shared mutable fields accepted by both `create` and `update`. `name` is
+// handled by the caller (positional for create, --name for update).
+interface TeamFieldOptions {
+  key?: string;
+  description?: string;
+  private?: string;
+  icon?: string;
+  color?: string;
+  timezone?: string;
+  parent?: string;
+  estimationType?: string;
+  estimationExtended?: string;
+  estimationAllowZero?: string;
+  defaultEstimate?: string;
+  inheritEstimation?: string;
+  cyclesEnabled?: string;
+  cycleDuration?: string;
+  cycleCooldown?: string;
+  cycleStartDay?: string;
+  triageEnabled?: string;
+  requirePriorityToLeaveTriage?: string;
+  autoClosePeriod?: string;
+  autoArchivePeriod?: string;
+}
+
+// Build the shared mutable field set once, resolving the parent team to a
+// UUID. Only fields the user provided are included, so `update` never
+// overwrites untouched settings.
+async function buildTeamFields(
+  ctx: CommandContext,
+  options: TeamFieldOptions,
+): Promise<UpdateTeamInput> {
+  const input: UpdateTeamInput = {};
+
+  if (options.key !== undefined) input.key = options.key;
+  if (options.description !== undefined)
+    input.description = options.description;
+  if (options.icon !== undefined) input.icon = options.icon;
+  if (options.color !== undefined) input.color = options.color;
+  if (options.timezone !== undefined) input.timezone = options.timezone;
+
+  if (options.private !== undefined) {
+    input.private = parseBooleanOption("--private", options.private);
+  }
+
+  if (options.parent !== undefined) {
+    input.parentId = await resolveTeamId(ctx.gql, options.parent);
+  }
+
+  if (options.estimationType !== undefined) {
+    input.issueEstimationType = parseEstimationType(options.estimationType);
+  }
+  if (options.estimationExtended !== undefined) {
+    input.issueEstimationExtended = parseBooleanOption(
+      "--estimation-extended",
+      options.estimationExtended,
+    );
+  }
+  if (options.estimationAllowZero !== undefined) {
+    input.issueEstimationAllowZero = parseBooleanOption(
+      "--estimation-allow-zero",
+      options.estimationAllowZero,
+    );
+  }
+  if (options.defaultEstimate !== undefined) {
+    input.defaultIssueEstimate = parseIntegerOption(
+      "--default-estimate",
+      options.defaultEstimate,
+    );
+  }
+  if (options.inheritEstimation !== undefined) {
+    input.inheritIssueEstimation = parseBooleanOption(
+      "--inherit-estimation",
+      options.inheritEstimation,
+    );
+  }
+
+  if (options.cyclesEnabled !== undefined) {
+    input.cyclesEnabled = parseBooleanOption(
+      "--cycles-enabled",
+      options.cyclesEnabled,
+    );
+  }
+  if (options.cycleDuration !== undefined) {
+    input.cycleDuration = parseNumberOption(
+      "--cycle-duration",
+      options.cycleDuration,
+    );
+  }
+  if (options.cycleCooldown !== undefined) {
+    input.cycleCooldownTime = parseNumberOption(
+      "--cycle-cooldown",
+      options.cycleCooldown,
+    );
+  }
+  if (options.cycleStartDay !== undefined) {
+    input.cycleStartDay = parseNumberOption(
+      "--cycle-start-day",
+      options.cycleStartDay,
+    );
+  }
+
+  if (options.triageEnabled !== undefined) {
+    input.triageEnabled = parseBooleanOption(
+      "--triage-enabled",
+      options.triageEnabled,
+    );
+  }
+  if (options.requirePriorityToLeaveTriage !== undefined) {
+    input.requirePriorityToLeaveTriage = parseBooleanOption(
+      "--require-priority-to-leave-triage",
+      options.requirePriorityToLeaveTriage,
+    );
+  }
+  if (options.autoClosePeriod !== undefined) {
+    input.autoClosePeriod = parseNumberOption(
+      "--auto-close-period",
+      options.autoClosePeriod,
+    );
+  }
+  if (options.autoArchivePeriod !== undefined) {
+    input.autoArchivePeriod = parseNumberOption(
+      "--auto-archive-period",
+      options.autoArchivePeriod,
+    );
+  }
+
+  return input;
+}
+
+// Register the estimation/cycle/triage flags shared by create and update.
+function addTeamSettingFlags(command: Command): Command {
+  return command
+    .option("--description <text>", "team description")
+    .option("--private <true|false>", "whether the team is private")
+    .option("--icon <icon>", "team icon")
+    .option("--color <color>", "team color (hex)")
+    .option("--timezone <tz>", "team timezone (e.g. America/New_York)")
+    .option("--parent <team>", "parent team (key, name, or UUID)")
+    .option(
+      "--estimation-type <type>",
+      `estimation scale (${ESTIMATION_TYPES.join(" | ")})`,
+    )
+    .option(
+      "--estimation-extended <true|false>",
+      "add extended estimate points",
+    )
+    .option(
+      "--estimation-allow-zero <true|false>",
+      "allow zero-point estimates",
+    )
+    .option("--default-estimate <n>", "default estimate for unestimated issues")
+    .option(
+      "--inherit-estimation <true|false>",
+      "inherit estimation from parent (sub-teams only)",
+    )
+    .option("--cycles-enabled <true|false>", "whether the team uses cycles")
+    .option("--cycle-duration <weeks>", "cycle length in weeks")
+    .option("--cycle-cooldown <n>", "cooldown between cycles in weeks")
+    .option("--cycle-start-day <n>", "day of week a new cycle starts")
+    .option("--triage-enabled <true|false>", "whether triage mode is enabled")
+    .option(
+      "--require-priority-to-leave-triage <true|false>",
+      "require a priority before leaving triage",
+    )
+    .option("--auto-close-period <months>", "auto-close period in months")
+    .option("--auto-archive-period <months>", "auto-archive period in months");
+}
 
 export function setupTeamsCommands(program: Command): void {
   const teams = program.command("teams").description("Team operations");
@@ -52,6 +290,122 @@ export function setupTeamsCommands(program: Command): void {
         const ctx = createContext(getRootOpts(command));
         const teamId = await resolveTeamId(ctx.gql, team);
         const result = await getTeam(ctx.gql, { id: teamId });
+        outputSuccess(result);
+      }),
+    );
+
+  addTeamSettingFlags(
+    teams
+      .command("create <name>")
+      .description("create a new team")
+      .option(
+        "--key <key>",
+        "unique team key (auto-derived from name if omitted)",
+      ),
+  ).action(
+    handleCommand(async (...args: unknown[]) => {
+      const [name, options, command] = args as [
+        string,
+        TeamFieldOptions,
+        Command,
+      ];
+      const ctx = createContext(getRootOpts(command));
+      const fields = await buildTeamFields(ctx, options);
+      const input: CreateTeamInput = { ...fields, name };
+      const result = await createTeam(ctx.gql, input);
+      outputSuccess(result);
+    }),
+  );
+
+  addTeamSettingFlags(
+    teams
+      .command("update <team>")
+      .description("update an existing team")
+      .option("--name <name>", "new team name")
+      .option("--key <key>", "new team key"),
+  ).action(
+    handleCommand(async (...args: unknown[]) => {
+      const [team, options, command] = args as [
+        string,
+        TeamFieldOptions & { name?: string },
+        Command,
+      ];
+      const ctx = createContext(getRootOpts(command));
+      const input = await buildTeamFields(ctx, options);
+      if (options.name !== undefined) input.name = options.name;
+
+      if (Object.keys(input).length === 0) {
+        throw invalidParameterError(
+          "update options",
+          "at least one field must be provided",
+        );
+      }
+
+      const teamId = await resolveTeamId(ctx.gql, team);
+      const result = await updateTeam(ctx.gql, teamId, input);
+      outputSuccess(result);
+    }),
+  );
+
+  teams
+    .command("members <team>")
+    .description("list a team's members")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const team = args[0] as string;
+        const command = args.at(-1) as Command;
+        const ctx = createContext(getRootOpts(command));
+        const teamId = await resolveTeamId(ctx.gql, team);
+        const result = await listTeamMembers(ctx.gql, { id: teamId });
+        outputSuccess(result);
+      }),
+    );
+
+  teams
+    .command("add-member <team>")
+    .description("add a user to a team")
+    .requiredOption("--user <user>", "user display name, email, or UUID")
+    .option("--owner <true|false>", "grant team-admin (owner) rights")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [team, options, command] = args as [
+          string,
+          { user: string; owner?: string },
+          Command,
+        ];
+        const ctx = createContext(getRootOpts(command));
+        const [teamId, userId] = await Promise.all([
+          resolveTeamId(ctx.gql, team),
+          resolveUserId(ctx.gql, options.user),
+        ]);
+        const result = await addTeamMember(ctx.gql, {
+          teamId,
+          userId,
+          ...(options.owner === undefined
+            ? {}
+            : { owner: parseBooleanOption("--owner", options.owner) }),
+        });
+        outputSuccess(result);
+      }),
+    );
+
+  teams
+    .command("remove-member <team>")
+    .description("remove a user from a team")
+    .requiredOption("--user <user>", "user display name, email, or UUID")
+    .action(
+      handleCommand(async (...args: unknown[]) => {
+        const [team, options, command] = args as [
+          string,
+          { user: string },
+          Command,
+        ];
+        const ctx = createContext(getRootOpts(command));
+        const [teamId, userId] = await Promise.all([
+          resolveTeamId(ctx.gql, team),
+          resolveUserId(ctx.gql, options.user),
+        ]);
+        const result = await removeTeamMember(ctx.gql, { teamId, userId });
         outputSuccess(result);
       }),
     );

--- a/src/services/team-service.ts
+++ b/src/services/team-service.ts
@@ -1,10 +1,26 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
-import type { UUID } from "../common/identifier.js";
+import { notFoundError } from "../common/errors.js";
+import type { BrandUuidFields, UUID } from "../common/identifier.js";
+import {
+  requireMutationEntity,
+  requireMutationSuccess,
+} from "../common/mutation-payload.js";
 import type { PaginatedResult, PaginationOptions } from "../common/types.js";
 import {
+  AddTeamMemberDocument,
+  type AddTeamMemberMutation,
+  CreateTeamDocument,
+  type CreateTeamMutation,
   GetTeamByIdDocument,
   type GetTeamByIdQuery,
+  GetTeamMembershipsDocument,
+  type GetTeamMembershipsQuery,
   GetTeamsDocument,
+  RemoveTeamMemberDocument,
+  type TeamCreateInput,
+  type TeamUpdateInput,
+  UpdateTeamDocument,
+  type UpdateTeamMutation,
 } from "../gql/graphql.js";
 
 // Team projection types
@@ -25,6 +41,65 @@ export interface Team {
   key: string;
   name: string;
 }
+
+export type CreatedTeam = NonNullable<CreateTeamMutation["teamCreate"]["team"]>;
+export type UpdatedTeam = NonNullable<UpdateTeamMutation["teamUpdate"]["team"]>;
+export type TeamMembership = NonNullable<
+  AddTeamMemberMutation["teamMembershipCreate"]["teamMembership"]
+>;
+
+// Mutable team fields the command layer may set. UUIDs (parentId) are
+// pre-resolved by the command before reaching the service.
+type TeamMutableFields =
+  | "name"
+  | "key"
+  | "description"
+  | "private"
+  | "icon"
+  | "color"
+  | "timezone"
+  | "parentId"
+  | "issueEstimationType"
+  | "issueEstimationExtended"
+  | "issueEstimationAllowZero"
+  | "defaultIssueEstimate"
+  | "inheritIssueEstimation"
+  | "cyclesEnabled"
+  | "cycleDuration"
+  | "cycleCooldownTime"
+  | "cycleStartDay"
+  | "triageEnabled"
+  | "requirePriorityToLeaveTriage"
+  | "autoClosePeriod"
+  | "autoArchivePeriod";
+
+export type CreateTeamInput = BrandUuidFields<
+  Pick<TeamCreateInput, TeamMutableFields>,
+  "parentId"
+>;
+export type UpdateTeamInput = BrandUuidFields<
+  Pick<TeamUpdateInput, TeamMutableFields>,
+  "parentId"
+>;
+
+export interface AddTeamMemberInput {
+  teamId: UUID;
+  userId: UUID;
+  owner?: boolean;
+}
+
+export interface RemoveTeamMemberInput {
+  teamId: UUID;
+  userId: UUID;
+}
+
+export type DeletedTeamMembership = {
+  id: string;
+  success: true;
+};
+
+type TeamMembershipNode =
+  GetTeamMembershipsQuery["team"]["memberships"]["nodes"][number];
 
 interface GetTeamInput {
   id: UUID;
@@ -153,4 +228,119 @@ export async function getTeam(
     validEstimates: deriveValidEstimates(config),
     estimationSource: source,
   };
+}
+
+export async function createTeam(
+  client: GraphQLClient,
+  input: CreateTeamInput,
+): Promise<CreatedTeam> {
+  const gqlInput: TeamCreateInput = input;
+  const result = await client.request(CreateTeamDocument, { input: gqlInput });
+
+  return requireMutationEntity(
+    result.teamCreate,
+    "team",
+    `Failed to create team "${input.name}"`,
+  );
+}
+
+export async function updateTeam(
+  client: GraphQLClient,
+  id: UUID,
+  input: UpdateTeamInput,
+): Promise<UpdatedTeam> {
+  const gqlInput: TeamUpdateInput = input;
+  const result = await client.request(UpdateTeamDocument, {
+    id,
+    input: gqlInput,
+  });
+
+  return requireMutationEntity(
+    result.teamUpdate,
+    "team",
+    `Failed to update team "${id}"`,
+  );
+}
+
+async function fetchTeamMemberships(
+  client: GraphQLClient,
+  teamId: UUID,
+): Promise<TeamMembershipNode[]> {
+  const nodes: TeamMembershipNode[] = [];
+  let after: string | undefined;
+
+  while (true) {
+    const result = await client.request(GetTeamMembershipsDocument, {
+      id: teamId,
+      after,
+    });
+
+    if (!result.team) {
+      throw notFoundError("Team", teamId);
+    }
+
+    const { memberships } = result.team;
+    nodes.push(...memberships.nodes);
+
+    if (!memberships.pageInfo.hasNextPage || !memberships.pageInfo.endCursor) {
+      break;
+    }
+
+    after = memberships.pageInfo.endCursor;
+  }
+
+  return nodes;
+}
+
+export async function listTeamMembers(
+  client: GraphQLClient,
+  input: GetTeamInput,
+): Promise<{ nodes: TeamMembershipNode[] }> {
+  return { nodes: await fetchTeamMemberships(client, input.id) };
+}
+
+export async function addTeamMember(
+  client: GraphQLClient,
+  input: AddTeamMemberInput,
+): Promise<TeamMembership> {
+  const result = await client.request(AddTeamMemberDocument, {
+    input: {
+      teamId: input.teamId,
+      userId: input.userId,
+      ...(input.owner === undefined ? {} : { owner: input.owner }),
+    },
+  });
+
+  return requireMutationEntity(
+    result.teamMembershipCreate,
+    "teamMembership",
+    `Failed to add user "${input.userId}" to team "${input.teamId}"`,
+  );
+}
+
+export async function removeTeamMember(
+  client: GraphQLClient,
+  input: RemoveTeamMemberInput,
+): Promise<DeletedTeamMembership> {
+  const memberships = await fetchTeamMemberships(client, input.teamId);
+  const membership = memberships.find((m) => m.user?.id === input.userId);
+
+  if (!membership) {
+    throw notFoundError(
+      "Team member",
+      input.userId,
+      `on team "${input.teamId}"`,
+    );
+  }
+
+  const result = await client.request(RemoveTeamMemberDocument, {
+    id: membership.id,
+  });
+
+  requireMutationSuccess(
+    result.teamMembershipDelete,
+    `Failed to remove user "${input.userId}" from team "${input.teamId}"`,
+  );
+
+  return { id: result.teamMembershipDelete.entityId, success: true };
 }

--- a/tests/integration/teams-cli.test.ts
+++ b/tests/integration/teams-cli.test.ts
@@ -34,6 +34,38 @@ describe("Teams CLI Commands", () => {
       expect(stdout).toContain("Team operations");
       expect(stdout).toContain("list");
     });
+
+    it("should list the management subcommands", async () => {
+      const { stdout } = await execAsync(`node ${CLI_PATH} teams --help`);
+
+      expect(stdout).toContain("create");
+      expect(stdout).toContain("update");
+      expect(stdout).toContain("members");
+      expect(stdout).toContain("add-member");
+      expect(stdout).toContain("remove-member");
+    });
+  });
+
+  describe("teams create --help", () => {
+    it("should document create flags", async () => {
+      const { stdout } = await execAsync(
+        `node ${CLI_PATH} teams create --help`,
+      );
+
+      expect(stdout).toContain("--key");
+      expect(stdout).toContain("--estimation-type");
+      expect(stdout).toContain("--parent");
+    });
+  });
+
+  describe("teams add-member --help", () => {
+    it("should document the --user flag", async () => {
+      const { stdout } = await execAsync(
+        `node ${CLI_PATH} teams add-member --help`,
+      );
+
+      expect(stdout).toContain("--user");
+    });
   });
 
   describe("teams list", () => {

--- a/tests/unit/commands/teams.test.ts
+++ b/tests/unit/commands/teams.test.ts
@@ -21,6 +21,10 @@ vi.mock("../../../src/resolvers/team-resolver.js", () => ({
   resolveTeamId: vi.fn().mockResolvedValue("resolved-team-uuid"),
 }));
 
+vi.mock("../../../src/resolvers/user-resolver.js", () => ({
+  resolveUserId: vi.fn().mockResolvedValue("resolved-user-uuid"),
+}));
+
 vi.mock("../../../src/services/team-service.js", () => ({
   listTeams: vi.fn().mockResolvedValue({
     nodes: [{ id: "team-1", key: "ENG", name: "Engineering" }],
@@ -38,12 +42,36 @@ vi.mock("../../../src/services/team-service.js", () => ({
     ],
     estimationSource: "self",
   }),
+  createTeam: vi
+    .fn()
+    .mockResolvedValue({ id: "team-new", key: "NEW", name: "New Team" }),
+  updateTeam: vi
+    .fn()
+    .mockResolvedValue({ id: "team-1", key: "ENG", name: "Renamed" }),
+  listTeamMembers: vi.fn().mockResolvedValue({
+    nodes: [{ id: "m1", owner: true, user: { id: "user-1", name: "Alice" } }],
+  }),
+  addTeamMember: vi.fn().mockResolvedValue({
+    id: "m1",
+    owner: false,
+    user: { id: "user-1", name: "Alice" },
+  }),
+  removeTeamMember: vi.fn().mockResolvedValue({ id: "m1", success: true }),
 }));
 
 import { setupTeamsCommands } from "../../../src/commands/teams.js";
 import { outputSuccess } from "../../../src/common/output.js";
 import { resolveTeamId } from "../../../src/resolvers/team-resolver.js";
-import { getTeam, listTeams } from "../../../src/services/team-service.js";
+import { resolveUserId } from "../../../src/resolvers/user-resolver.js";
+import {
+  addTeamMember,
+  createTeam,
+  getTeam,
+  listTeamMembers,
+  listTeams,
+  removeTeamMember,
+  updateTeam,
+} from "../../../src/services/team-service.js";
 
 function createProgram(): Command {
   const program = new Command();
@@ -99,5 +127,157 @@ describe("teams list", () => {
       nodes: [{ id: "team-1", key: "ENG", name: "Engineering" }],
       pageInfo: { hasNextPage: false, endCursor: null },
     });
+  });
+});
+
+describe("teams create", () => {
+  it("builds input from flags and outputs the created team", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "teams",
+      "create",
+      "New Team",
+      "--key",
+      "NEW",
+      "--private",
+      "true",
+      "--cycles-enabled",
+      "false",
+      "--cycle-duration",
+      "2",
+    ]);
+
+    expect(createTeam).toHaveBeenCalledWith(expect.anything(), {
+      name: "New Team",
+      key: "NEW",
+      private: true,
+      cyclesEnabled: false,
+      cycleDuration: 2,
+    });
+    expect(outputSuccess).toHaveBeenCalledWith({
+      id: "team-new",
+      key: "NEW",
+      name: "New Team",
+    });
+  });
+
+  it("rejects an invalid estimation type", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "teams",
+      "create",
+      "New Team",
+      "--estimation-type",
+      "bogus",
+    ]);
+
+    expect(createTeam).not.toHaveBeenCalled();
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("teams update", () => {
+  it("resolves the team and passes only provided fields", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "teams",
+      "update",
+      "ENG",
+      "--name",
+      "Renamed",
+      "--triage-enabled",
+      "true",
+    ]);
+
+    expect(resolveTeamId).toHaveBeenCalledWith(expect.anything(), "ENG");
+    expect(updateTeam).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-team-uuid",
+      { name: "Renamed", triageEnabled: true },
+    );
+  });
+
+  it("errors when no fields are provided", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "test", "teams", "update", "ENG"]);
+
+    expect(updateTeam).not.toHaveBeenCalled();
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("teams members", () => {
+  it("lists members for the resolved team", async () => {
+    const program = createProgram();
+
+    await program.parseAsync(["node", "test", "teams", "members", "ENG"]);
+
+    expect(listTeamMembers).toHaveBeenCalledWith(expect.anything(), {
+      id: "resolved-team-uuid",
+    });
+    expect(outputSuccess).toHaveBeenCalledWith({
+      nodes: [{ id: "m1", owner: true, user: { id: "user-1", name: "Alice" } }],
+    });
+  });
+});
+
+describe("teams add-member", () => {
+  it("resolves team and user then adds the member", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "teams",
+      "add-member",
+      "ENG",
+      "--user",
+      "alice@example.com",
+      "--owner",
+      "true",
+    ]);
+
+    expect(resolveTeamId).toHaveBeenCalledWith(expect.anything(), "ENG");
+    expect(resolveUserId).toHaveBeenCalledWith(
+      expect.anything(),
+      "alice@example.com",
+    );
+    expect(addTeamMember).toHaveBeenCalledWith(expect.anything(), {
+      teamId: "resolved-team-uuid",
+      userId: "resolved-user-uuid",
+      owner: true,
+    });
+  });
+});
+
+describe("teams remove-member", () => {
+  it("resolves team and user then removes the member", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "teams",
+      "remove-member",
+      "ENG",
+      "--user",
+      "alice@example.com",
+    ]);
+
+    expect(removeTeamMember).toHaveBeenCalledWith(expect.anything(), {
+      teamId: "resolved-team-uuid",
+      userId: "resolved-user-uuid",
+    });
+    expect(outputSuccess).toHaveBeenCalledWith({ id: "m1", success: true });
   });
 });

--- a/tests/unit/services/team-service.test.ts
+++ b/tests/unit/services/team-service.test.ts
@@ -4,11 +4,16 @@ import { describe, expect, it, vi } from "vitest";
 import type { GraphQLClient } from "../../../src/client/graphql-client.js";
 import { asUuid } from "../../../src/common/identifier.js";
 import {
+  addTeamMember,
+  createTeam,
   getTeam,
+  listTeamMembers,
   listTeams,
+  removeTeamMember,
   type TeamDetail,
   type TeamEstimateOption,
   type TeamEstimationSource,
+  updateTeam,
 } from "../../../src/services/team-service.js";
 
 const assertTeamDetailShape = (value: TeamDetail): TeamDetail => value;
@@ -398,5 +403,250 @@ describe("getTeam", () => {
       { value: 6, label: "6" },
       { value: 7, label: "7" },
     ]);
+  });
+});
+
+describe("createTeam", () => {
+  it("returns the created team", async () => {
+    const client = mockGqlClient({
+      teamCreate: {
+        success: true,
+        team: { id: "team-new", key: "NEW", name: "New Team" },
+      },
+    });
+
+    const result = await createTeam(client, { name: "New Team", key: "NEW" });
+
+    expect(result.id).toBe("team-new");
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      input: { name: "New Team", key: "NEW" },
+    });
+  });
+
+  it("throws when the mutation fails", async () => {
+    const client = mockGqlClient({
+      teamCreate: { success: false, team: null },
+    });
+
+    await expect(createTeam(client, { name: "Fail" })).rejects.toThrow(
+      'Failed to create team "Fail"',
+    );
+  });
+});
+
+describe("updateTeam", () => {
+  it("returns the updated team", async () => {
+    const client = mockGqlClient({
+      teamUpdate: {
+        success: true,
+        team: { id: "team-1", key: "ENG", name: "Renamed" },
+      },
+    });
+
+    const result = await updateTeam(client, asUuid("team-1"), {
+      name: "Renamed",
+    });
+
+    expect(result.name).toBe("Renamed");
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      id: "team-1",
+      input: { name: "Renamed" },
+    });
+  });
+
+  it("throws when the mutation fails", async () => {
+    const client = mockGqlClient({
+      teamUpdate: { success: false, team: null },
+    });
+
+    await expect(
+      updateTeam(client, asUuid("team-1"), { name: "Renamed" }),
+    ).rejects.toThrow('Failed to update team "team-1"');
+  });
+});
+
+describe("listTeamMembers", () => {
+  it("returns the team's memberships", async () => {
+    const client = mockGqlClient({
+      team: {
+        id: "team-1",
+        key: "ENG",
+        name: "Engineering",
+        memberships: {
+          nodes: [
+            { id: "m1", owner: true, user: { id: "user-1", name: "Alice" } },
+          ],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+    });
+
+    const result = await listTeamMembers(client, { id: asUuid("team-1") });
+
+    expect(result.nodes).toHaveLength(1);
+    expect(result.nodes[0]?.id).toBe("m1");
+  });
+
+  it("paginates until all members are fetched", async () => {
+    const client = mockGqlClientWithSequence([
+      {
+        team: {
+          id: "team-1",
+          key: "ENG",
+          name: "Engineering",
+          memberships: {
+            nodes: [
+              { id: "m1", owner: true, user: { id: "user-1", name: "Alice" } },
+            ],
+            pageInfo: { hasNextPage: true, endCursor: "cursor-1" },
+          },
+        },
+      },
+      {
+        team: {
+          id: "team-1",
+          key: "ENG",
+          name: "Engineering",
+          memberships: {
+            nodes: [
+              { id: "m2", owner: false, user: { id: "user-2", name: "Bob" } },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+    ]);
+
+    const result = await listTeamMembers(client, { id: asUuid("team-1") });
+
+    expect(result.nodes.map((m) => m.id)).toEqual(["m1", "m2"]);
+    expect(client.request).toHaveBeenNthCalledWith(2, expect.anything(), {
+      id: "team-1",
+      after: "cursor-1",
+    });
+  });
+
+  it("throws when the team is not found", async () => {
+    const client = mockGqlClient({ team: null });
+
+    await expect(
+      listTeamMembers(client, { id: asUuid("missing") }),
+    ).rejects.toThrow('Team "missing" not found');
+  });
+});
+
+describe("addTeamMember", () => {
+  it("returns the created membership", async () => {
+    const client = mockGqlClient({
+      teamMembershipCreate: {
+        success: true,
+        teamMembership: {
+          id: "m1",
+          owner: false,
+          user: { id: "user-1", name: "Alice" },
+        },
+      },
+    });
+
+    const result = await addTeamMember(client, {
+      teamId: asUuid("team-1"),
+      userId: asUuid("user-1"),
+    });
+
+    expect(result.id).toBe("m1");
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      input: { teamId: "team-1", userId: "user-1" },
+    });
+  });
+
+  it("passes owner when provided", async () => {
+    const client = mockGqlClient({
+      teamMembershipCreate: {
+        success: true,
+        teamMembership: {
+          id: "m1",
+          owner: true,
+          user: { id: "user-1", name: "Alice" },
+        },
+      },
+    });
+
+    await addTeamMember(client, {
+      teamId: asUuid("team-1"),
+      userId: asUuid("user-1"),
+      owner: true,
+    });
+
+    expect(client.request).toHaveBeenCalledWith(expect.anything(), {
+      input: { teamId: "team-1", userId: "user-1", owner: true },
+    });
+  });
+
+  it("throws when the mutation fails", async () => {
+    const client = mockGqlClient({
+      teamMembershipCreate: { success: false, teamMembership: null },
+    });
+
+    await expect(
+      addTeamMember(client, {
+        teamId: asUuid("team-1"),
+        userId: asUuid("user-1"),
+      }),
+    ).rejects.toThrow('Failed to add user "user-1" to team "team-1"');
+  });
+});
+
+describe("removeTeamMember", () => {
+  it("resolves the membership id and deletes it", async () => {
+    const client = mockGqlClientWithSequence([
+      {
+        team: {
+          id: "team-1",
+          key: "ENG",
+          name: "Engineering",
+          memberships: {
+            nodes: [
+              { id: "m1", owner: false, user: { id: "user-1", name: "Alice" } },
+              { id: "m2", owner: false, user: { id: "user-2", name: "Bob" } },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: null },
+          },
+        },
+      },
+      { teamMembershipDelete: { success: true, entityId: "m2" } },
+    ]);
+
+    const result = await removeTeamMember(client, {
+      teamId: asUuid("team-1"),
+      userId: asUuid("user-2"),
+    });
+
+    expect(result).toEqual({ id: "m2", success: true });
+    expect(client.request).toHaveBeenNthCalledWith(2, expect.anything(), {
+      id: "m2",
+    });
+  });
+
+  it("throws when the user is not a team member", async () => {
+    const client = mockGqlClient({
+      team: {
+        id: "team-1",
+        key: "ENG",
+        name: "Engineering",
+        memberships: {
+          nodes: [
+            { id: "m1", owner: false, user: { id: "user-1", name: "Alice" } },
+          ],
+          pageInfo: { hasNextPage: false, endCursor: null },
+        },
+      },
+    });
+
+    await expect(
+      removeTeamMember(client, {
+        teamId: asUuid("team-1"),
+        userId: asUuid("user-9"),
+      }),
+    ).rejects.toThrow('Team member "user-9" on team "team-1" not found');
   });
 });


### PR DESCRIPTION
## What does this PR do?

Adds team management to the `teams` command group: `create`, `update`, `members`, `add-member`, and `remove-member` subcommands. Team/user IDs are resolved once in the command layer, and membership listing paginates so all members are fetched regardless of team size. Estimation, cycle, and triage settings are exposed as explicit `true|false` flags so scripts can set or unset them unambiguously. New GraphQL mutations (`CreateTeam`, `UpdateTeam`, `AddTeamMember`, `RemoveTeamMember`) and a `GetTeamMemberships` query back the service layer, with unit, command, and integration test coverage.

Closes #142

## Type of change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

`npm run check:ci`, `npx tsc --noEmit`, and `npm test` (884 tests) all pass locally.

## Notes for reviewers

`remove-member` resolves the membership id from the team + user pair by paginating memberships, since Linear deletes memberships by their own id.