### PR TITLE
fix(release): pin conventionalcommits preset and backfill lost release notes

### DIFF
--- a/.github/workflows/ci-validate.yml
+++ b/.github/workflows/ci-validate.yml
@@ -268,13 +268,53 @@ jobs:
           fi
 
           base_ref="origin/${GITHUB_BASE_REF:-main}"
-          output=$(git log "$base_ref"..HEAD --name-status --pretty=format: -- CHANGELOG.md | sed '/^$/d')
 
-          if [ -n "$output" ]; then
+          # Repairing notes the release workflow itself lost is the one
+          # legitimate reason for a PR to touch CHANGELOG.md — see
+          # "Changelog ownership" in CONTRIBUTING.md. Exempt commits whose
+          # subject is exactly the reserved backfill subject, and only when
+          # they change nothing outside CHANGELOG.md and only add lines.
+          exempt_subject="chore(release): backfill changelog notes"
+
+          # Capture into a variable rather than feeding `git log` straight into
+          # a here-string: a here-string swallows the command substitution's
+          # exit status, so an unresolvable "$base_ref" would read as an empty
+          # commit list and the guard would silently pass.
+          candidates=$(git log "$base_ref"..HEAD --format=%H -- CHANGELOG.md)
+
+          offenders=""
+          while read -r sha; do
+            [ -n "$sha" ] || continue
+            subject=$(git log -1 --format=%s "$sha")
+            if [ "$subject" = "$exempt_subject" ]; then
+              violation=""
+
+              extra=$(git show --name-only --pretty=format: "$sha" | sed '/^$/d' | grep -v '^CHANGELOG.md$' || true)
+              if [ -n "$extra" ]; then
+                echo "::error::$exempt_subject commit $sha also touches files other than CHANGELOG.md"
+                echo "$extra"
+                violation="yes"
+              fi
+
+              deletions=$(git show --numstat --pretty=format: "$sha" -- CHANGELOG.md | awk 'NF { total += $2 } END { print total + 0 }')
+              if [ "$deletions" -ne 0 ]; then
+                echo "::error::$exempt_subject commit $sha removes $deletions CHANGELOG.md line(s); a backfill may only add notes"
+                violation="yes"
+              fi
+
+              if [ -z "$violation" ]; then
+                continue
+              fi
+            fi
+            offenders="$offenders$sha $subject"$'\n'
+          done <<< "$candidates"
+
+          if [ -n "$offenders" ]; then
             echo "::error::CHANGELOG.md is release-workflow-owned and must not appear in PR branch history"
             echo "Drop or amend commits that touch CHANGELOG.md, then push with --force-with-lease"
+            echo "The only exception is an additions-only, CHANGELOG.md-only commit whose subject is exactly: $exempt_subject"
             echo
-            echo "$output"
+            echo "$offenders"
             exit 1
           fi
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,16 +1,68 @@
 ## [2026.7.0](https://github.com/linearis-oss/linearis/compare/v2026.6.0...v2026.7.0) (2026-08-07)
 
