### PR TITLE
ci: Fail release on failed npm publish and use OIDC trusted publishing

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -97,26 +97,18 @@ jobs:
           git config user.name "${{ steps.app-bot.outputs.name }}"
           git config user.email "${{ steps.app-bot.outputs.email }}"
 
-      # No `registry-url`: passing it makes setup-node write a
-      # `_authToken=${NODE_AUTH_TOKEN}` line into .npmrc, which shadows OIDC.
-      # npm defaults to the official registry, and auth is OIDC trusted
-      # publishing (no token) — see the "Run semantic-release" step.
+      # No registry-url: it writes _authToken into .npmrc, shadowing OIDC.
       - name: Setup, install and build
         uses: ./.github/actions/setup
 
-      # OIDC trusted publishing requires npm >= 11.5.1; .nvmrc pins only the
-      # Node major, so the bundled npm minor is not guaranteed. Pin a floor
-      # (not @latest, which would inject an unreviewed npm into the publish path).
+      # OIDC trusted publishing needs npm >= 11.5.1; .nvmrc pins only Node major.
       - name: Ensure npm supports trusted publishing
         shell: bash
         run: |
           npm install -g npm@^11.5.1
           npm --version
 
-      # Auth is npm OIDC trusted publishing: no NODE_AUTH_TOKEN is set, so the
-      # npm CLI performs the OIDC exchange (id-token: write + npmjs trusted
-      # publisher for this workflow/environment). GH_TOKEN/GITHUB_TOKEN are the
-      # linearis-bot App token, used only for the GitHub release + git push.
+      # Publishes via OIDC (no NODE_AUTH_TOKEN); GH_TOKEN is only for the release + push.
       - name: Run semantic-release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -97,26 +97,30 @@ jobs:
           git config user.name "${{ steps.app-bot.outputs.name }}"
           git config user.email "${{ steps.app-bot.outputs.email }}"
 
+      # No `registry-url`: passing it makes setup-node write a
+      # `_authToken=${NODE_AUTH_TOKEN}` line into .npmrc, which shadows OIDC.
+      # npm defaults to the official registry, and auth is OIDC trusted
+      # publishing (no token) — see the "Run semantic-release" step.
       - name: Setup, install and build
         uses: ./.github/actions/setup
-        with:
-          registry-url: https://registry.npmjs.org
 
-      - name: Verify npm auth
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+      # OIDC trusted publishing requires npm >= 11.5.1; .nvmrc pins only the
+      # Node major, so the bundled npm minor is not guaranteed. Pin a floor
+      # (not @latest, which would inject an unreviewed npm into the publish path).
+      - name: Ensure npm supports trusted publishing
+        shell: bash
         run: |
-          test -n "${NODE_AUTH_TOKEN}" || {
-            echo "NPM_TOKEN missing (check job environment + secret scope)"
-            exit 1
-          }
-          npm whoami --registry=https://registry.npmjs.org/
+          npm install -g npm@^11.5.1
+          npm --version
 
