### PR TITLE
fix(projects): bound project query connections to avoid complexity limit

### DIFF
--- a/graphql/queries/projects.graphql
+++ b/graphql/queries/projects.graphql
@@ -12,6 +12,12 @@
 # Fields returned for each project in list results. Includes status,
 # priority, lead, teams, labels, health, and progress for rich output.
 # Retains deprecated `state` field for backward compatibility.
+#
+# Nested connections are explicitly bounded: Linear's complexity
+# estimator charges an unbounded connection at its default page size
+# (50) per parent row, which pushed the default `projects list`
+# (first: 100) to ~13950 against a 10000 budget — the "Query too
+# complex" error in #276. Bounds of 25 keep the same query at ~7450.
 fragment ProjectListFields on Project {
   id
   name
@@ -34,14 +40,14 @@ fragment ProjectListFields on Project {
     id
     name
   }
-  teams {
+  teams(first: 25) {
     nodes {
       id
       key
       name
     }
   }
-  labels {
+  labels(first: 25) {
     nodes {
       id
       name
@@ -69,13 +75,13 @@ fragment ProjectDetailFields on Project {
     id
     name
   }
-  members {
+  members(first: 25) {
     nodes {
       id
       name
     }
   }
-  initiatives {
+  initiatives(first: 25) {
     nodes {
       id
       name
@@ -85,7 +91,7 @@ fragment ProjectDetailFields on Project {
 
 fragment ProjectDetailWithDefaultConnectionsFields on Project {
   ...ProjectDetailFields
-  projectMilestones {
+  projectMilestones(first: 25) {
     nodes {
       id
       name
@@ -192,6 +198,23 @@ query GetProjectStatuses {
     nodes {
       id
       name
+    }
+  }
+}
+
+# Get only a project's label IDs
+#
+# Lean lookup used by `projects update --label-mode add|remove`, which
+# previously fetched the full project detail (milestones + issues) just
+# to read the current label set — an over-budget query on real
+# workspaces (#283).
+query GetProjectLabelIds($id: String!) {
+  project(id: $id) {
+    id
+    labels(first: 250) {
+      nodes {
+        id
+      }
     }
   }
 }

--- a/graphql/queries/projects.graphql
+++ b/graphql/queries/projects.graphql
@@ -61,8 +61,25 @@ fragment ProjectListFields on Project {
 # Extended fields for single-project read view. Includes content,
 # members, milestones, initiatives, creator, lifecycle dates, and
 # visual properties.
+#
+# Every bounded connection selects pageInfo.hasNextPage here so a
+# truncated page is detectable. The teams/labels re-selections merge
+# with ProjectListFields (identical first: arguments), adding the
+# truncation signal only in detail/mutation contexts: pageInfo prices
+# at ~23 complexity per parent row, which is negligible on a single
+# project but would put the 100-row list back over the 10000 budget.
 fragment ProjectDetailFields on Project {
   ...ProjectListFields
+  teams(first: 25) {
+    pageInfo {
+      hasNextPage
+    }
+  }
+  labels(first: 25) {
+    pageInfo {
+      hasNextPage
+    }
+  }
   content
   icon
   color
@@ -80,11 +97,17 @@ fragment ProjectDetailFields on Project {
       id
       name
     }
+    pageInfo {
+      hasNextPage
+    }
   }
   initiatives(first: 25) {
     nodes {
       id
       name
+    }
+    pageInfo {
+      hasNextPage
     }
   }
 }
@@ -96,6 +119,9 @@ fragment ProjectDetailWithDefaultConnectionsFields on Project {
       id
       name
       targetDate
+    }
+    pageInfo {
+      hasNextPage
     }
   }
 }
@@ -208,12 +234,20 @@ query GetProjectStatuses {
 # previously fetched the full project detail (milestones + issues) just
 # to read the current label set — an over-budget query on real
 # workspaces (#283).
+#
+# 250 is Linear's per-connection maximum, so this read cannot be raised
+# further; hasNextPage lets the service refuse a truncated label set
+# instead of writing it back as if it were complete (labelIds is a
+# full-replacement input).
 query GetProjectLabelIds($id: String!) {
   project(id: $id) {
     id
     labels(first: 250) {
       nodes {
         id
+      }
+      pageInfo {
+        hasNextPage
       }
     }
   }

--- a/src/commands/projects.ts
+++ b/src/commands/projects.ts
@@ -37,6 +37,7 @@ import {
   createProject,
   deleteProject,
   getProject,
+  getProjectLabelIds,
   listProjects,
   type UpdateProjectInput,
   unarchiveProject,
@@ -283,7 +284,7 @@ export function setupProjectsCommands(program: Command): void {
     .option(
       "--issues-first <n>",
       "how many issues to fetch; 0 omits issues",
-      "50",
+      "25",
     )
     .action(
       commandAction<[string, ReadOptions, Command]>(
@@ -731,9 +732,9 @@ export function setupProjectsCommands(program: Command): void {
           const projectId = await resolveProjectId(ctx.gql, project);
           const needsLabelContext =
             options.labels && (labelMode === "add" || labelMode === "remove");
-          const projectContext = needsLabelContext
-            ? await getProject(ctx.gql, projectId)
-            : undefined;
+          const currentLabelIds = needsLabelContext
+            ? await getProjectLabelIds(ctx.gql, projectId)
+            : [];
 
           const input: UpdateProjectInput = {};
 
@@ -813,15 +814,9 @@ export function setupProjectsCommands(program: Command): void {
             const labelIds = await resolveProjectLabelIds(ctx.gql, labelNames);
 
             if (labelMode === "add") {
-              const currentLabels = projectContext?.labels?.nodes
-                ? projectContext.labels.nodes.map((l) => asUuid(l.id))
-                : [];
-              input.labelIds = [...new Set([...currentLabels, ...labelIds])];
+              input.labelIds = [...new Set([...currentLabelIds, ...labelIds])];
             } else if (labelMode === "remove") {
-              const currentLabels = projectContext?.labels?.nodes
-                ? projectContext.labels.nodes.map((l) => asUuid(l.id))
-                : [];
-              input.labelIds = currentLabels.filter(
+              input.labelIds = currentLabelIds.filter(
                 (id) => !labelIds.includes(id),
               );
             } else {

--- a/src/services/project-service.ts
+++ b/src/services/project-service.ts
@@ -159,6 +159,15 @@ export async function getProjectLabelIds(
     throw new Error(`Project with ID "${id}" not found`);
   }
 
+  // labelIds is a full-replacement input on projectUpdate; merging from a
+  // truncated read would silently delete every label past the page limit.
+  if (result.project.labels.pageInfo.hasNextPage) {
+    throw new Error(
+      `Project with ID "${id}" has more labels than a single read can ` +
+        "return; refusing to modify labels from a truncated label set",
+    );
+  }
+
   return result.project.labels.nodes.map((label) => asUuid(label.id));
 }
 

--- a/src/services/project-service.ts
+++ b/src/services/project-service.ts
@@ -1,5 +1,9 @@
 import type { GraphQLClient } from "../client/graphql-client.js";
-import type { BrandUuidFields, UUID } from "../common/identifier.js";
+import {
+  asUuid,
+  type BrandUuidFields,
+  type UUID,
+} from "../common/identifier.js";
 import {
   requireMutationEntity,
   requireMutationSuccess,
@@ -12,6 +16,7 @@ import {
   type CreateProjectMutation,
   DeleteProjectDocument,
   GetProjectDocument,
+  GetProjectLabelIdsDocument,
   type GetProjectQuery,
   GetProjectsDocument,
   type GetProjectsQuery,
@@ -93,7 +98,11 @@ export interface ProjectDetailOptions {
 }
 
 const DEFAULT_PROJECT_MILESTONES_FIRST = 25;
-const DEFAULT_PROJECT_ISSUES_FIRST = 50;
+// 25 keeps the default read under Linear's 10000 complexity budget: each
+// issue in the response costs ~260 (CompleteIssueFields carries four
+// connections charged at their default page size), so 50 issues alone
+// exceeded the budget and the default read failed on real workspaces (#276).
+const DEFAULT_PROJECT_ISSUES_FIRST = 25;
 
 function connectionFirstOrOneWhenSkipped(value: number): number {
   return value === 0 ? 1 : value;
@@ -138,6 +147,19 @@ export async function getProject(
   }
 
   return result.project;
+}
+
+export async function getProjectLabelIds(
+  client: GraphQLClient,
+  id: UUID,
+): Promise<UUID[]> {
+  const result = await client.request(GetProjectLabelIdsDocument, { id });
+
+  if (!result.project) {
+    throw new Error(`Project with ID "${id}" not found`);
+  }
+
+  return result.project.labels.nodes.map((label) => asUuid(label.id));
 }
 
 export async function createProject(

--- a/tests/unit/commands/projects.test.ts
+++ b/tests/unit/commands/projects.test.ts
@@ -38,6 +38,7 @@ vi.mock("../../../src/services/project-service.js", () => ({
   archiveProject: vi.fn().mockResolvedValue({ id: "proj-1", name: "Archived" }),
   listProjects: vi.fn().mockResolvedValue({ nodes: [], pageInfo: {} }),
   getProject: vi.fn().mockResolvedValue({ id: "proj-1" }),
+  getProjectLabelIds: vi.fn().mockResolvedValue([]),
   createProject: vi.fn().mockResolvedValue({ id: "proj-new" }),
   deleteProject: vi.fn().mockResolvedValue({ id: "proj-1", success: true }),
   unarchiveProject: vi.fn().mockResolvedValue({ id: "proj-1", name: "Active" }),
@@ -139,6 +140,7 @@ import {
   createProject,
   deleteProject,
   getProject,
+  getProjectLabelIds,
   listProjects,
   unarchiveProject,
   updateProject,
@@ -204,7 +206,7 @@ describe("projects read", () => {
     expect(getProject).toHaveBeenCalledWith(
       expect.anything(),
       "resolved-project-uuid",
-      { milestonesFirst: 25, issuesFirst: 50 },
+      { milestonesFirst: 25, issuesFirst: 25 },
     );
     expect(outputSuccess).toHaveBeenCalledWith({ id: "proj-1" });
   });
@@ -1056,10 +1058,9 @@ describe("projects update", () => {
   });
 
   it("adds labels without dropping existing project labels", async () => {
-    vi.mocked(getProject).mockResolvedValueOnce({
-      id: "proj-1",
-      labels: { nodes: [{ id: "existing-label-uuid" }] },
-    } as Awaited<ReturnType<typeof getProject>>);
+    vi.mocked(getProjectLabelIds).mockResolvedValueOnce([
+      "existing-label-uuid",
+    ] as Awaited<ReturnType<typeof getProjectLabelIds>>);
 
     const program = createProgram();
     await program.parseAsync([
@@ -1074,7 +1075,7 @@ describe("projects update", () => {
       "add",
     ]);
 
-    expect(getProject).toHaveBeenCalledWith(
+    expect(getProjectLabelIds).toHaveBeenCalledWith(
       expect.anything(),
       "resolved-project-uuid",
     );
@@ -1091,12 +1092,10 @@ describe("projects update", () => {
   });
 
   it("removes selected project labels without clearing all labels", async () => {
-    vi.mocked(getProject).mockResolvedValueOnce({
-      id: "proj-1",
-      labels: {
-        nodes: [{ id: "keep-label-uuid" }, { id: "resolved-label-uuid" }],
-      },
-    } as Awaited<ReturnType<typeof getProject>>);
+    vi.mocked(getProjectLabelIds).mockResolvedValueOnce([
+      "keep-label-uuid",
+      "resolved-label-uuid",
+    ] as Awaited<ReturnType<typeof getProjectLabelIds>>);
 
     const program = createProgram();
     await program.parseAsync([

--- a/tests/unit/services/project-service.test.ts
+++ b/tests/unit/services/project-service.test.ts
@@ -9,6 +9,7 @@ import {
   GetProjectDocument,
   GetProjectLabelIdsDocument,
   GetProjectWithReactionsDocument,
+  UpdateProjectDocument,
 } from "../../../src/gql/graphql.js";
 import {
   archiveProject,
@@ -354,7 +355,10 @@ describe("getProjectLabelIds", () => {
     const client = mockGqlClient({
       project: {
         id: "proj-1",
-        labels: { nodes: [{ id: "label-1" }, { id: "label-2" }] },
+        labels: {
+          nodes: [{ id: "label-1" }, { id: "label-2" }],
+          pageInfo: { hasNextPage: false },
+        },
       },
     });
 
@@ -371,6 +375,115 @@ describe("getProjectLabelIds", () => {
     await expect(
       getProjectLabelIds(client, asUuid("nonexistent")),
     ).rejects.toThrow('Project with ID "nonexistent" not found');
+  });
+
+  it("throws instead of returning a truncated label set", async () => {
+    const client = mockGqlClient({
+      project: {
+        id: "proj-1",
+        labels: {
+          nodes: [{ id: "label-1" }],
+          pageInfo: { hasNextPage: true },
+        },
+      },
+    });
+
+    await expect(getProjectLabelIds(client, asUuid("proj-1"))).rejects.toThrow(
+      "refusing to modify labels from a truncated label set",
+    );
+  });
+});
+
+describe("project fragment connection bounds", () => {
+  // Linear's complexity estimator charges an unbounded connection at its
+  // default page size per parent row; unbounded connections in these
+  // fragments are what made default `projects list`/`read` exceed the
+  // 10000 budget (#276, #283). These assertions make a future tidy-up
+  // that unbounds them fail CI instead of shipping the regression.
+  // pageInfo itself prices at ~23 complexity per parent row, so the
+  // truncation signal lives only in the detail fragment (parent count of
+  // one) — selecting it in ProjectListFields would put the 100-row list
+  // back over budget.
+  const BOUNDED_CONNECTIONS: Array<[string, string, boolean]> = [
+    ["ProjectListFields", "teams", false],
+    ["ProjectListFields", "labels", false],
+    ["ProjectDetailFields", "teams", true],
+    ["ProjectDetailFields", "labels", true],
+    ["ProjectDetailFields", "members", true],
+    ["ProjectDetailFields", "initiatives", true],
+    ["ProjectDetailWithDefaultConnectionsFields", "projectMilestones", true],
+  ];
+
+  it.each(BOUNDED_CONNECTIONS)(
+    "%s bounds %s with a literal first argument",
+    (fragmentName, connectionName, requiresPageInfo) => {
+      const fragment = getFragment(UpdateProjectDocument, fragmentName);
+
+      const field = fragment.selectionSet.selections.find(
+        (selection) =>
+          selection.kind === Kind.FIELD &&
+          selection.name.value === connectionName,
+      );
+      if (!field || field.kind !== Kind.FIELD) {
+        throw new Error(`${fragmentName} does not select ${connectionName}`);
+      }
+
+      const firstArgument = field.arguments?.find(
+        (argument) => argument.name.value === "first",
+      );
+      expect(
+        firstArgument?.value.kind,
+        `${fragmentName}.${connectionName} must carry a literal first: bound`,
+      ).toBe(Kind.INT);
+
+      if (requiresPageInfo) {
+        const pageInfo = field.selectionSet?.selections.find(
+          (selection) =>
+            selection.kind === Kind.FIELD &&
+            selection.name.value === "pageInfo",
+        );
+        expect(
+          pageInfo,
+          `${fragmentName}.${connectionName} must select pageInfo so consumers can detect truncation`,
+        ).toBeDefined();
+      }
+    },
+  );
+
+  it("bounds the lean label lookup and selects its truncation signal", () => {
+    const operation = GetProjectLabelIdsDocument.definitions.find(
+      (definition) => definition.kind === Kind.OPERATION_DEFINITION,
+    );
+    if (!operation || operation.kind !== Kind.OPERATION_DEFINITION) {
+      throw new Error("GetProjectLabelIds operation not found");
+    }
+
+    const projectField = operation.selectionSet.selections.find(
+      (selection) =>
+        selection.kind === Kind.FIELD && selection.name.value === "project",
+    );
+    if (!projectField || projectField.kind !== Kind.FIELD) {
+      throw new Error("GetProjectLabelIds does not select project");
+    }
+
+    const labelsField = projectField.selectionSet?.selections.find(
+      (selection) =>
+        selection.kind === Kind.FIELD && selection.name.value === "labels",
+    );
+    if (!labelsField || labelsField.kind !== Kind.FIELD) {
+      throw new Error("GetProjectLabelIds does not select labels");
+    }
+
+    const firstArgument = labelsField.arguments?.find(
+      (argument) => argument.name.value === "first",
+    );
+    expect(firstArgument?.value.kind).toBe(Kind.INT);
+
+    const pageInfo = labelsField.selectionSet?.selections.find(
+      (selection) =>
+        selection.kind === Kind.FIELD && selection.name.value === "pageInfo",
+    );
+    expect(pageInfo).toBeDefined();
   });
 });
 

--- a/tests/unit/services/project-service.test.ts
+++ b/tests/unit/services/project-service.test.ts
@@ -7,6 +7,7 @@ import { asUuid } from "../../../src/common/identifier.js";
 import {
   ArchiveProjectDocument,
   GetProjectDocument,
+  GetProjectLabelIdsDocument,
   GetProjectWithReactionsDocument,
 } from "../../../src/gql/graphql.js";
 import {
@@ -14,6 +15,7 @@ import {
   createProject,
   deleteProject,
   getProject,
+  getProjectLabelIds,
   listProjects,
   unarchiveProject,
   updateProject,
@@ -290,7 +292,7 @@ describe("getProject", () => {
       id: "proj-1",
       milestonesFirst: 25,
       skipMilestones: false,
-      issuesFirst: 50,
+      issuesFirst: 25,
       skipIssues: false,
     });
   });
@@ -344,6 +346,31 @@ describe("getProject", () => {
     await expect(getProject(client, asUuid("nonexistent"))).rejects.toThrow(
       'Project with ID "nonexistent" not found',
     );
+  });
+});
+
+describe("getProjectLabelIds", () => {
+  it("returns the project's label UUIDs via the lean query", async () => {
+    const client = mockGqlClient({
+      project: {
+        id: "proj-1",
+        labels: { nodes: [{ id: "label-1" }, { id: "label-2" }] },
+      },
+    });
+
+    const result = await getProjectLabelIds(client, asUuid("proj-1"));
+
+    expect(result).toEqual(["label-1", "label-2"]);
+    expect(client.request).toHaveBeenCalledWith(GetProjectLabelIdsDocument, {
+      id: "proj-1",
+    });
+  });
+
+  it("throws when project not found", async () => {
+    const client = mockGqlClient({ project: null });
+    await expect(
+      getProjectLabelIds(client, asUuid("nonexistent")),
+    ).rejects.toThrow('Project with ID "nonexistent" not found');
   });
 });
 


### PR DESCRIPTION
## What does this PR do?

Fixes the "Query too complex" failures on the `projects` commands by bounding the nested connections Linear's complexity estimator charges at default page size (50) per parent row — the query cost was determined by page-size math, not actual data, which is why even a fresh one-project workspace failed (#276).

Closes #276
Closes #283

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI

## Changes

- **`ProjectListFields`**: `teams(first: 25)`, `labels(first: 25)`. Measured against the live API: the default `projects list` (first: 100) priced at **13,950** vs the 10,000 budget; with these bounds it prices at **~7,450** (works up to `--limit 134`). Each connection node with a 3-field selection costs 1.3; unbounded is charged identically to `first: 50`.
- **`ProjectDetailFields` / `...WithDefaultConnections`**: `members`, `initiatives`, `projectMilestones` bounded at 25 for the same reason (these ride along in every project mutation payload).
- **`projects read` issues default 50 → 25**: each returned issue prices at ~260 (`CompleteIssueFields` carries four connections charged at 50 each), so the old default read exceeded the budget on real workspaces (empirically passes at `--issues-first 35`, fails at 40). I deliberately did **not** touch `CompleteIssueFields` itself to keep this fix scoped to `projects` — bounding its inner connections would roughly halve per-issue cost across the whole issues domain if you'd prefer that direction instead; happy to follow up.
- **`update --label-mode add|remove`**: the pre-read fetched the full project detail (milestones + default issues) just to read current label IDs — that pre-read, not the mutation payload, is what actually made label updates fail (#283 originally blamed the payload; correction noted there). Replaced with a lean `GetProjectLabelIds` query per the resolver/service layer rules.

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

- 894/894 unit tests, `knip` clean; new `getProjectLabelIds` service tests (happy path + not-found), label-mode command tests updated to the lean call.
- Live against a real workspace (9 projects, ~200 issues): `projects list` (default limit) and `projects read <p>` (default milestones/issues) both previously returned `{"error":"Query too complex"}` and now succeed; `projects read --issues-first 35` passes / `40` fails, confirming the ~260/issue pricing.
- Mutation payload verified under budget via a nil-UUID `projectUpdate` probe (fails with "Entity not found" *after* passing complexity validation, so nothing mutates).

## Notes for reviewers

- Bounds of 25 are a trade-off: projects with more than 25 teams/labels/members/initiatives/milestones get truncated rows (no nested pagination exists today). Unbounded was already an implicit 50-row truncation, so the delta only affects entities with 26–50 of one of those — rare, but flagging it.
- The `--issues-first` default change (50 → 25) is user-visible; `--issues-first <n>` still overrides.
- Complexity numbers come from the error's `extensions.userPresentableMessage` (e.g. "Complexity: 13119.99… Maximum allowed complexity: 10000"), reproducible with any workspace since the estimator ignores actual row counts.