+### Features
+
+* **initiatives:** add --clear-owner to initiatives update ([fb401ea](https://github.com/linearis-oss/linearis/commit/fb401ea029bd559140567ea61c6ff1493609b3ea)), closes [#282](https://github.com/linearis-oss/linearis/issues/282)
+* **issues:** add --clear-assignee and --clear-project to issues update ([9a5ca75](https://github.com/linearis-oss/linearis/commit/9a5ca7529efdec30d95c77838f947f6e7255b225)), closes [#282](https://github.com/linearis-oss/linearis/issues/282) [#282](https://github.com/linearis-oss/linearis/issues/282)
+
+### Bug Fixes
+
+* **cli:** classify the two option-shaped parse failures ([19ec395](https://github.com/linearis-oss/linearis/commit/19ec3955285f7fcad3d74e21b294604f59d54ccb)), closes [#281](https://github.com/linearis-oss/linearis/issues/281)
+* **cli:** disable Commander's implicit help subcommand ([de405af](https://github.com/linearis-oss/linearis/commit/de405afd709abe27cac3fedf0e06165e7b0becc5)), closes [#281](https://github.com/linearis-oss/linearis/issues/281)
+* **cli:** emit JSON envelope for argument-parse errors ([3bd0e38](https://github.com/linearis-oss/linearis/commit/3bd0e3899d64bfa5195009d686cf2cbdddc4ed06)), closes [#281](https://github.com/linearis-oss/linearis/issues/281)
+* **cli:** give every bare command group the same MISSING_SUBCOMMAND envelope ([b4c3a8b](https://github.com/linearis-oss/linearis/commit/b4c3a8b58690da398c702147b1c1446f00ab34ca))
+* **cli:** keep the usage-error message on a single line ([a447807](https://github.com/linearis-oss/linearis/commit/a4478075c73af9e0c0d3af699c68402559c05343))
+* **common:** point auth recovery at 'auth login', not the bare group ([cca71ec](https://github.com/linearis-oss/linearis/commit/cca71ec64c86148dbaa27987933d6fae05541082)), closes [#281](https://github.com/linearis-oss/linearis/issues/281)
+* **deps:** update dependency commander to v15 ([290424a](https://github.com/linearis-oss/linearis/commit/290424ae2a7f53d3b014de822187429d4fc350b6))
+* **deps:** update dependency graphql to v16.14.2 ([ca72bf7](https://github.com/linearis-oss/linearis/commit/ca72bf7ac32f40643f8b34b7bcafe15675f07226))
+* **deps:** update dependency graphql to v17 ([05bb7af](https://github.com/linearis-oss/linearis/commit/05bb7af33f14b5ab91e6c9797d613ac192c58c80))
+* **projects:** bound project query connections to avoid complexity limit ([dfe97b8](https://github.com/linearis-oss/linearis/commit/dfe97b8f0c3cf15c5fc40a7861f2cd422fdc30b9)), closes [#276](https://github.com/linearis-oss/linearis/issues/276) [#283](https://github.com/linearis-oss/linearis/issues/283)
+* **projects:** surface truncation on bounded connections, lock bounds in tests ([a3145c1](https://github.com/linearis-oss/linearis/commit/a3145c1b99273c11b1e7f077cf2799f63ae4c141)), closes [#276](https://github.com/linearis-oss/linearis/issues/276) [#284](https://github.com/linearis-oss/linearis/issues/284)
+* **usage:** list nested group subcommands in domain usage ([2bff44f](https://github.com/linearis-oss/linearis/commit/2bff44ff745df8e186d4a46f92feaac65ac4740c)), closes [#281](https://github.com/linearis-oss/linearis/issues/281)
+
 ## [2026.7.0-next.6](https://github.com/linearis-oss/linearis/compare/v2026.7.0-next.5...v2026.7.0-next.6) (2026-08-07)
+
+### Bug Fixes
+
+* **projects:** bound project query connections to avoid complexity limit ([dfe97b8](https://github.com/linearis-oss/linearis/commit/dfe97b8f0c3cf15c5fc40a7861f2cd422fdc30b9)), closes [#276](https://github.com/linearis-oss/linearis/issues/276) [#283](https://github.com/linearis-oss/linearis/issues/283)
+* **projects:** surface truncation on bounded connections, lock bounds in tests ([a3145c1](https://github.com/linearis-oss/linearis/commit/a3145c1b99273c11b1e7f077cf2799f63ae4c141)), closes [#276](https://github.com/linearis-oss/linearis/issues/276) [#284](https://github.com/linearis-oss/linearis/issues/284)
 
 ## [2026.7.0-next.5](https://github.com/linearis-oss/linearis/compare/v2026.7.0-next.4...v2026.7.0-next.5) (2026-08-06)
 
+### Bug Fixes
+
+* **deps:** update dependency graphql to v17 ([05bb7af](https://github.com/linearis-oss/linearis/commit/05bb7af33f14b5ab91e6c9797d613ac192c58c80))
+
 ## [2026.7.0-next.4](https://github.com/linearis-oss/linearis/compare/v2026.7.0-next.3...v2026.7.0-next.4) (2026-08-06)
+
+### Bug Fixes
+
+* **cli:** classify the two option-shaped parse failures ([19ec395](https://github.com/linearis-oss/linearis/commit/19ec3955285f7fcad3d74e21b294604f59d54ccb)), closes [#281](https://github.com/linearis-oss/linearis/issues/281)
+* **cli:** disable Commander's implicit help subcommand ([de405af](https://github.com/linearis-oss/linearis/commit/de405afd709abe27cac3fedf0e06165e7b0becc5)), closes [#281](https://github.com/linearis-oss/linearis/issues/281)
+* **cli:** emit JSON envelope for argument-parse errors ([3bd0e38](https://github.com/linearis-oss/linearis/commit/3bd0e3899d64bfa5195009d686cf2cbdddc4ed06)), closes [#281](https://github.com/linearis-oss/linearis/issues/281)
+* **cli:** give every bare command group the same MISSING_SUBCOMMAND envelope ([b4c3a8b](https://github.com/linearis-oss/linearis/commit/b4c3a8b58690da398c702147b1c1446f00ab34ca))
+* **cli:** keep the usage-error message on a single line ([a447807](https://github.com/linearis-oss/linearis/commit/a4478075c73af9e0c0d3af699c68402559c05343))
+* **common:** point auth recovery at 'auth login', not the bare group ([cca71ec](https://github.com/linearis-oss/linearis/commit/cca71ec64c86148dbaa27987933d6fae05541082)), closes [#281](https://github.com/linearis-oss/linearis/issues/281)
+* **usage:** list nested group subcommands in domain usage ([2bff44f](https://github.com/linearis-oss/linearis/commit/2bff44ff745df8e186d4a46f92feaac65ac4740c)), closes [#281](https://github.com/linearis-oss/linearis/issues/281)
 
 ## [2026.7.0-next.3](https://github.com/linearis-oss/linearis/compare/v2026.7.0-next.2...v2026.7.0-next.3) (2026-08-06)
 
+### Features
+
+* **initiatives:** add --clear-owner to initiatives update ([fb401ea](https://github.com/linearis-oss/linearis/commit/fb401ea029bd559140567ea61c6ff1493609b3ea)), closes [#282](https://github.com/linearis-oss/linearis/issues/282)
+* **issues:** add --clear-assignee and --clear-project to issues update ([9a5ca75](https://github.com/linearis-oss/linearis/commit/9a5ca7529efdec30d95c77838f947f6e7255b225)), closes [#282](https://github.com/linearis-oss/linearis/issues/282) [#282](https://github.com/linearis-oss/linearis/issues/282)
+
 ## [2026.7.0-next.2](https://github.com/linearis-oss/linearis/compare/v2026.7.0-next.1...v2026.7.0-next.2) (2026-07-06)
 
+### Bug Fixes
+
+* **deps:** update dependency commander to v15 ([290424a](https://github.com/linearis-oss/linearis/commit/290424ae2a7f53d3b014de822187429d4fc350b6))
+
 ## [2026.7.0-next.1](https://github.com/linearis-oss/linearis/compare/v2026.6.0...v2026.7.0-next.1) (2026-07-06)
+
+### Bug Fixes
+
+* **deps:** update dependency graphql to v16.14.2 ([ca72bf7](https://github.com/linearis-oss/linearis/commit/ca72bf7ac32f40643f8b34b7bcafe15675f07226))
 
 ## [2026.6.0](https://github.com/linearis-oss/linearis/compare/v2026.5.0...v2026.6.0) (2026-07-04)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -58,6 +58,28 @@ For the authoritative workflow trigger matrix, required check names, and verific
 `CHANGELOG.md` is release-workflow-owned. Do not edit it in feature/fix PRs.
 If CI reports changelog history violations, rebase on `main` and drop/amend commits that touched `CHANGELOG.md`.
 
+There is one exception, for repairing releases whose notes semantic-release
+failed to render — as happened for `2026.7.0-next.1` … `2026.7.0`, when the
+`conventionalcommits` preset resolved to a version incompatible with the notes
+generator's writer. `guard-changelog-history` in `ci-validate.yml` lets through
+a commit whose subject is exactly:
+
+```
+chore(release): backfill changelog notes
+```
+
+and only when that commit changes nothing but `CHANGELOG.md` and only adds
+lines to it — a backfill that removes or rewrites an existing line fails the
+guard. Every other `CHANGELOG.md` edit stays blocked.
+
+Such a repair must be generated rather than hand-written: re-render the notes
+for each empty section using the commit range from the compare link already in
+its heading, and splice in only the body so the heading's original version,
+date and compare link survive untouched — which is also what keeps the diff
+additions-only, as the guard requires.
+GitHub Release bodies are damaged the same way and cannot be fixed by a
+committed file; a maintainer patches those separately with `gh api`.
+
 ## Pull Requests
 
 1. Fork the repo and create your branch from `main`

--- a/knip.json
+++ b/knip.json
@@ -5,6 +5,6 @@
   "ignoreDependencies": [
     "@semantic-release/github",
     "@semantic-release/npm",
-    "@semantic-release/release-notes-generator"
+    "conventional-changelog-conventionalcommits"
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,6 +35,7 @@
         "@vitest/coverage-v8": "^4.0.0",
         "@vitest/ui": "^4.0.0",
         "clean-publish": "^7.0.0",
+        "conventional-changelog-conventionalcommits": "9.3.1",
         "knip": "^6.24.0",
         "lefthook": "^2.1.0",
         "semantic-release": "^25.0.1",
@@ -646,6 +647,19 @@
         "node": ">=22.12.0"
       }
     },
+    "node_modules/@commitlint/config-conventional/node_modules/conventional-changelog-conventionalcommits": {
+      "version": "10.2.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.1.tgz",
+      "integrity": "sha512-n4Kr1HFMTf3iMbES0TMxKIcYtUUv4rKqyQQp2JwfOEfFCOfGT3Tq4mCyJ8S9/YPyWhydjfKrrvnyl+gCjA+mJQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "@conventional-changelog/template": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=22"
+      }
+    },
     "node_modules/@commitlint/config-validator": {
       "version": "21.2.0",
       "resolved": "https://registry.npmjs.org/@commitlint/config-validator/-/config-validator-21.2.0.tgz",
@@ -1000,9 +1014,9 @@
       }
     },
     "node_modules/@conventional-changelog/template": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.0.tgz",
-      "integrity": "sha512-12qHxvlKjHmP0PQ+17EREgC7lWyLwbph1RKcZQZ7k7ZWGmrxfxC9gadHGfvzr0g0u8BhiBGg3tks93txodlyRQ==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@conventional-changelog/template/-/template-1.2.1.tgz",
+      "integrity": "sha512-TzlTVpKPjaqW6qOYjQcYUDuGsLCNsvFHVBXkYGTAnf5V37jCWrE5haKNXzz0WZUtVHjrpV76L1buANjwXMfT8w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6021,16 +6035,16 @@
       }
     },
     "node_modules/conventional-changelog-conventionalcommits": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-10.2.0.tgz",
-      "integrity": "sha512-UtlM9GqolY7OmlQh5L/UEVoKsTUpTgUVy1PU8JN5gl5Ydaejb7WRklGliG1SKPxxj7hzA173eG3Kt5fYWE2pmg==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/conventional-changelog-conventionalcommits/-/conventional-changelog-conventionalcommits-9.3.1.tgz",
+      "integrity": "sha512-dTYtpIacRpcZgrvBYvBfArMmK2xvIpv2TaxM0/ZI5CBtNUzvF2x0t15HsbRABWprS6UPmvj+PzHVjSx4qAVKyw==",
       "dev": true,
       "license": "ISC",
       "dependencies": {
-        "@conventional-changelog/template": "^1.2.0"
+        "compare-func": "^2.0.0"
       },
       "engines": {
-        "node": ">=22"
+        "node": ">=18"
       }
     },
     "node_modules/conventional-changelog-writer": {

--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "@vitest/coverage-v8": "^4.0.0",
     "@vitest/ui": "^4.0.0",
     "clean-publish": "^7.0.0",
+    "conventional-changelog-conventionalcommits": "9.3.1",
     "knip": "^6.24.0",
     "lefthook": "^2.1.0",
     "semantic-release": "^25.0.1",

--- a/renovate.json
+++ b/renovate.json
@@ -23,6 +23,11 @@
       "groupName": "dev dependencies (non-major)"
     },
     {
+      "description": "Hold conventional-changelog-conventionalcommits on the 9.x line: v10 moved to the @conventional-changelog/writer@2 API (function template/commitPartial), which @semantic-release/release-notes-generator's Handlebars writer@8 cannot render. The result is silently empty release notes, not a build failure. Lift once release-notes-generator ships writer@2 support.",
+      "matchPackageNames": ["conventional-changelog-conventionalcommits"],
+      "allowedVersions": "<10"
+    },
+    {
       "description": "Group GitHub Actions updates (SHA-pinned actions + docker digests)",
       "matchManagers": ["github-actions"],
       "groupName": "github actions"

--- a/tests/types/semantic-release-plugins.d.ts
+++ b/tests/types/semantic-release-plugins.d.ts
@@ -1,0 +1,12 @@
+/**
+ * Minimal ambient types for the semantic-release plugins exercised by the
+ * release tests. The upstream packages ship no declarations, and we only call
+ * a single entry point, so a hand-written surface is cheaper (and clearer)
+ * than pulling in a full third-party type dependency.
+ */
+declare module "@semantic-release/release-notes-generator" {
+  export function generateNotes(
+    pluginConfig: Record<string, unknown>,
+    context: Record<string, unknown>,
+  ): Promise<string>;
+}

--- a/tests/unit/release/release-notes.test.ts
+++ b/tests/unit/release/release-notes.test.ts
@@ -1,0 +1,94 @@
+import { createRequire } from "node:module";
+import { generateNotes } from "@semantic-release/release-notes-generator";
+import { describe, expect, it } from "vitest";
+
+/**
+ * Regression guard for silently empty release notes.
+ *
+ * `.releaserc.cjs` selects the `conventionalcommits` preset by bare specifier,
+ * so the preset version that actually gets loaded is whatever npm resolves
+ * from release-notes-generator's own directory. Preset v10 switched to the
+ * `@conventional-changelog/writer@2` API (function `template`/`commitPartial`),
+ * which release-notes-generator's Handlebars-based writer@8 cannot render: the
+ * heading survives, every `### <group>` section and bullet disappears, and the
+ * release still succeeds. These tests turn that silent data loss into a
+ * failing check.
+ */
+
+type PluginEntry = string | [string, Record<string, unknown>];
+
+const require = createRequire(import.meta.url);
+
+function releaseNotesPluginConfig(): Record<string, unknown> {
+  const config = require("../../../.releaserc.cjs") as {
+    plugins: PluginEntry[];
+  };
+
+  const entry = config.plugins.find(
+    (plugin): plugin is [string, Record<string, unknown>] =>
+      Array.isArray(plugin) &&
+      plugin[0] === "@semantic-release/release-notes-generator",
+  );
+
+  if (!entry) {
+    throw new Error(
+      "no @semantic-release/release-notes-generator entry in .releaserc.cjs",
+    );
+  }
+
+  return entry[1];
+}
+
+const COMMITS = [
+  {
+    hash: "1111111111111111111111111111111111111111",
+    message: "feat(issues): add activity command\n\nCloses #144",
+  },
+  {
+    hash: "2222222222222222222222222222222222222222",
+    message: "fix(labels): allow clearing label description",
+  },
+  {
+    hash: "3333333333333333333333333333333333333333",
+    message: "chore(deps): bump something unreleasable",
+  },
+];
+
+async function render(): Promise<string> {
+  return generateNotes(releaseNotesPluginConfig(), {
+    cwd: process.cwd(),
+    options: { repositoryUrl: "https://github.com/linearis-oss/linearis" },
+    lastRelease: { gitTag: "v2026.6.0", version: "2026.6.0" },
+    nextRelease: { gitTag: "v2026.7.0", version: "2026.7.0", channel: null },
+    commits: COMMITS,
+    logger: { log: () => {}, error: () => {} },
+  });
+}
+
+describe("release notes generation", () => {
+  it("renders grouped sections and bullets for releasable commits", async () => {
+    const notes = await render();
+
+    expect(notes).toContain("### Features");
+    expect(notes).toContain("### Bug Fixes");
+    expect(notes).toContain("* **issues:** add activity command");
+    expect(notes).toContain("* **labels:** allow clearing label description");
+  });
+
+  it("links commits and referenced issues", async () => {
+    const notes = await render();
+
+    expect(notes).toContain(
+      "https://github.com/linearis-oss/linearis/commit/1111111",
+    );
+    expect(notes).toContain(
+      "https://github.com/linearis-oss/linearis/issues/144",
+    );
+  });
+
+  it("omits non-deliverable commit types", async () => {
+    const notes = await render();
+
+    expect(notes).not.toContain("bump something unreleasable");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Every release since `2026.7.0-next.1` shipped with empty notes: `.releaserc.cjs` requests the `conventionalcommits` preset by bare specifier, and Renovate bumped the (undeclared, hoisted) transitive copy to v10, which uses the `@conventional-changelog/writer@2` API that release-notes-generator's Handlebars writer@8 cannot render — the heading survived, every section and bullet rendered empty, and the release still succeeded. This declares the preset as an exact `9.3.1` devDependency, holds it below 10 in `renovate.json`, adds a regression test that renders synthetic commits through the real `.releaserc.cjs` plugin options, and backfills the seven damaged `CHANGELOG.md` sections. Because `guard-changelog-history` blocks any PR that touches `CHANGELOG.md`, the guard now exempts exactly one reserved subject (`chore(release): backfill changelog notes`) and only when that commit is CHANGELOG.md-only and additions-only; `CONTRIBUTING.md` documents the exemption.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor (no behavior change)
- [x] Documentation
- [x] Tests
- [x] Build / CI

## Checklist

- [x] `npm run check:ci` passes (lint + format)
- [x] `npx tsc --noEmit` passes (type check)
- [x] `npm test` passes (unit tests)
- [x] New code has tests (happy path + primary error case)
- [x] Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)

## Testing

Full AGENTS.md checklist on this branch: `npm run generate`, `npm run check:ci` (200 files, clean), `npx tsc --noEmit` (clean), `npm test` (67 files / 938 tests passing), `npm run build`, `npm run knip` (no findings). The new `tests/unit/release/release-notes.test.ts` fails on `next` today and fails again if the preset is forced back to 10.x. The guard's failure-open path was verified against both a resolvable and a bogus base ref.

## Notes for reviewers

Risk is concentrated in `guard-changelog-history`: it now walks matching commits individually instead of reading `--name-status` in bulk, and captures the commit list into a variable rather than a here-string so an unresolvable base ref fails loudly instead of silently passing. Every `CHANGELOG.md` edit outside the reserved subject stays blocked. The `CHANGELOG.md` commit is generated, not hand-edited — headings, dates and compare links are untouched, so the diff is 52 insertions and zero deletions. GitHub Release bodies are damaged the same way and need a separate `gh api` patch by a maintainer; the one-off generator script is deliberately not committed.