### PR TITLE
fix(issues): add --description-file to avoid argv-length hangs

### DIFF
--- a/src/commands/issues.ts
+++ b/src/commands/issues.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from "node:fs";
 import type { Command } from "commander";
 import { firstOrThrow } from "../common/array.js";
 import type { CommandContext } from "../common/context.js";
@@ -122,6 +123,7 @@ interface FilterOptions extends RawFilterFlags {
 
 interface CreateOptions {
   description?: string;
+  descriptionFile?: string;
   assignee?: string;
   priority?: string;
   estimate?: string;
@@ -145,6 +147,7 @@ interface CreateOptions {
 interface UpdateOptions {
   title?: string;
   description?: string;
+  descriptionFile?: string;
   status?: string;
   priority?: string;
   estimate?: string;
@@ -176,6 +179,37 @@ interface UpdateOptions {
   duplicateOf?: string;
   similarTo?: string;
   removeRelation?: string;
+}
+
+/**
+ * Resolves `--description`/`--description-file` into a single description
+ * value. Reading from a file (or `-` for stdin) avoids passing large text as
+ * a single shell argument, which some sandboxed shells (e.g. an agent's tool
+ * runner) silently kill above a size threshold.
+ */
+function resolveDescriptionInput(options: {
+  description?: string;
+  descriptionFile?: string;
+}): string | undefined {
+  if (
+    options.description !== undefined &&
+    options.descriptionFile !== undefined
+  ) {
+    throw invalidParameterError(
+      "--description",
+      "cannot be combined with --description-file",
+    );
+  }
+
+  if (options.descriptionFile !== undefined) {
+    const content = readFileSync(
+      options.descriptionFile === "-" ? 0 : options.descriptionFile,
+      "utf8",
+    );
+    return content.replace(/\r?\n+$/, "");
+  }
+
+  return options.description;
 }
 
 interface ReadOptions {
@@ -1348,6 +1382,10 @@ export function setupIssuesCommands(program: Command): void {
     .command("create <title>")
     .description("create new issue")
     .option("--description <text>", "issue body")
+    .option(
+      "--description-file <path>",
+      "read issue body from file (- for stdin)",
+    )
     .option("--assignee <user>", "assign to user")
     .option("--priority <1-4>", "1=urgent 2=high 3=medium 4=low")
     .option("--project <project>", "add to project")
@@ -1431,8 +1469,9 @@ export function setupIssuesCommands(program: Command): void {
             teamId: ids.teamId,
           };
 
-          if (options.description) {
-            input.description = options.description;
+          const description = resolveDescriptionInput(options);
+          if (description) {
+            input.description = description;
           }
 
           if (ids.assigneeId) {
@@ -1507,6 +1546,10 @@ export function setupIssuesCommands(program: Command): void {
     )
     .option("--title <text>", "new title")
     .option("--description <text>", "new description")
+    .option(
+      "--description-file <path>",
+      "read new description from file (- for stdin)",
+    )
     .option("--status <status>", "new status")
     .option("--priority <1-4>", "new priority")
     .option("--assignee <user>", "new assignee")
@@ -1750,8 +1793,9 @@ export function setupIssuesCommands(program: Command): void {
             input.title = options.title;
           }
 
-          if (options.description) {
-            input.description = options.description;
+          const description = resolveDescriptionInput(options);
+          if (description) {
+            input.description = description;
           }
 
           if (ids.stateId) {

--- a/tests/unit/commands/issues.test.ts
+++ b/tests/unit/commands/issues.test.ts
@@ -1,7 +1,10 @@
 // tests/unit/commands/issues.test.ts
 
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
 import { Command } from "commander";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { asUuid } from "../../../src/common/identifier.js";
 
 // Mock all external dependencies before importing the module under test
@@ -671,6 +674,78 @@ describe("issues create --due-date", () => {
   });
 });
 
+describe("issues create --description-file", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    dir = mkdtempSync(join(tmpdir(), "linearis-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reads description from file, stripping a trailing newline", async () => {
+    const file = join(dir, "description.md");
+    writeFileSync(file, "Long description body.\n");
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "create",
+      "Fix login bug",
+      "--team",
+      "ENG",
+      "--description-file",
+      file,
+    ]);
+
+    expect(createIssue).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ description: "Long description body." }),
+    );
+  });
+
+  it("rejects --description combined with --description-file", async () => {
+    const file = join(dir, "description.md");
+    writeFileSync(file, "From file");
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "create",
+      "Fix login bug",
+      "--team",
+      "ENG",
+      "--description",
+      "Inline",
+      "--description-file",
+      file,
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          error:
+            "Invalid --description: cannot be combined with --description-file",
+        },
+        null,
+        2,
+      ),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(createIssue).not.toHaveBeenCalled();
+  });
+});
+
 describe("issues update --estimate", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -1173,6 +1248,75 @@ describe("issues update --assignee", () => {
     ]);
 
     expect(resolveUpdateIssueIds).not.toHaveBeenCalled();
+  });
+});
+
+describe("issues update --description-file", () => {
+  let dir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, "log").mockImplementation(() => {});
+    vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(() => undefined as never);
+    dir = mkdtempSync(join(tmpdir(), "linearis-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it("reads new description from file, stripping a trailing newline", async () => {
+    const file = join(dir, "description.md");
+    writeFileSync(file, "Updated description body.\n");
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--description-file",
+      file,
+    ]);
+
+    expect(updateIssue).toHaveBeenCalledWith(
+      expect.anything(),
+      "resolved-issue-uuid",
+      expect.objectContaining({ description: "Updated description body." }),
+    );
+  });
+
+  it("rejects --description combined with --description-file", async () => {
+    const file = join(dir, "description.md");
+    writeFileSync(file, "From file");
+
+    const program = createProgram();
+    await program.parseAsync([
+      "node",
+      "test",
+      "issues",
+      "update",
+      "ENG-42",
+      "--description",
+      "Inline",
+      "--description-file",
+      file,
+    ]);
+
+    expect(console.error).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          error:
+            "Invalid --description: cannot be combined with --description-file",
+        },
+        null,
+        2,
+      ),
+    );
+    expect(process.exit).toHaveBeenCalledWith(1);
+    expect(updateIssue).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- `--description "<long text>"` passes the whole description as a single shell argv token. In sandboxed shells (notably an LLM agent's Bash tool runner — Linearis's own stated audience), a single argv string of roughly 1000+ bytes gets silently `SIGKILL`ed with no error output, which looks exactly like an indefinite hang.
- Added `--description-file <path>` (`-` for stdin) to `issues create` and `issues update`, mirroring the existing `--file -` stdin convention already used in `issues-batch.ts`, so long description text never has to travel through a single argv token.
- `--description` and `--description-file` are mutually exclusive (mirrors the existing `--json`/`--file` exclusivity pattern).

## Root cause detail
Confirmed this is not a request-timeout/retry-loop issue (that class of bug was already fixed in #157 — the GraphQL client correctly clears its abort timer in a `finally`). Reproduced directly: a bare, unrelated Node script spawned with a single argv string shows a hard cliff — 999 bytes runs fine, 1000 bytes gets instantly killed (`SIGKILL`), independent of Linearis code entirely. That matches the reported "700–1000 char description hangs" symptom precisely.

## Test plan
- [x] `npm test` — 1213 tests pass (4 new, covering file read, trailing-newline stripping, and the mutual-exclusion error for both `create` and `update`)
- [x] `npx tsc --noEmit`
- [x] `npm run check:ci`
- [x] `npm run build`
- [x] `npm run knip`
- [x] Manual end-to-end verification against a local mock GraphQL server with a ~900-char description read from both a file and stdin

🤖 Generated with [Claude Code](https://claude.com/claude-code)