+      # Auth is npm OIDC trusted publishing: no NODE_AUTH_TOKEN is set, so the
+      # npm CLI performs the OIDC exchange (id-token: write + npmjs trusted
+      # publisher for this workflow/environment). GH_TOKEN/GITHUB_TOKEN are the
+      # linearis-bot App token, used only for the GitHub release + git push.
       - name: Run semantic-release
         env:
           GH_TOKEN: ${{ steps.app-token.outputs.token }}
           GITHUB_TOKEN: ${{ steps.app-token.outputs.token }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           GITHUB_REF: refs/heads/${{ steps.target.outputs.branch }}
           GITHUB_REF_NAME: ${{ steps.target.outputs.branch }}
         run: npm run release:run

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 /src/gql/
 USAGE.md
 
+# clean-publish staging dir (release publish; see .releaserc.cjs)
+/.clean-pkg/
+
 docs/superpowers/
 
 # pi

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -35,8 +35,29 @@ module.exports = {
     [
       "@semantic-release/exec",
       {
-        publishCmd:
-          'npx clean-publish --access public --tag $( [ "$GITHUB_REF_NAME" = "next" ] && echo next || echo latest ) -- --provenance',
+        // Publish in two explicit stages so a failed `npm publish` FAILS the
+        // release. `clean-publish --without-publish` only strips the configured
+        // package.json fields into a deterministic `.clean-pkg` dir (it swallows
+        // exit codes, so it must NOT own the publish); the real `npm publish`
+        // then runs directly, and its non-zero exit propagates to this plugin.
+        // Auth is npm OIDC trusted publishing (no NODE_AUTH_TOKEN in CI).
+        // Runs under `/bin/sh -c` (POSIX) via @semantic-release/exec shell:true.
+        publishCmd: [
+          "set -e",
+          "npx clean-publish --without-publish --temp-dir .clean-pkg",
+          'VERSION="$(node -p "require(\'./.clean-pkg/package.json\').version")"',
+          'TAG="$([ "$GITHUB_REF_NAME" = next ] && echo next || echo latest)"',
+          'npm publish ./.clean-pkg --provenance --access public --tag "$TAG"',
+          // Read-back guard: the original outage was a publish that "succeeded"
+          // while nothing reached the registry. Fail loudly if the version is
+          // not actually visible (retry for read-after-write lag).
+          "for i in $(seq 1 6); do",
+          '  if npm view "linearis@$VERSION" version; then FOUND=1; break; fi',
+          '  echo "waiting for registry to reflect $VERSION ($i/6)"; sleep 5',
+          "done",
+          '[ "$FOUND" = 1 ] || { echo "publish verification failed: linearis@$VERSION not on registry"; exit 1; }',
+          "rm -rf .clean-pkg",
+        ].join("\n"),
       },
     ],
     ["@semantic-release/github", { successComment: false, failComment: false }],

--- a/.releaserc.cjs
+++ b/.releaserc.cjs
@@ -35,22 +35,18 @@ module.exports = {
     [
       "@semantic-release/exec",
       {
-        // Publish in two explicit stages so a failed `npm publish` FAILS the
-        // release. `clean-publish --without-publish` only strips the configured
-        // package.json fields into a deterministic `.clean-pkg` dir (it swallows
-        // exit codes, so it must NOT own the publish); the real `npm publish`
-        // then runs directly, and its non-zero exit propagates to this plugin.
-        // Auth is npm OIDC trusted publishing (no NODE_AUTH_TOKEN in CI).
-        // Runs under `/bin/sh -c` (POSIX) via @semantic-release/exec shell:true.
+        // Two stages so a failed publish fails the release: clean-publish
+        // swallows exit codes, so it only stages .clean-pkg (--without-publish)
+        // and the real `npm publish` runs separately and can propagate failure.
         publishCmd: [
           "set -e",
           "npx clean-publish --without-publish --temp-dir .clean-pkg",
           'VERSION="$(node -p "require(\'./.clean-pkg/package.json\').version")"',
           'TAG="$([ "$GITHUB_REF_NAME" = next ] && echo next || echo latest)"',
           'npm publish ./.clean-pkg --provenance --access public --tag "$TAG"',
-          // Read-back guard: the original outage was a publish that "succeeded"
-          // while nothing reached the registry. Fail loudly if the version is
-          // not actually visible (retry for read-after-write lag).
+          // Read-back guard: fail if the version is not visible on the
+          // registry (the outage was a publish that "succeeded" but published
+          // nothing); retry for read-after-write lag.
           "for i in $(seq 1 6); do",
           '  if npm view "linearis@$VERSION" version; then FOUND=1; break; fi',
           '  echo "waiting for registry to reflect $VERSION ($i/6)"; sleep 5',

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "knip": "knip --no-config-hints",
     "knip:ci": "knip --no-config-hints --reporter markdown",
     "verify:packed-binaries": "node scripts/verify-packed-binaries.mjs",
-    "release": "npm test && npm run build && npm run verify:packed-binaries && npx clean-publish --access public",
+    "release": "npm test && npm run build && npm run verify:packed-binaries && npx clean-publish --without-publish --temp-dir .clean-pkg && npm publish ./.clean-pkg --access public && rm -rf .clean-pkg",
     "prestart": "npm run generate",
     "predev": "npm run generate",
     "prebuild": "npm run generate && npm run generate:usage",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "knip": "knip --no-config-hints",
     "knip:ci": "knip --no-config-hints --reporter markdown",
     "verify:packed-binaries": "node scripts/verify-packed-binaries.mjs",
-    "release": "npm test && npm run build && npm run verify:packed-binaries && npx clean-publish --without-publish --temp-dir .clean-pkg && npm publish ./.clean-pkg --access public && rm -rf .clean-pkg",
+    "release": "npm test && npm run build && npm run verify:packed-binaries && rm -rf .clean-pkg && npx clean-publish --without-publish --temp-dir .clean-pkg && npm publish ./.clean-pkg --access public && rm -rf .clean-pkg",
     "prestart": "npm run generate",
     "predev": "npm run generate",
     "prebuild": "npm run generate && npm run generate:usage",


### PR DESCRIPTION
## What does this PR do?

Fixes the prerelease publish path so a failed `npm publish` actually fails the release instead of silently succeeding. `clean-publish` now only stages a stripped `package.json` into `.clean-pkg` (`--without-publish`), and the real `npm publish` runs directly so its non-zero exit propagates, followed by a registry read-back guard that fails loudly if the version never lands on the registry. Also switches npm auth to OIDC trusted publishing (drops `NPM_TOKEN`/`registry-url`) and ensures npm >= 11.5.1 in CI.

## Type of change

- [x] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [ ] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

CI/release-config only; verified locally with `npm run check:ci`. The publish path is exercised by the release workflow itself.

## Notes for reviewers

OIDC trusted publishing requires a configured npmjs trusted publisher for this workflow/environment and `id-token: write`. No `NODE_AUTH_TOKEN` is set anywhere in the publish path anymore.