### PR TITLE
feat(issues): add --clear-assignee, --clear-project, and --clear-owner flags

### DIFF
--- a/src/commands/initiatives/entity.ts
+++ b/src/commands/initiatives/entity.ts
@@ -185,6 +185,7 @@ interface InitiativeUpdateOptions {
   description?: string;
   content?: string;
   owner?: string;
+  clearOwner?: boolean;
   status?: string;
   targetDate?: string;
   sortOrder?: string;
@@ -734,12 +735,20 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
     .option("--description <text>", "new description")
     .option("--content <text>", "new content (markdown)")
     .option("--owner <user>", "new owner (name, email, or UUID)")
+    .option("--clear-owner", "clear owner")
     .option("--status <status>", "planned, active, completed")
     .option("--target-date <date>", "new target date (YYYY-MM-DD)")
     .option("--sort-order <n>", "new display sort order")
     .action(
       commandAction<[string, InitiativeUpdateOptions, Command]>(
         async (initiative, options, command) => {
+          if (options.owner && options.clearOwner) {
+            throw invalidParameterError(
+              "--owner",
+              "cannot be combined with --clear-owner",
+            );
+          }
+
           const ctx = createContext(getRootOpts(command));
           const initiativeId = await resolveInitiativeId(ctx.gql, initiative);
 
@@ -757,7 +766,9 @@ export function setupInitiativeEntityCommands(initiatives: Command): void {
             input.content = options.content;
           }
 
-          if (options.owner) {
+          if (options.clearOwner) {
+            input.ownerId = null;
+          } else if (options.owner) {
             input.ownerId = await resolveUserId(ctx.gql, options.owner);
           }
 

--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -121,7 +121,9 @@ interface UpdateOptions {
   estimate?: string;
   clearEstimate?: boolean;
   assignee?: string;
+  clearAssignee?: boolean;
   project?: string;
+  clearProject?: boolean;
   labels?: string;
   labelMode?: string;
   clearLabels?: boolean;
@@ -1282,7 +1284,9 @@ export function setupIssuesCommands(program: Command): void {
     .option("--status <status>", "new status")
     .option("--priority <1-4>", "new priority")
     .option("--assignee <user>", "new assignee")
+    .option("--clear-assignee", "clear assignee")
     .option("--project <project>", "new project")
+    .option("--clear-project", "clear project (also clears project milestone)")
     .option("--labels <labels>", "labels to apply (comma-separated)")
     .option("--label-mode <mode>", "add | remove | overwrite")
     .option("--clear-labels", "remove all labels")
@@ -1305,6 +1309,24 @@ export function setupIssuesCommands(program: Command): void {
     .action(
       commandAction<[string, UpdateOptions, Command]>(
         async (issue, options, command) => {
+          if (options.assignee && options.clearAssignee) {
+            throw new Error(
+              "Cannot use --assignee and --clear-assignee together",
+            );
+          }
+
+          if (options.project && options.clearProject) {
+            throw new Error(
+              "Cannot use --project and --clear-project together",
+            );
+          }
+
+          if (options.clearProject && options.projectMilestone) {
+            throw new Error(
+              "Cannot use --clear-project and --project-milestone together",
+            );
+          }
+
           if (options.parentTicket && options.clearParentTicket) {
             throw new Error(
               "Cannot use --parent-ticket and --clear-parent-ticket together",
@@ -1406,8 +1428,12 @@ export function setupIssuesCommands(program: Command): void {
           }
 
           const updIdsInput: ResolveUpdateIssueIdsInput = {};
-          if (options.assignee) updIdsInput.assignee = options.assignee;
-          if (options.project) updIdsInput.project = options.project;
+          if (!options.clearAssignee && options.assignee) {
+            updIdsInput.assignee = options.assignee;
+          }
+          if (!options.clearProject && options.project) {
+            updIdsInput.project = options.project;
+          }
           if (!options.clearLabels && options.labels) {
             updIdsInput.labels = options.labels.split(",").map((l) => l.trim());
           }
@@ -1459,11 +1485,15 @@ export function setupIssuesCommands(program: Command): void {
             input.estimate = parsedEstimate;
           }
 
-          if (ids.assigneeId) {
+          if (options.clearAssignee) {
+            input.assigneeId = null;
+          } else if (ids.assigneeId) {
             input.assigneeId = ids.assigneeId;
           }
 
-          if (ids.projectId) {
+          if (options.clearProject) {
+            input.projectId = null;
+          } else if (ids.projectId) {
             input.projectId = ids.projectId;
           }
 
@@ -1495,7 +1525,13 @@ export function setupIssuesCommands(program: Command): void {
             input.parentId = ids.parentId;
           }
 
-          if (options.clearProjectMilestone) {
+          // A milestone belongs to a project, so --clear-project must detach the
+          // milestone too — otherwise the issue keeps pointing at a milestone of
+          // a project it no longer belongs to. Moving the issue to a different
+          // project with --project is deliberately not handled here: the new
+          // milestone is the caller's to pick, and reconciling the old one is
+          // left to the API rather than guessed at locally.
+          if (options.clearProjectMilestone || options.clearProject) {
             input.projectMilestoneId = null;
           } else if (ids.projectMilestoneId) {
             input.projectMilestoneId = ids.projectMilestoneId;

--- a/tests/unit/commands/initiatives.test.ts
+++ b/tests/unit/commands/initiatives.test.ts
@@ -398,6 +398,47 @@ describe("initiatives update", () => {
       expect.stringContaining("at least one option must be provided"),
     );
   });
+
+  it("clears the owner with --clear-owner", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "update",
+      "Growth",
+      "--clear-owner",
+    ]);
+
+    expect(resolveUserId).not.toHaveBeenCalled();
+    expect(updateInitiative).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-initiative-uuid",
+      expect.objectContaining({ ownerId: null }),
+    );
+  });
+
+  it("rejects --owner and --clear-owner together", async () => {
+    const program = createProgram();
+
+    await program.parseAsync([
+      "node",
+      "test",
+      "initiatives",
+      "update",
+      "Growth",
+      "--owner",
+      "Alice",
+      "--clear-owner",
+    ]);
+
+    expect(updateInitiative).not.toHaveBeenCalled();
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("cannot be combined with --clear-owner"),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+  });
 });
 
 describe("initiative relations and projects wiring", () => {

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -1098,6 +1098,166 @@ describe("issues update --assignee", () => {
   });
 });
 
+describe("issues update --clear-assignee", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("sends an explicit null assigneeId", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--clear-assignee",
+    ]);
+
+    expect(updateIssue).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+      expect.objectContaining({ assigneeId: null }),
+    );
+  });
+
+  it("does not resolve an assignee when clearing alongside other fields", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--clear-assignee",
+      "--status",
+      "Todo",
+    ]);
+
+    expect(resolveUpdateIssueIds).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.not.objectContaining({ assignee: expect.anything() }),
+      expect.anything(),
+    );
+  });
+
+  it("rejects --assignee and --clear-assignee together", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--assignee",
+      "Jane Smith",
+      "--clear-assignee",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Cannot use --assignee and --clear-assignee together",
+      ),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(updateIssue).not.toHaveBeenCalled();
+  });
+});
+
+describe("issues update --clear-project", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+  });
+
+  it("sends an explicit null projectId and clears the project milestone", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--clear-project",
+    ]);
+
+    expect(updateIssue).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+      expect.objectContaining({ projectId: null, projectMilestoneId: null }),
+    );
+  });
+
+  it("does not resolve a project when clearing alongside other fields", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--clear-project",
+      "--status",
+      "Todo",
+    ]);
+
+    expect(resolveUpdateIssueIds).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.not.objectContaining({ project: expect.anything() }),
+      expect.anything(),
+    );
+  });
+
+  it("rejects --project and --clear-project together", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--project",
+      "Apollo",
+      "--clear-project",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Cannot use --project and --clear-project together",
+      ),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(updateIssue).not.toHaveBeenCalled();
+  });
+
+  it("rejects --clear-project and --project-milestone together", async () => {
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--clear-project",
+      "--project-milestone",
+      "Beta",
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining(
+        "Cannot use --clear-project and --project-milestone together",
+      ),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(updateIssue).not.toHaveBeenCalled();
+  });
+});
+
 describe("issues read", () => {
   beforeEach(() => {
     vi.clearAllMocks();


### PR DESCRIPTION
## What does this PR do?

Adds three `--clear-*` flags so ownership/reference fields can be unset, not just set:

- `issues update --clear-assignee` — unassign an issue
- `issues update --clear-project` — detach an issue from its project
- `initiatives update --clear-owner` — remove an initiative's owner

All three previously behaved as write-only: the input key was assembled behind a truthiness guard (`if (ids.assigneeId)`), so no `assigneeId` / `projectId` / `ownerId` ever reached the Linear API when the user wanted the field gone, and no CLI spelling produced one. The reported use case (#282) is LLM-agent orchestration using assignee as a soft ownership lock — a lock you can take but never release is not a lock.

The flags follow the convention already established by the nine existing clear flags (`--clear-labels`, `--clear-due-date`, `--clear-estimate`, `--clear-cycle`, `--clear-parent-ticket`, `--clear-project-milestone`, `--clear-lead`, `--clear-start-date`, `--clear-target-date`): reject the setter and clearer together, skip ID resolution when clearing so no pointless resolver round-trip happens, and assemble the input with if/else-if sending an explicit `null`.

`--clear-project` additionally rejects `--project-milestone` — a milestone belongs to a project, so detaching the project while assigning a milestone is contradictory, and it is better caught locally than left to the API.

No service or GraphQL change was needed: `UpdateIssueInput` and `UpdateInitiativeInput` `Pick` these fields from the codegen `*UpdateInput` types, where they are already `InputMaybe<...>`, and `ReplaceStringWithUuid` preserves `null`.

Closes #282

## Type of change

- [x] Bug fix
- [x] New feature
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [ ] Tests
- [ ] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Ran the full AGENTS.md verification checklist, all green:

```
npm run generate
npx vitest run tests/unit/commands/issues.test.ts tests/unit/commands/initiatives.test.ts   # 133 passed
npm run check:ci
npx tsc --noEmit
npm test                                                                                     # 901 passed / 65 files
npm run build
npm run knip                                                                                 # no findings
```

Also confirmed the flags register in Commander:

```
node dist/main.js issues update --help       # --clear-assignee, --clear-project
node dist/main.js initiatives update --help  # --clear-owner
```

New unit tests cover, per flag: the explicit `null` reaching the service, the resolver *not* receiving the field when clearing alongside another resolved field, and each mutual-exclusion error.

## Notes for reviewers

- **Alternative considered and rejected:** a sentinel such as `--assignee ""`. It is ambiguous against a legitimately empty argument, invisible in `--help`, and inconsistent with the existing clear flags.
- **Deliberate inconsistency:** `issues.ts` throws a plain `Error` for these conflicts while `initiatives/entity.ts` uses `invalidParameterError`. Each new check matches its own file's local convention rather than unifying the two — unifying would be a larger, separate change.
- Not manually smoke-tested against a live Linear workspace (no API token in this environment); verification is unit tests plus `--help` output.